### PR TITLE
GOCART errors

### DIFF
--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1084,6 +1084,9 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 !   SU Settling
 !   -----------
     do n = 1, self%nbins
+       ! if radius == 0 then we're dealing with a gas which has no settling losses
+       if (self%radius(n) == 0.0) cycle
+
        call MAPL_VarSpecGet(InternalSpec(n), SHORT_NAME=short_name, __RC__)
        call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1085,7 +1085,10 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 !   -----------
     do n = 1, self%nbins
        ! if radius == 0 then we're dealing with a gas which has no settling losses
-       if (self%radius(n) == 0.0) cycle
+       if (self%radius(n) == 0.0) then
+          if (associated(SUSD)) SUSD(:,:,n) = 0.0
+          cycle
+       end if
 
        call MAPL_VarSpecGet(InternalSpec(n), SHORT_NAME=short_name, __RC__)
        call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -7086,6 +7086,8 @@ loop2: DO l = 1,nspecies_HL
 !-------------------------------------------------------------------------
 !  Begin...
 
+      rc = __SUCCESS__
+
       ! For extremely low relative humidity ( less than 1% ) set the 
       ! water content to a minimum and skip the calculation.
       IF ( RH .LT. 0.01 ) THEN


### PR DESCRIPTION
@gmao-esherman reported two errors resulting from the `rc` handling PR #31, due to it catching non-zero return codes. Namely, the tracebacks:
```
pe=00010 FAIL at line=00832 NI2G_GridCompMod.F90 <status=-858993460>
pe=00025 FAIL at line=01092 SU2G_GridCompMod.F90 <status=100>
```
The first was cased by an uninitialized value for the `rc` in the process library. While the second is due to the inclusion of a gas phase in the SU bins, so there shouldn't be any settling for that bin anyways.