### PR TITLE
Remove mpeu dependency from GOCART2G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Switched StrTemplate from using the one provided by `GMAO_MPEU` to one provided by `MAPL`
 ### Fixed
 ### Removed
 ### Added

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -17,7 +17,7 @@ module CA2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_GridCompMod
-   use m_StrTemplate          ! string templates
+   use MAPL_StringTemplate
 
    implicit none
    private
@@ -827,7 +827,7 @@ contains
 !   Read any pointwise emissions, if requested
 !   ------------------------------------------
     if(self%doing_point_emissions) then
-       call StrTemplate (fname, self%point_emissions_srcfilen, xid='unknown', &
+       call fill_grads_template (fname, self%point_emissions_srcfilen, experiment_id='unknown', &
                          nymd=nymd, nhms=120000 )
        call ReadPointEmissions (nymd, fname, self%nPts, self%pLat, self%pLon, &
                                  self%pBase, self%pTop, self%pEmis, self%pStart, &

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -17,7 +17,7 @@ module CA2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_GridCompMod
-   use MAPL_StringTemplate
+   use MAPL_StringTemplate, only: StrTemplate
 
    implicit none
    private
@@ -827,7 +827,7 @@ contains
 !   Read any pointwise emissions, if requested
 !   ------------------------------------------
     if(self%doing_point_emissions) then
-       call fill_grads_template (fname, self%point_emissions_srcfilen, experiment_id='unknown', &
+       call StrTemplate(fname, self%point_emissions_srcfilen, xid='unknown', &
                          nymd=nymd, nhms=120000 )
        call ReadPointEmissions (nymd, fname, self%nPts, self%pLat, self%pLon, &
                                  self%pBase, self%pTop, self%pEmis, self%pStart, &

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -17,7 +17,7 @@ module DU2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_GridCompMod
-   use m_StrTemplate          ! string templates
+   use MAPL_StringTemplate
    
    implicit none
    private
@@ -712,7 +712,7 @@ real, allocatable, dimension(:,:)     :: dqa
     if (self%doing_point_emissions) then
        if (self%day_save /= idd) then
           self%day_save = idd
-          call StrTemplate (fname, self%point_emissions_srcfilen, xid='unknown', &
+          call fill_grads_template (fname, self%point_emissions_srcfilen, experiment_id='unknown', &
                             nymd=nymd, nhms=120000 )
           call ReadPointEmissions (nymd, fname, self%nPts, self%pLat, self%pLon, &
                                    self%pBase, self%pTop, self%pEmis, self%pStart, &

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -17,7 +17,7 @@ module DU2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_GridCompMod
-   use MAPL_StringTemplate
+   use MAPL_StringTemplate, only: StrTemplate
    
    implicit none
    private
@@ -712,7 +712,7 @@ real, allocatable, dimension(:,:)     :: dqa
     if (self%doing_point_emissions) then
        if (self%day_save /= idd) then
           self%day_save = idd
-          call fill_grads_template (fname, self%point_emissions_srcfilen, experiment_id='unknown', &
+          call StrTemplate(fname, self%point_emissions_srcfilen, xid='unknown', &
                             nymd=nymd, nhms=120000 )
           call ReadPointEmissions (nymd, fname, self%nPts, self%pLat, self%pLon, &
                                    self%pBase, self%pTop, self%pEmis, self%pStart, &

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -17,7 +17,7 @@ module SU2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_GridCompMod
-   use m_StrTemplate          ! string templates
+   use MAPL_StringTemplate
 
    implicit none
    private
@@ -848,7 +848,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 
 !      Get pointwise SO2 and altitude of volcanoes from a daily file data base
        if(index(self%volcano_srcfilen,'volcanic_') /= 0) then
-          call StrTemplate (fname, self%volcano_srcfilen, xid='unknown', &
+          call fill_grads_template (fname, self%volcano_srcfilen, experiment_id='unknown', &
                             nymd=nymd, nhms=120000 )
           call ReadPointEmissions (nymd, fname, self%nVolc, self%vLat, self%vLon, &
                                    self%vElev, self%vCloud, self%vSO2, self%vStart, &
@@ -915,7 +915,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 !   Read any pointwise emissions, if requested
 !   ------------------------------------------
     if(self%doing_point_emissions) then
-       call StrTemplate (fname, self%point_emissions_srcfilen, xid='unknown', &
+       call fill_grads_template (fname, self%point_emissions_srcfilen, experiment_id='unknown', &
                          nymd=nymd, nhms=120000 )
        call ReadPointEmissions (nymd, fname, self%nPts, self%pLat, self%pLon, &
                                  self%pBase, self%pTop, self%pEmis, self%pStart, &

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -17,7 +17,7 @@ module SU2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_GridCompMod
-   use MAPL_StringTemplate
+   use MAPL_StringTemplate, only: StrTemplate
 
    implicit none
    private
@@ -848,7 +848,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 
 !      Get pointwise SO2 and altitude of volcanoes from a daily file data base
        if(index(self%volcano_srcfilen,'volcanic_') /= 0) then
-          call fill_grads_template (fname, self%volcano_srcfilen, experiment_id='unknown', &
+          call StrTemplate(fname, self%volcano_srcfilen, xid='unknown', &
                             nymd=nymd, nhms=120000 )
           call ReadPointEmissions (nymd, fname, self%nVolc, self%vLat, self%vLon, &
                                    self%vElev, self%vCloud, self%vSO2, self%vStart, &
@@ -915,7 +915,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 !   Read any pointwise emissions, if requested
 !   ------------------------------------------
     if(self%doing_point_emissions) then
-       call fill_grads_template (fname, self%point_emissions_srcfilen, experiment_id='unknown', &
+       call StrTemplate(fname, self%point_emissions_srcfilen, xid='unknown', &
                          nymd=nymd, nhms=120000 )
        call ReadPointEmissions (nymd, fname, self%nPts, self%pLat, self%pLon, &
                                  self%pBase, self%pTop, self%pEmis, self%pStart, &

--- a/config/GMAO_Shared.sparse
+++ b/config/GMAO_Shared.sparse
@@ -15,3 +15,4 @@
 !/GMAO_stoch
 !/GMAO_transf
 !/LANL_Shared
+!/GMAO_mpeu


### PR DESCRIPTION
Small changes to GOCART2G, to eliminate the dependency on the `m_StrTemplate` provided by  `GMAO_Shared/GMAO_mpeu` in favor of the replacement in `MAPL_StringTemplate` provided by MAPL.

Note that I have not tested this yet, so I ask @gmao-esherman to please test this change before this is accepted.