### PR TITLE
Fixed gfortran build errors

### DIFF
--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -169,7 +169,7 @@ contains
 !   ------------------------
     call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Initialize,  Initialize, __RC__)
     call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Run, Run, __RC__)
-    if (data_driven /= .true.) then
+    if (data_driven .neqv. .true.) then
        call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Run, Run2, __RC__)
     end if
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -154,7 +154,7 @@ contains
 !   ------------------------
     call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Initialize,  Initialize, __RC__)
     call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Run, Run, __RC__)
-    if (data_driven /= .true.) then
+    if (data_driven .neqv. .true.) then
        call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Run, Run2, __RC__)
     end if
 

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -133,7 +133,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),' SetServices BEGIN'
 !   ------------------------
     call MAPL_GridCompSetEntryPoint (GC, ESMF_METHOD_INITIALIZE,  Initialize, __RC__)
     call MAPL_GridCompSetEntryPoint (GC, ESMF_METHOD_RUN, Run, __RC__)
-    if (data_driven /= .true.) then
+    if (data_driven .neqv. .true.) then
        call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Run, Run2, __RC__)
     end if
 

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -145,7 +145,7 @@ contains
 !   ------------------------
     call MAPL_GridCompSetEntryPoint (GC, ESMF_METHOD_INITIALIZE,  Initialize, __RC__)
     call MAPL_GridCompSetEntryPoint (GC, ESMF_METHOD_RUN, Run, __RC__)
-    if (data_driven /= .true.) then
+    if (data_driven .neqv. .true.) then
        call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Run, Run2, __RC__)
     end if
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -198,7 +198,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 !   ------------------------
     call MAPL_GridCompSetEntryPoint (GC, ESMF_METHOD_INITIALIZE,  Initialize, __RC__)
     call MAPL_GridCompSetEntryPoint (GC, ESMF_METHOD_RUN, Run, __RC__)
-    if (data_driven /= .true.) then
+    if (data_driven .neqv. .true.) then
        call MAPL_GridCompSetEntryPoint (GC, ESMF_Method_Run, Run2, __RC__)
     end if
 

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -1840,7 +1840,7 @@ CONTAINS
 !-------------------------------------------------------------------------
 !  Begin...
 
-   if( present(NO3nFlag) .and. (NO3nFlag ==.true.)) NO3nFlag_ = .true.
+   if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) NO3nFlag_ = .true.
 
 !  Initialize local variables
 !  --------------------------
@@ -2028,7 +2028,7 @@ CONTAINS
 !         Integrate in the vertical
           if( present(exttau) .and. associated(exttau) ) exttau(i,j) = exttau(i,j) + tau
           if( present(exttaufm) .and. associated(exttaufm)) then
-             if( present(NO3nFlag) .and. (NO3nFlag==.true.)) then
+             if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) then
                 exttaufm(i,j) = exttaufm(i,j) + tau
              else
                 exttaufm(i,j) = exttaufm(i,j) + tau * fPMfm(n)
@@ -2036,7 +2036,7 @@ CONTAINS
           end if
 
           if( present(exttau25) .and. associated(exttau25)) then
-             if( present(NO3nFlag) .and. (NO3nFlag==.true.)) then
+             if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) then
                 exttau25(i,j) = exttau25(i,j) + tau
              else
                 exttau25(i,j) = exttau25(i,j) + tau * fPM25(n)
@@ -2045,7 +2045,7 @@ CONTAINS
 
           if( present(scatau) .and. associated(scatau) ) scatau(i,j) = scatau(i,j) + tau*ssa
           if( present(scataufm) .and. associated(scataufm) ) then
-             if( present(NO3nFlag) .and. (NO3nFlag==.true.)) then
+             if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) then
                 scataufm(i,j) = scataufm(i,j) + tau * ssa
              else
                 scataufm(i,j) = scataufm(i,j) + tau * ssa * fPMfm(n)
@@ -2053,7 +2053,7 @@ CONTAINS
           end if
 
           if( present(scatau25) .and. associated(scatau25) ) then
-             if( present(NO3nFlag) .and. (NO3nFlag==.true.)) then
+             if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) then
                 scatau25(i,j) = scatau25(i,j) + tau * ssa
              else
                 scatau25(i,j) = scatau25(i,j) + tau * ssa * fPM25(n)


### PR DESCRIPTION
Fixed a few bugs that caused build failures when building with the gfortran compiler. All were related, namely logical variables cannot be compared with `==` and `\=`, they must instead be compared with `.eqv.` and `.neqv.` respectively. 