### PR TITLE
Update CircleCI to use large, and update components.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_btl_vader_single_copy_mechanism: none
-    resource_class: xlarge
+    resource_class: large
     #MEDIUM# resource_class: medium
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ executors:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_btl_vader_single_copy_mechanism: none
-    #XLARGE# resource_class: xlarge
-    resource_class: medium
+    resource_class: xlarge
+    #MEDIUM# resource_class: medium
 
 workflows:
   version: 2.1
@@ -52,8 +52,8 @@ jobs:
           name: "Build GOCART2G_GridComp"
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/GOCART/build
-            #XLARGE# make -j"$(nproc)" install
-            make -j4 GOCART2G_GridComp
+            make -j"$(nproc)" install
+            #MEDIUM# make -j4 GOCART2G_GridComp
 
   build-GEOSgcm:
     executor: gcc-build-env
@@ -88,5 +88,5 @@ jobs:
           name: "Build and install"
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm/build
-            #XLARGE# make -j"$(nproc)" install
-            make -j4 install
+            make -j"$(nproc)" install
+            #MEDIUM# make -j4 install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           name: "Build GOCART2G_GridComp"
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/GOCART/build
-            make -j"$(nproc)" install
+            make -j"$(nproc)" GOCART2G_GridComp
             #MEDIUM# make -j4 GOCART2G_GridComp
 
   build-GEOSgcm:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /cmake@/
+/env@/
 /.mepo/
 /ESMF/Shared/MAPL@/
 /ESMF/Shared/GMAO_Shared@/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated `CODEOWNERS` to reflect changes in staffing
-- Updated `components.yaml` for latest MAPL
+- Updated `components.yaml`
+  - Added fixture block
+  - Added ESMA_env 3.2.1
+  - Updated ESMA_cmake to 3.4.0
+  - Updated GMAO_Shared to 1.4.0
+  - Updated MAPL to v2.6.7
+- Updated CircleCI to use `large` resource
 
 ### Fixed
 

--- a/components.yaml
+++ b/components.yaml
@@ -1,7 +1,17 @@
+GOCART:
+  fixture: true
+  develop: develop
+
+env:
+  local: ./env@
+  remote: ../ESMA_env.git
+  tag: v3.2.1
+  develop: main
+
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.3.6
+  tag: v3.4.0
   develop: develop
 
 ecbuild:
@@ -17,11 +27,12 @@ HEMCO:
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.3.8
+  tag: v1.4.0
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  branch: develop
+  tag: v2.6.7
+  develop: develop


### PR DESCRIPTION
This PR updates the CircleCI to use the `large` resource due to resumption of paid plan.

In order to debug why this was failing at first, I also updated the `components.yaml` to something that is usable on discover for debugging. 