### PR TITLE
Implement NOAA/ARL FENGSHA dust scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Compute and export PM2.5 and PM10 diagnostic tracers in UFS interface
+- Add NOAA/ARL FENGSHA dust scheme
 
 ## [1.0.1] - 2021-03-22
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -58,7 +58,7 @@ module DU2G_GridCompMod
        real                   :: Ch_DU          ! dust emission tuning coefficient [kg s2 m-5].
        logical                :: maringFlag=.false.  ! maring settling velocity correction
        integer                :: day_save = -1      
-       character(len=8)       :: emission_scheme     ! emission scheme selector
+       character(len=:), allocatable :: emission_scheme     ! emission scheme selector
 !      !Workspae for point emissions
        logical                :: doing_point_emissions = .false.
        character(len=255)     :: point_emissions_srcfilen   ! filename for pointwise emissions
@@ -110,7 +110,7 @@ contains
     type (DU2G_GridComp), pointer      :: self
 
     character (len=ESMF_MAXSTR)        :: field_name
-    character (len=8)                  :: emission_scheme
+    character (len=ESMF_MAXSTR)        :: emission_scheme
     integer                            :: i
     real                               :: DEFVAL
     logical                            :: data_driven = .true.
@@ -151,7 +151,7 @@ contains
     call ESMF_ConfigGetAttribute (cfg, self%rlow,       label='radius_lower:', __RC__)
     call ESMF_ConfigGetAttribute (cfg, self%rup,        label='radius_upper:', __RC__)
     call ESMF_ConfigGetAttribute (cfg, emission_scheme, label='emission_scheme:', default='ginoux', __RC__)
-    self%emission_scheme = ESMF_UtilStringLowerCase(emission_scheme, __RC__)
+    self%emission_scheme = ESMF_UtilStringLowerCase(trim(emission_scheme), __RC__)
     call ESMF_ConfigGetAttribute (cfg, self%point_emissions_srcfilen, &
                                   label='point_emissions_srcfilen:', default='/dev/null', __RC__)
     if ( (index(self%point_emissions_srcfilen,'/dev/null')>0) ) then
@@ -744,7 +744,7 @@ end do
 
 !   Get surface gridded emissions
 !   -----------------------------
-    select case (trim(self%emission_scheme))
+    select case (self%emission_scheme)
       case ('fengsha')
         call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, du_clay, du_sand, du_silt,       &
                                   du_ssm, du_rdrag, airdens(:,:,self%km), ustar, du_uthres,  &
@@ -759,7 +759,7 @@ end do
                                   self%Ch_DU, du_src, MAPL_GRAV, &
                                   emissions_surface, __RC__)
       case default
-         _ASSERT_RC(.false.,'missing dust emission scheme',ESMF_RC_NOT_IMPL)
+        _ASSERT_RC(.false.,'missing dust emission scheme',ESMF_RC_NOT_IMPL)
     end select
 
 !   Read point emissions file once per day

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -746,8 +746,8 @@ end do
 !   -----------------------------
     select case (trim(self%emission_scheme))
       case ('fengsha')
-        call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, frclay, frsand, frsilt, &
-                                  ssm, rdrag, airdens(:,:,self%km), ustar, uthres,  &
+        call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, du_clay, du_sand, du_silt,       &
+                                  du_ssm, du_rdrag, airdens(:,:,self%km), ustar, du_uthres,  &
                                   self%alpha, self%gamma, self%kvhmax, MAPL_GRAV,   &
                                   self%rhop, self%sdist, emissions_surface, __RC__)
       case ('ginoux')

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -708,10 +708,6 @@ integer :: n
 !   -----------------------------------
     call MAPL_Get (mapl, INTERNAL_ESMF_STATE=internal, __RC__)
 
-do n=1,5
-   if(mapl_am_i_root()) print*,'n = ', n,' : Run1 B DU2G sum(du00n) = ',sum(DU(:,:,:,n))
-end do
-
 !   Get my private internal state
 !   ------------------------------
     call ESMF_UserCompGetInternalState(GC, 'DU2G_GridComp', wrap, STATUS)
@@ -728,6 +724,10 @@ end do
     associate (scheme => self%emission_scheme)
 #include "DU2G_GetPointer___.h"
     end associate
+
+do n=1,5
+   if(mapl_am_i_root()) print*,'n = ', n,' : Run1 B DU2G sum(du00n) = ',sum(DU(:,:,:,n))
+end do
 
 !   Get dimensions
 !   ---------------
@@ -872,10 +872,6 @@ end do
 !   -----------------------------------
     call MAPL_Get (MAPL, INTERNAL_ESMF_STATE=internal, __RC__)
 
-do n=1,5
-   if(mapl_am_i_root()) print*,'n = ', n,' : Run2 B DU2G sum(du00n) = ',sum(DU(:,:,:,n))
-end do
-
 !   Get my private internal state
 !   ------------------------------
     call ESMF_UserCompGetInternalState(GC, 'DU2G_GridComp', wrap, STATUS)
@@ -885,6 +881,10 @@ end do
     associate (scheme => self%emission_scheme)
 #include "DU2G_GetPointer___.h"
     end associate
+
+do n=1,5
+   if(mapl_am_i_root()) print*,'n = ', n,' : Run2 B DU2G sum(du00n) = ',sum(DU(:,:,:,n))
+end do
 
     allocate(dqa, mold=wet1, __STAT__)
     allocate(drydepositionfrequency, mold=wet1, __STAT__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridComp_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridComp_DU.rc
@@ -38,7 +38,7 @@ nbins: 5
 pressure_lid_in_hPa: 0.01
 
 # Emissions methods
-emission_scheme: 1       # 1 for GOCART, 2 for FENGSHA
+emission_scheme: Ginoux       # available schemes: Ginoux, FENGSHA
 
 # FENGSHA settings
 alpha: 0.3

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridComp_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridComp_DU.rc
@@ -37,5 +37,13 @@ nbins: 5
 
 pressure_lid_in_hPa: 0.01
 
+# Emissions methods
+emission_scheme: 1       # 1 for GOCART, 2 for FENGSHA
+
+# FENGSHA settings
+alpha: 0.3
+gamma: 1.3
+vertical_to_horizontal_flux_ratio_limit: 2.e-04
+
 #point_emissions_srcfilen: /gpfsm/dnb32/esherman/gocartRefactor/RC/CA2G_point_src_test.rc
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -7,18 +7,18 @@ category: IMPORT
 #----------------------------------------------------------------------------------------
      NAME   | UNITS  | DIMS | VLOC| COND | LONG NAME
 #----------------------------------------------------------------------------------------
- DU_SRC     | 1      | xy   | N   |      | erod - dust emissions
- FRLAKE     | 1      | xy   | N   |      | fraction_of_lake
- FRSNOW     | 1      | xy   | N   |      | surface_snow_area_fraction
+ DU_SRC     | 1      | xy   | N   | scheme == 'ginoux'  | erod - dust emissions
+ FRSNOW     | 1      | xy   | N   | scheme == 'fengsha' | surface_snow_area_fraction
+ SLC        | 1      | xy   | N   | scheme == 'fengsha' | liquid_water_content_of_soil_layer
+ FRCLAY     | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_clay_in_soil
+ FRSAND     | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_sand_in_soil
+ FRSILT     | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_silt_in_soil
+ RDRAG      | m-1    | xy   | N   | scheme == 'fengsha' | drag_partition
+ SSM        | 1      | xy   | N   | scheme == 'fengsha' | sediment_supply_map
+ UTHRES     | m s-1  | xy   | N   | scheme == 'fengsha' | surface_dry_threshold_velocity
  WET1       | 1      | xy   | N   |      | surface_soil_wetness
- SLC        | 1      | xy   | N   |      | liquid_water_content_of_soil_layer
  LWI        | 1      | xy   | N   |      | land-ocean-ice_mask
- FRCLAY     | 1      | xy   | N   |      | volume_fraction_of_clay_in_soil
- FRSAND     | 1      | xy   | N   |      | volume_fraction_of_sand_in_soil
- FRSILT     | 1      | xy   | N   |      | volume_fraction_of_silt_in_soil
- RDRAG      | m-1    | xy   | N   |      | drag_partition
- SSM        | 1      | xy   | N   |      | sediment_supply_map
- UTHRES     | m s-1  | xy   | N   |      | surface_dry_threshold_velocity
+ FRLAKE     | 1      | xy   | N   |      | fraction_of_lake
  U10M       | m s-1  | xy   | N   |      | 10-meter_eastward_wind
  V10M       | m s-1  | xy   | N   |      | 10-meter_northward_wind
  AREA       | m^2    | xy   | N   |      | agrid_cell_area

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -8,14 +8,14 @@ category: IMPORT
      NAME   | UNITS  | DIMS | VLOC| COND | LONG NAME
 #----------------------------------------------------------------------------------------
  DU_SRC     | 1      | xy   | N   | scheme == 'ginoux'  | erod - dust emissions
+ DU_CLAY    | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_clay_in_soil
+ DU_SAND    | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_sand_in_soil
+ DU_SILT    | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_silt_in_soil
+ DU_RDRAG   | m-1    | xy   | N   | scheme == 'fengsha' | drag_partition
+ DU_SSM     | 1      | xy   | N   | scheme == 'fengsha' | sediment_supply_map
+ DU_UTHRES  | m s-1  | xy   | N   | scheme == 'fengsha' | surface_dry_threshold_velocity
  FRSNOW     | 1      | xy   | N   | scheme == 'fengsha' | surface_snow_area_fraction
  SLC        | 1      | xy   | N   | scheme == 'fengsha' | liquid_water_content_of_soil_layer
- FRCLAY     | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_clay_in_soil
- FRSAND     | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_sand_in_soil
- FRSILT     | 1      | xy   | N   | scheme == 'fengsha' | volume_fraction_of_silt_in_soil
- RDRAG      | m-1    | xy   | N   | scheme == 'fengsha' | drag_partition
- SSM        | 1      | xy   | N   | scheme == 'fengsha' | sediment_supply_map
- UTHRES     | m s-1  | xy   | N   | scheme == 'fengsha' | surface_dry_threshold_velocity
  WET1       | 1      | xy   | N   |      | surface_soil_wetness
  LWI        | 1      | xy   | N   |      | land-ocean-ice_mask
  FRLAKE     | 1      | xy   | N   |      | fraction_of_lake

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -9,8 +9,16 @@ category: IMPORT
 #----------------------------------------------------------------------------------------
  DU_SRC     | 1      | xy   | N   |      | erod - dust emissions
  FRLAKE     | 1      | xy   | N   |      | fraction_of_lake
+ FRSNOW     | 1      | xy   | N   |      | surface_snow_area_fraction
  WET1       | 1      | xy   | N   |      | surface_soil_wetness
+ SLC        | 1      | xy   | N   |      | liquid_water_content_of_soil_layer
  LWI        | 1      | xy   | N   |      | land-ocean-ice_mask
+ FRCLAY     | 1      | xy   | N   |      | volume_fraction_of_clay_in_soil
+ FRSAND     | 1      | xy   | N   |      | volume_fraction_of_sand_in_soil
+ FRSILT     | 1      | xy   | N   |      | volume_fraction_of_silt_in_soil
+ RDRAG      | 1      | xy   | N   |      | drag_partition
+ SSM        | 1      | xy   | N   |      | sediment_supply_map
+ UTHRES     | m s-1  | xy   | N   |      | surface_dry_threshold_velocity
  U10M       | m s-1  | xy   | N   |      | 10-meter_eastward_wind
  V10M       | m s-1  | xy   | N   |      | 10-meter_northward_wind
  AREA       | m^2    | xy   | N   |      | agrid_cell_area

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -16,7 +16,7 @@ category: IMPORT
  FRCLAY     | 1      | xy   | N   |      | volume_fraction_of_clay_in_soil
  FRSAND     | 1      | xy   | N   |      | volume_fraction_of_sand_in_soil
  FRSILT     | 1      | xy   | N   |      | volume_fraction_of_silt_in_soil
- RDRAG      | 1      | xy   | N   |      | drag_partition
+ RDRAG      | m-1    | xy   | N   |      | drag_partition
  SSM        | 1      | xy   | N   |      | sediment_supply_map
  UTHRES     | m s-1  | xy   | N   |      | surface_dry_threshold_velocity
  U10M       | m s-1  | xy   | N   |      | 10-meter_eastward_wind

--- a/ESMF/UFS/Aerosol_Cap.F90
+++ b/ESMF/UFS/Aerosol_Cap.F90
@@ -24,7 +24,7 @@ module Aerosol_Cap
   implicit none
 
   ! -- import fields
-  integer, parameter :: importFieldCount = 26
+  integer, parameter :: importFieldCount = 28
   character(len=*), dimension(importFieldCount), parameter :: &
     importFieldNames = (/ &
       "inst_pres_interface                  ", &
@@ -50,9 +50,11 @@ module Aerosol_Cap
       "inst_sensi_heat_flx                  ", &
       "inst_surface_roughness               ", &
       "inst_surface_soil_wetness            ", &
+      "inst_soil_moisture_content           ", &
       "ice_fraction                         ", &
       "lake_fraction                        ", &
-      "ocean_fraction                       "  &
+      "ocean_fraction                       ", &
+      "surface_snow_area_fraction           "  &
     /)
   ! -- export fields
   integer, parameter :: exportFieldCount = 3

--- a/ESMF/UFS/Aerosol_Cap.F90
+++ b/ESMF/UFS/Aerosol_Cap.F90
@@ -24,9 +24,8 @@ module Aerosol_Cap
   implicit none
 
   ! -- import fields
-  integer, parameter :: importFieldCount = 28
-  character(len=*), dimension(importFieldCount), parameter :: &
-    importFieldNames = (/ &
+  character(len=*), dimension(*), parameter :: &
+    importFieldNames = [ &
       "inst_pres_interface                  ", &
       "inst_pres_levels                     ", &
       "inst_geop_interface                  ", &
@@ -55,15 +54,14 @@ module Aerosol_Cap
       "lake_fraction                        ", &
       "ocean_fraction                       ", &
       "surface_snow_area_fraction           "  &
-    /)
+    ]
   ! -- export fields
-  integer, parameter :: exportFieldCount = 3
-  character(len=*), dimension(exportFieldCount), parameter :: &
-    exportFieldNames = (/ &
+  character(len=*), dimension(*), parameter :: &
+    exportFieldNames = [ &
       "inst_tracer_mass_frac                ", &
       "inst_tracer_up_surface_flx           ", &
       "inst_tracer_down_surface_flx         "  &
-    /)
+    ]
 
   type Aerosol_InternalState_T
     type(MAPL_Cap), pointer :: maplCap
@@ -189,28 +187,24 @@ contains
     rc = ESMF_SUCCESS
 
     ! -- advertise imported fields
-    if (importFieldCount > 0) then
-      call NUOPC_Advertise(importState, importFieldNames, &
-        TransferOfferGeomObject="cannot provide", &
-        SharePolicyField="share", &
-        rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-    end if
+    call NUOPC_Advertise(importState, importFieldNames, &
+      TransferOfferGeomObject="cannot provide", &
+      SharePolicyField="share", &
+      rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
 
     ! -- advertise exported fields
-    if (exportFieldCount > 0) then
-      call NUOPC_Advertise(exportState, exportFieldNames, &
-        TransferOfferGeomObject="cannot provide", &
-        SharePolicyField="share", &
-        rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-    end if
+    call NUOPC_Advertise(exportState, exportFieldNames, &
+      TransferOfferGeomObject="cannot provide", &
+      SharePolicyField="share", &
+      rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
 
   end subroutine ModelInitializeP1
 

--- a/ESMF/UFS/Aerosol_Comp_Mod.F90
+++ b/ESMF/UFS/Aerosol_Comp_Mod.F90
@@ -6,9 +6,8 @@ module Aerosol_Comp_Mod
 
   implicit none
 
-  integer, parameter :: fieldMapSize = 20
-  character(len=*), dimension(fieldMapSize, 2), parameter :: &
-    fieldMap = reshape((/ &
+  character(len=*), dimension(*), parameter :: &
+    fieldPairList = [ &
       "FROCEAN                         ", "ocean_fraction                  ", &
       "FRACI                           ", "ice_fraction                    ", &
       "FRLAKE                          ", "lake_fraction                   ", &
@@ -29,7 +28,10 @@ module Aerosol_Comp_Mod
       "PFI_LSAN                        ", "inst_ice_nonconv_tendency_levels", &
       "PFL_LSAN                        ", "inst_liq_nonconv_tendency_levels", &
       "FCLD                            ", "inst_cloud_frac_levels          "  &
-      /), (/fieldMapSize, 2/), order=(/2,1/))
+    ]
+
+  character(len=*), dimension(*,2), parameter :: &
+    fieldMap = reshape(fieldPairList, [size(fieldPairList)/2,2], order=[2,1])
 
   ! gravity (m/s2)
   real(ESMF_KIND_R8), parameter :: con_g = 9.80665e+0_ESMF_KIND_R8
@@ -99,6 +101,7 @@ contains
     integer :: localrc, stat
     integer :: imap, item, itemCount
     integer :: rank
+    integer :: fieldMapSize
     integer :: i,j, k, kk, n, ni, nj, nk, nlev, offset, v
     integer, dimension(1) :: plb, pub, rlb, rub
     real(ESMF_KIND_R4) :: blkevap, blkesat
@@ -242,6 +245,7 @@ contains
           ni = size(q, 1)
           nj = size(q, 2)
           nk = size(q, 3)
+          fieldMapSize = size(fieldMap, 1)
 
           do item = 1, itemCount
             if (itemTypeList(item) == ESMF_STATEITEM_FIELD) then

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -26,7 +26,12 @@
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
+   public DustAerosolDistributionKok
+   public DustEmissionFENGSHA
    public DustEmissionGOCART2G
+   public DustFluxV2HRatioMB95
+   public moistureCorrectionFecan
+   public soilMoistureConvertVol2Grav
    public DistributePointEmission
    public updatePointwiseEmissions
    public Chem_Settling2Gorig
@@ -93,9 +98,336 @@
 !                   physics and chemistry code into a single process library that only uses
 !                   intrinsic Fortran functions.
 !
+!  01Apr2021  R.Montuoro/NOAA - Added FENGSHA dust scheme and related methods.
+!
+!
 !EOP
 !-------------------------------------------------------------------------
 CONTAINS
+
+!=====================================================================================
+!BOP
+!
+! !IROUTINE:  DustAerosolDistributionKok - Compute Kok's dust size aerosol distribution
+!
+! !INTERFACE:
+   subroutine DustAerosolDistributionKok ( radius, rLow, rUp, distribution )
+
+! !USES:
+   implicit NONE
+
+! !INPUT PARAMETERS:
+   real, dimension(:), intent(in)  :: radius      ! Dry particle bin effective radius [um]
+   real, dimension(:), intent(in)  :: rLow, rUp   ! Dry particle bin edge radii [um]
+
+! !OUTPUT PARAMETERS:
+   real, dimension(:), intent(out) :: distribution    ! Normalized dust aerosol distribution [1]
+
+! !DESCRIPTION: Computes lognormal aerosol size distribution for dust bins according to
+!               J.F.Kok, PNAS, Jan 2011, 108 (3) 1016-1021; doi:10.1073/pnas.1014798108
+!
+! !REVISION HISTORY:
+!
+! 22Feb2020 B.Baker/NOAA    - Original implementation
+! 01Apr2021 R.Montuoro/NOAA - Refactored for GOCART process library
+!
+
+! !Local Variables
+   integer :: n, nbins
+   real    :: diameter, dlam, dvol
+
+! !CONSTANTS
+   real, parameter    :: mmd    = 3.4          ! median mass diameter [um]
+   real, parameter    :: stddev = 3.0          ! geometric standard deviation [1]
+   real, parameter    :: lambda = 12.0         ! crack propagation length [um]
+   real, parameter    :: factor = 1.e0 / (sqrt(2.e0) * log(stddev))  ! auxiliary constant
+
+   character(len=*), parameter :: myname = 'DustAerosolDistributionKok'
+
+!EOP
+!-------------------------------------------------------------------------
+!  Begin...
+
+   distribution = 0.
+
+!  Assume all arrays are dimensioned consistently
+   nbins = size(radius)
+
+   dvol = 0.
+   do n = 1, nbins
+     diameter = 2 * radius(n)
+     dlam = diameter/lambda
+     distribution(n) = diameter * (1. + erf(factor * log(diameter/mmd))) &
+                     * exp(-dlam * dlam * dlam) * log(rUp(n)/rLow(n))
+     dvol = dvol + distribution(n)
+   end do
+
+!  Normalize distribution
+   do n = 1, nbins
+     distribution(n) = distribution(n) / dvol
+   end do
+
+   end subroutine DustAerosolDistributionKok
+
+!===============================================================================
+!BOP
+!
+! !IROUTINE: soilMoistureConvertVol2Grav - volumetric to gravimetric soil moisture
+!
+! !INTERFACE:
+   real function soilMoistureConvertVol2Grav(vsoil, sandfrac, rhop)
+
+! !USES:
+   implicit NONE
+
+! !INPUT PARAMETERS:
+   real, intent(in) :: vsoil       ! volumetric soil moisture fraction [1]
+   real, intent(in) :: sandfrac    ! fractional sand content [1]
+   real, intent(in) :: rhop        ! dry dust density [kg m-3]
+
+! !DESCRIPTION: Convert soil moisture fraction from volumetric to gravimetric.
+!
+! !REVISION HISTORY:
+!
+!  02Apr2020, B.Baker/NOAA    - Original implementation
+!  01Apr2020, R.Montuoro/NOAA - Adapted for GOCART process library
+
+!  !Local Variables
+   real :: vsat
+
+!  !CONSTANTS:
+   real, parameter :: rhow = 1000.    ! density of water [kg m-3]
+
+!EOP
+!-------------------------------------------------------------------------
+!  Begin...
+
+!  Saturated volumetric water content (sand-dependent) ! [m3 m-3]
+   vsat = 0.489 - 0.00126 * ( 100. * sandfrac )
+
+!  Gravimetric soil content
+   soilMoistureConvertVol2Grav = vsoil * rhow / (rhop * (1. - vsat))
+
+   end function soilMoistureConvertVol2Grav
+
+!===============================================================================
+!BOP
+!
+! !IROUTINE: moistureCorrectionFecan - Correction factor for Fecan soil moisture
+!
+! !INTERFACE:
+   real function moistureCorrectionFecan(slc, sand, clay, rhop)
+
+! !USES:
+   implicit NONE
+
+! !INPUT PARAMETERS:
+   real, intent(in) :: slc     ! liquid water content of top soil layer [kg m-2]
+   real, intent(in) :: sand    ! fractional sand content [1]
+   real, intent(in) :: clay    ! fractional clay content [1]
+   real, intent(in) :: rhop    ! dry dust density [kg m-3]
+
+! !DESCRIPTION: Compute correction factor to account for Fecal soil moisture
+!
+! !REVISION HISTORY:
+!
+!  02Apr2020, B.Baker/NOAA    - Original implementation
+!  01Apr2020, R.Montuoro/NOAA - Adapted for GOCART process library
+
+!  !Local Variables
+   real :: grvsoilm
+   real :: drylimit
+
+!EOP
+!-------------------------------------------------------------------------
+!  Begin...
+
+!  Convert soil moisture from volumetric to gravimetric
+   grvsoilm = soilMoistureConvertVol2Grav(slc, sand, rhop)
+
+!  Compute fecan dry limit
+   drylimit = clay * (14.0 * clay + 17.0)
+
+!  Compute soil moisture correction
+   moistureCorrectionFecan = sqrt(1.0 + 1.21 * max(0., grvsoilm - drylimit)**0.68)
+
+   end function moistureCorrectionFecan
+
+!===============================================================================
+!BOP
+!
+! !IROUTINE: DustFluxV2HRatioMB95 - vertical-to-horizontal dust flux ratio (MB95)
+!
+! !INTERFACE:
+   real function DustFluxV2HRatioMB95(clay, kvhmax)
+
+! !USES:
+   implicit NONE
+
+! !INPUT PARAMETERS:
+   real, intent(in) :: clay      ! fractional clay content [1]
+   real, intent(in) :: kvhmax    ! maximum flux ratio [1]
+
+!  !CONSTANTS:
+   real, parameter :: clay_thresh = 0.2    ! clay fraction above which the maximum flux ratio is returned
+
+! !DESCRIPTION: Computes the vertical-to-horizontal dust flux ratio according to
+!               B.Marticorena, G.Bergametti, J.Geophys.Res., 100(D8), 16415–16430
+!               doi:10.1029/95JD00690
+!
+! !REVISION HISTORY:
+!
+! 22Feb2020 B.Baker/NOAA    - Original implementation
+! 01Apr2021 R.Montuoro/NOAA - Adapted for GOCART process library
+!
+!EOP
+!-------------------------------------------------------------------------
+!  Begin...
+
+   if (clay > clay_thresh) then
+     DustFluxV2HRatioMB95 = kvhmax
+   else
+     DustFluxV2HRatioMB95 = 10.0**(13.4*clay-6.0)
+   end if
+
+   end function DustFluxV2HRatioMB95
+
+!==================================================================================
+!BOP
+!
+! !IROUTINE: DustEmissionFENGSHA - Compute dust emissions using NOAA/ARL FENGSHA model
+!
+! !INTERFACE:
+   subroutine DustEmissionFENGSHA(fraclake, fracsnow, oro, slc, clay, sand, silt,  &
+                                  ssm, rdrag, airdens, ustar, uthrs, alpha, gamma, &
+                                  kvhmax, grav, rhop, distribution, emissions, rc)
+
+! !USES:
+   implicit NONE
+
+! !INPUT PARAMETERS:
+   real, dimension(:,:), intent(in) :: fraclake ! fraction of lake [1]
+   real, dimension(:,:), intent(in) :: fracsnow ! surface snow area fraction [1]
+   real, dimension(:,:), intent(in) :: slc      ! liquid water content of soil layer [kg m-2]
+   real, dimension(:,:), intent(in) :: oro      ! land-ocean-ice mask [1]
+   real, dimension(:,:), intent(in) :: clay     ! fractional clay content [1]
+   real, dimension(:,:), intent(in) :: sand     ! fractional sand content [1]
+   real, dimension(:,:), intent(in) :: silt     ! fractional silt content [1]
+   real, dimension(:,:), intent(in) :: ssm      ! erosion map [1]
+   real, dimension(:,:), intent(in) :: rdrag    ! drag partition [1/m]
+   real, dimension(:,:), intent(in) :: airdens  ! air density at lowest level [kg/m^3]
+   real, dimension(:,:), intent(in) :: ustar    ! friction velocity [m/sec]
+   real, dimension(:,:), intent(in) :: uthrs    ! threshold velocity [m/2]
+   real,                 intent(in) :: alpha    ! scaling factor [1]
+   real,                 intent(in) :: gamma    ! scaling factor [1]
+   real,                 intent(in) :: kvhmax   ! max. vertical to horizontal mass flux ratio [1]
+   real,                 intent(in) :: grav     ! gravity [m/sec^2]
+   real, dimension(:),   intent(in) :: rhop            ! soil class density [kg/m^3]
+   real, dimension(:),   intent(in) :: distribution    ! normalized dust binned distribution [1]
+
+! !OUTPUT PARAMETERS:
+   real,    intent(out) :: emissions(:,:,:)     ! binned surface emissions [kg/(m^2 sec)]
+   integer, intent(out) :: rc                   ! Error return code: __SUCCESS__ or __FAIL__
+
+! !DESCRIPTION: Compute dust emissions using NOAA/ARL FENGSHA model
+!
+! !REVISION HISTORY:
+!
+! 22Feb2020 B.Baker/NOAA    - Original implementation
+! 29Mar2021 R.Montuoro/NOAA - Refactored for process library
+!
+
+! !Local Variables
+   logical               :: skip
+   integer               :: i, j, n, nbins
+   integer, dimension(2) :: ilb, iub
+   real                  :: fracland
+   real                  :: h
+   real                  :: kvh
+   real                  :: q
+   real                  :: sepd
+   real                  :: u_thresh
+
+! !CONSTANTS:
+   real, parameter       :: ssm_thresh = 1.e-02    ! emit above this erodibility threshold [1]
+
+!EOP
+!-------------------------------------------------------------------------
+!  Begin
+
+   rc = __SUCCESS__
+
+!  Get dimensions and index bounds
+!  -------------------------------
+   nbins = size(emissions, dim=3)
+   ilb = lbound(ustar)
+   iub = ubound(ustar)
+
+!  Initialize emissions
+!  --------------------
+   emissions = 0.
+
+!  Compute size-independent factors for emission flux
+!  ---------------------------
+   do j = ilb(2), iub(2)
+     do i = ilb(1), iub(1)
+       ! skip if we are not on land
+       ! --------------------------
+       skip = (oro(i,j) /= LAND)
+       ! threshold and sanity check for surface input
+       ! --------------------------------------------
+       if (.not.skip) skip = (ssm(i,j) < ssm_thresh) &
+         .or. (clay(i,j) < 0.) .or. (sand(i,j) < 0.) &
+         .or. (rdrag(i,j) < 0.)
+
+       if (.not.skip) then
+         fracland = max(0., min(1., 1.-fraclake(i,j))) &
+                  * max(0., min(1., 1.-fracsnow(i,j)))
+
+         ! compute soil erosion potential distribution (commented out for now)
+         ! -------------------------------------------
+!        sepd = 0.08 * clay(i,j) + 0.8 * silt(i,j) + 0.12 * sand(i,j)
+
+         ! Compute vertical-to-horizontal mass flux ratio
+         ! ----------------------------------------------
+         kvh = DustFluxV2HRatioMB95(clay(i,j), kvhmax)
+
+         ! Compute total emissions
+         ! -----------------------
+         emissions(i,j,nbins) = alpha * fracland * (ssm(i,j) ** gamma) &
+                              * airdens(i,j) * kvh / grav
+       end if
+
+     end do
+   end do
+
+!  Now compute size-dependent total emission flux
+!  ----------------------------------------------
+   do n = 1, nbins
+     do j = ilb(2), iub(2)
+       do i = ilb(1), iub(1)
+         if (emissions(i,j,nbins) > 0.) then
+           ! Fecan moisture correction
+           ! -------------------------
+           h = moistureCorrectionFecan(slc(i,j), sand(i,j), clay(i,j), rhop(n))
+
+           ! Adjust threshold
+           ! ----------------
+           u_thresh = uthrs(i,j) * h / rdrag(i,j)
+
+           ! Compute Horizontal Saltation Flux
+           ! ---------------------------------
+           q = max(0., ustar(i,j) * (ustar(i,j) * ustar(i,j) - u_thresh * u_thresh))
+
+           ! Distribute emissions to bins and convert to mass flux (kg s-1)
+           ! --------------------------------------------------------------
+           emissions(i,j,n) = distribution(n) * emissions(i,j,nbins) * q
+         end if
+       end do
+     end do
+   end do
+
+   end subroutine DustEmissionFENGSHA
 
 !==================================================================================
 !BOP

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -222,7 +222,7 @@ CONTAINS
    implicit NONE
 
 ! !INPUT PARAMETERS:
-   real, intent(in) :: slc     ! liquid water content of top soil layer [kg m-2]
+   real, intent(in) :: slc     ! liquid water content of top soil layer, volumetric fraction [1]
    real, intent(in) :: sand    ! fractional sand content [1]
    real, intent(in) :: clay    ! fractional clay content [1]
    real, intent(in) :: rhop    ! dry dust density [kg m-3]
@@ -308,7 +308,7 @@ CONTAINS
 ! !INPUT PARAMETERS:
    real, dimension(:,:), intent(in) :: fraclake ! fraction of lake [1]
    real, dimension(:,:), intent(in) :: fracsnow ! surface snow area fraction [1]
-   real, dimension(:,:), intent(in) :: slc      ! liquid water content of soil layer [kg m-2]
+   real, dimension(:,:), intent(in) :: slc      ! liquid water content of soil layer, volumetric fraction [1]
    real, dimension(:,:), intent(in) :: oro      ! land-ocean-ice mask [1]
    real, dimension(:,:), intent(in) :: clay     ! fractional clay content [1]
    real, dimension(:,:), intent(in) :: sand     ! fractional sand content [1]

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -384,9 +384,9 @@ CONTAINS
          fracland = max(0., min(1., 1.-fraclake(i,j))) &
                   * max(0., min(1., 1.-fracsnow(i,j)))
 
-         ! compute soil erosion potential distribution (commented out for now)
+         ! compute soil erosion potential distribution
          ! -------------------------------------------
-!        sepd = 0.08 * clay(i,j) + 0.8 * silt(i,j) + 0.12 * sand(i,j)
+         sepd = 0.08 * clay(i,j) + 0.8 * silt(i,j) + 0.12 * sand(i,j)
 
          ! Compute vertical-to-horizontal mass flux ratio
          ! ----------------------------------------------
@@ -395,7 +395,7 @@ CONTAINS
          ! Compute total emissions
          ! -----------------------
          emissions(i,j,nbins) = alpha * fracland * (ssm(i,j) ** gamma) &
-                              * airdens(i,j) * kvh / grav
+                              * sepd * airdens(i,j) * kvh / grav
        end if
 
      end do

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -272,7 +272,7 @@ CONTAINS
    real, parameter :: clay_thresh = 0.2    ! clay fraction above which the maximum flux ratio is returned
 
 ! !DESCRIPTION: Computes the vertical-to-horizontal dust flux ratio according to
-!               B.Marticorena, G.Bergametti, J.Geophys.Res., 100(D8), 16415–16430
+!               B.Marticorena, G.Bergametti, J.Geophys.Res., 100(D8), 16415–16430, 1995
 !               doi:10.1029/95JD00690
 !
 ! !REVISION HISTORY:


### PR DESCRIPTION
This PR implements the FENGSHA dust scheme as an option for the GOCART dust component.

The FENGSHA scheme, developed at NOAA/ARL, is added to the GOCART process library along with few auxiliary procedures. It requires the additional input fields below, provided as surface map files via ExtData:

```
# dust component
FRCLAY                '1'  Y E - none none clayfrac     ExtData/Dust/FENGSHA_DUST_INPUTS_v0.6.nc
FRSAND                '1'  Y E - none none sandfrac     ExtData/Dust/FENGSHA_DUST_INPUTS_v0.6.nc
FRSILT                '1'  Y E - none none siltfrac     ExtData/Dust/FENGSHA_DUST_INPUTS_v0.6.nc
SSM                   '1'  Y E - none none ssm          ExtData/Dust/FENGSHA_DUST_INPUTS_v0.6.nc
RDRAG                 '1'  Y E - none none drag_part    ExtData/Dust/FENGSHA_DUST_INPUTS_v0.6.nc
UTHRES                '1'  Y E - none none uthres       ExtData/Dust/FENGSHA_DUST_INPUTS_v0.6.nc

```
Note the `E` option for nearest-neighbor interpolation enabled by MAPL PR [#788](https://github.com/GEOS-ESM/MAPL/pull/788). Until this PR has been merged, the scheme can work (not ideally) with other interpolation methods, too.

FENGSHA also requires the liquid water content (`SLC`) in the soil top layer, as well as the surface snow fraction (`FRSNOW`). All required fields fields have been added to `DU2G_StateSpecs.rc`:
```
FRSNOW     | 1      | xy   | N   |      | surface_snow_area_fraction
SLC        | 1      | xy   | N   |      | liquid_water_content_of_soil_layer
FRCLAY     | 1      | xy   | N   |      | volume_fraction_of_clay_in_soil
FRSAND     | 1      | xy   | N   |      | volume_fraction_of_sand_in_soil
FRSILT     | 1      | xy   | N   |      | volume_fraction_of_silt_in_soil
RDRAG      | m-1    | xy   | N   |      | drag_partition
SSM        | 1      | xy   | N   |      | sediment_supply_map
UTHRES     | m s-1  | xy   | N   |      | surface_dry_threshold_velocity
```

Additional input parameters have also been added to the dust component's resource file (`DU2G_GridComp_DU.rc`):
- `emission_scheme` - an integer selector for the original GOCART (1) or the FENGSHA (2) dust scheme
- `alpha`, `gamma` - FENGSHA scaling parameters (size-independent)
- `vertical_to_horizontal_flux_ratio_limit` - Maximum vertical-to-horizontal dust flux ratio, according to: B. Marticorena, G. Bergametti, _J. Geophys. Res._, 100(D8), 16415–16430, 1995.

```
# Emissions methods
emission_scheme: 2       # 1 for GOCART, 2 for FENGSHA

# FENGSHA settings
alpha: 0.3
gamma: 1.3
vertical_to_horizontal_flux_ratio_limit: 2.e-04
```
All FENGSHA-related parameters are read only if `emission_scheme is 2`.

Note also that no attempt is currently made to verify all pointers used by FENGSHA are actually allocated. I would like to have a general discussion to identify a common strategy to implement such sanity checks in GOCART, since this may affect other methods, too.

This PR was tested within UFS-GOCART on the NOAA RDHPCS Hera platform, and the generated dust distributions verified by NOAA/ARL.