### PR TITLE
Bug fix for reading bands from RC files

### DIFF
--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -533,19 +533,14 @@ contains
                                   label="aerosol_radBands_optics_file:", __RC__ )
 
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
+    self%rad_MieTable(instance)%nch = NUM_BANDS
 
     call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, rc=status)
-
-    if (rc /= 0) then
-       do i = 1, NUM_BANDS
-          self%rad_MieTable(instance)%channels(i) = i
-       end do
-    end if
+                                 count=self%rad_MieTable(instance)%nch, __RC__)
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
-    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, rc)
-    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, rc)
+    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)
+    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, __RC__)
 
 !   Create Diagnostics Mie Table
 !   -----------------------------

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -373,6 +373,7 @@ contains
     real, pointer, dimension(:,:)        :: area
     logical                              :: data_driven
     integer                              :: NUM_BANDS
+    logical                              :: bands_are_present
 
     __Iam__('Initialize')
 
@@ -535,8 +536,16 @@ contains
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
     self%rad_MieTable(instance)%nch = NUM_BANDS
 
-    call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, __RC__)
+    call ESMF_ConfigFindLabel(cfg, label="BANDS:", isPresent=bands_are_present, __RC__)
+
+    if (bands_are_present) then
+       call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
+                                    count=self%rad_MieTable(instance)%nch, __RC__)
+    else
+       do i = 1, NUM_BANDS
+          self%rad_MieTable(instance)%channels(i) = i
+       end do
+    endif
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
     self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -342,6 +342,7 @@ contains
     real, pointer, dimension(:,:)        :: area
     logical                              :: data_driven
     integer                              :: NUM_BANDS
+    logical                              :: bands_are_present
 
     __Iam__('Initialize')
 
@@ -490,8 +491,16 @@ contains
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
     self%rad_MieTable(instance)%nch = NUM_BANDS
 
-    call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, __RC__)
+    call ESMF_ConfigFindLabel(cfg, label="BANDS:", isPresent=bands_are_present, __RC__)
+
+    if (bands_are_present) then
+       call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
+                                    count=self%rad_MieTable(instance)%nch, __RC__)
+    else
+       do i = 1, NUM_BANDS
+          self%rad_MieTable(instance)%channels(i) = i
+       end do
+    endif
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
     self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -488,19 +488,14 @@ contains
                                   label="aerosol_radBands_optics_file:", __RC__ )
 
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
+    self%rad_MieTable(instance)%nch = NUM_BANDS
 
     call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, rc=status)
-
-    if (rc /= 0) then
-       do i = 1, NUM_BANDS
-          self%rad_MieTable(instance)%channels(i) = i
-       end do
-    end if
+                                 count=self%rad_MieTable(instance)%nch, __RC__)
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
-    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, rc)
-    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, rc)
+    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)
+    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, __RC__)
 
 !   Create Diagnostics Mie Table
 !   -----------------------------

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -321,6 +321,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),' SetServices END'
     integer                              :: HDT         ! model     timestep (secs)
     real, pointer, dimension(:,:,:)      :: int_ptr
     logical                              :: data_driven
+    logical                              :: bands_are_present
     integer                              :: NUM_BANDS
     character (len=ESMF_MAXSTR), allocatable    :: aerosol_names(:)
     real, pointer, dimension(:,:,:)      :: ple
@@ -515,8 +516,16 @@ if(mapl_am_i_root()) print*,trim(comp_name),' Init BEGIN'
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
     self%rad_MieTable(instance)%nch = NUM_BANDS
 
-    call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, __RC__)
+    call ESMF_ConfigFindLabel(cfg, label="BANDS:", isPresent=bands_are_present, __RC__)
+
+    if (bands_are_present) then
+       call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
+                                    count=self%rad_MieTable(instance)%nch, __RC__)
+    else
+       do i = 1, NUM_BANDS
+          self%rad_MieTable(instance)%channels(i) = i
+       end do
+    endif
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
     self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -513,19 +513,14 @@ if(mapl_am_i_root()) print*,trim(comp_name),' Init BEGIN'
                                   label="aerosol_radBands_optics_file:", __RC__ )
 
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
+    self%rad_MieTable(instance)%nch = NUM_BANDS
 
     call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, rc=status)
-
-    if (rc /= 0) then
-       do i = 1, NUM_BANDS
-          self%rad_MieTable(instance)%channels(i) = i
-       end do
-    end if
+                                 count=self%rad_MieTable(instance)%nch, __RC__)
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
-    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, rc)
-    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, rc)
+    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)
+    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, __RC__)
 
 !   Create Diagnostics Mie Table
 !   -----------------------------

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -487,19 +487,14 @@ end do
                                   label="aerosol_radBands_optics_file:", __RC__ )
 
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
+    self%rad_MieTable(instance)%nch = NUM_BANDS
 
     call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, rc=status)
-
-    if (rc /= 0) then
-       do i = 1, NUM_BANDS
-          self%rad_MieTable(instance)%channels(i) = i
-       end do
-    end if
+                                 count=self%rad_MieTable(instance)%nch, __RC__)
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
-    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, rc)
-    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, rc)
+    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)
+    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, __RC__)
 
 !   Create Diagnostics Mie Table
 !   -----------------------------

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -334,6 +334,7 @@ contains
     real, pointer, dimension(:,:,:,:)    :: int_ptr
     logical                              :: data_driven
     integer                              :: NUM_BANDS
+    logical                              :: bands_are_present
     real, pointer, dimension(:,:,:)      :: ple
     real, pointer, dimension(:,:)        :: area
 
@@ -489,8 +490,16 @@ end do
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
     self%rad_MieTable(instance)%nch = NUM_BANDS
 
-    call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, __RC__)
+    call ESMF_ConfigFindLabel(cfg, label="BANDS:", isPresent=bands_are_present, __RC__)
+
+    if (bands_are_present) then
+       call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
+                                    count=self%rad_MieTable(instance)%nch, __RC__)
+    else
+       do i = 1, NUM_BANDS
+          self%rad_MieTable(instance)%channels(i) = i
+       end do
+    endif
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
     self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -412,6 +412,7 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
     real, pointer, dimension(:,:,:)      :: int_ptr
     logical                              :: data_driven
     integer                              :: NUM_BANDS
+    logical                              :: bands_are_present
     real, pointer, dimension(:,:,:)      :: ple
     real, pointer, dimension(:,:)        :: area
 
@@ -606,8 +607,16 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
     self%rad_MieTable(instance)%nch = NUM_BANDS
 
-    call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, __RC__)
+    call ESMF_ConfigFindLabel(cfg, label="BANDS:", isPresent=bands_are_present, __RC__)
+
+    if (bands_are_present) then
+       call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
+                                    count=self%rad_MieTable(instance)%nch, __RC__)
+    else
+       do i = 1, NUM_BANDS
+          self%rad_MieTable(instance)%channels(i) = i
+       end do
+    endif
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
     self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -604,19 +604,14 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
                                   label="aerosol_radBands_optics_file:", __RC__ )
 
     allocate (self%rad_MieTable(instance)%channels(NUM_BANDS), __STAT__ )
+    self%rad_MieTable(instance)%nch = NUM_BANDS
 
     call ESMF_ConfigGetAttribute (cfg, self%rad_MieTable(instance)%channels, label= "BANDS:", &
-                                 count=self%rad_MieTable(instance)%nch, rc=status)
-
-    if (rc /= 0) then
-       do i = 1, NUM_BANDS
-          self%rad_MieTable(instance)%channels(i) = i
-       end do
-    end if
+                                 count=self%rad_MieTable(instance)%nch, __RC__)
 
     allocate (self%rad_MieTable(instance)%mie_aerosol, __STAT__)
-    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, rc)
-    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, rc)
+    self%rad_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%rad_MieTable(instance)%optics_file, __RC__)
+    call Chem_MieTableRead (self%rad_MieTable(instance)%mie_aerosol, NUM_BANDS, self%rad_MieTable(instance)%channels, __RC__)
 
 !   Create Diagnostics Mie Table
 !   -----------------------------


### PR DESCRIPTION
In running GOCART2G tests within NOAA's UFS system @rmontuoro discovered an error in the `PET.ESMF_LogFiles` related to reading the `BANDS:` option from the MAPL config.

This fixes this issue along with several related `rc` code errors found in GOCART2G's children.