### PR TITLE
Update gitignore for mepo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
 /cmake@/
+/cmake/
+/@cmake/
 /.mepo/
 /ESMF/Shared/MAPL@/
+/ESMF/Shared/MAPL/
+/ESMF/Shared/@MAPL/
 /ESMF/Shared/GMAO_Shared@/
+/ESMF/Shared/GMAO_Shared/
+/ESMF/Shared/@GMAO_Shared/
 /ESMF/Shared/NCEP_Shared@/
+/ESMF/Shared/NCEP_Shared/
+/ESMF/Shared/@NCEP_Shared/
 /ESMF/HEMCO_GridComp@/
+/ESMF/HEMCO_GridComp/
+/ESMF/@HEMCO_GridComp/


### PR DESCRIPTION
Soon, `mepo` will have the ability to checkout subrepos as `repo`, `repo@`, or `@repo`. This commit updates the `.gitignore` files to support this flexibility.