### PR TITLE
Updates for UFS integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated GMAO_Shared to 1.4.0
   - Updated MAPL to v2.6.7
 - Updated CircleCI to use `large` resource
+- Rename BUILD_UFS CMake flag as UFS_GOCART
+- Rename UFS target as UFS_Aerosols
+- Add CMake macros replacing ecBuild and ESMA_cmake for the UFS
+- Relax PFLOGGER dependency requirement outside Baselibs
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if (UFS_GOCART)
   elseif (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     string (REPLACE "-fdefault-real-8" "" CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
   endif()
+  list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ESMF/UFS/cmake")
 endif()
 
 if (NOT COMMAND esma)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,14 @@ if (NOT CMAKE_BUILD_TYPE)
 endif ()
 
 # Set build options
-option (BUILD_UFS "Build GOCART component for UFS" OFF)
+option (UFS_GOCART "Build GOCART component for UFS" OFF)
 
 set (DOING_GEOS5 YES)
 
 # Should find a better place for this - used in Chem component
 set (ACG_FLAGS -v)
 
-if (BUILD_UFS)
+if (UFS_GOCART)
 # Ensure we build as 32-bit
   message ("Force 32-bit build for GOCART")
   if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
@@ -63,7 +63,7 @@ if (NOT Baselibs_FOUND)
   find_package (YAFYAML REQUIRED)
 endif ()
 
-if (BUILD_UFS)
+if (UFS_GOCART)
   find_package (MAPL REQUIRED)
   include(mapl_acg)
 elseif (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/ESMF/Shared/MAPL@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if (NOT Baselibs_FOUND)
 
   find_package (GFTL REQUIRED)
   find_package (GFTL_SHARED REQUIRED)
-  find_package (PFLOGGER REQUIRED)
+  find_package (PFLOGGER QUIET)
   find_package (YAFYAML REQUIRED)
 endif ()
 

--- a/ESMF/CMakeLists.txt
+++ b/ESMF/CMakeLists.txt
@@ -2,7 +2,7 @@ set (HEMCO_EXTERNAL_CONFIG TRUE)
 set (MAPL_ESMF TRUE)
 set (BUILD_GEOS_INTERFACE TRUE)
 
-if (BUILD_UFS)
+if (UFS_GOCART)
   esma_add_subdirectories(
     Aerosol_GridComp
     GOCART2G_GridComp

--- a/ESMF/UFS/CMakeLists.txt
+++ b/ESMF/UFS/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this ()
+esma_set_this (OVERRIDE UFS_Aerosols)
 
 set (srcs
   Aerosol_Cap.F90

--- a/ESMF/UFS/cmake/README.md
+++ b/ESMF/UFS/cmake/README.md
@@ -1,0 +1,14 @@
+# UFS CMake API
+
+This directory contains a simplified implementation of CMake
+functions and macros required to build GOCART within the UFS.
+
+The included APIs eliminate GOCART's dependency on ESMA_cmake
+and ecBuild packages required to build GEOS-5. The code has
+been adapted from the following package versions:
+
+ - ESMA_cmake v3.4.2 (May 17, 2021)
+   Retrieved from: https://github.com/GEOS-ESM/ESMA_cmake
+
+ - ecBuild 3.3.2.jcsda3 (Aug 31, 2020)
+   Retrieved from: https://github.com/JCSDA-internal/ecbuild

--- a/ESMF/UFS/cmake/esma.cmake
+++ b/ESMF/UFS/cmake/esma.cmake
@@ -1,0 +1,4 @@
+# UFS/GOCART interface
+
+include (ufs_ecbuild)
+include (ufs_esma)

--- a/ESMF/UFS/cmake/ufs_ecbuild.cmake
+++ b/ESMF/UFS/cmake/ufs_ecbuild.cmake
@@ -1,0 +1,10 @@
+# UFS/GOCART interface
+#
+# UFS porting of ecBuild package.
+# See original version at: https://github.com/JCSDA-internal/ecbuild (tag: 3.3.2.jcsda3)
+
+# ecbuild_declare_project
+include (ufs_ecbuild_declare_project)
+
+# ecbuild_install_project
+include (ufs_ecbuild_install_project)

--- a/ESMF/UFS/cmake/ufs_ecbuild_declare_project.cmake
+++ b/ESMF/UFS/cmake/ufs_ecbuild_declare_project.cmake
@@ -1,0 +1,12 @@
+# UFS/GOCART interface
+#
+# UFS porting of ecBuild package.
+# See original version at: https://github.com/JCSDA-internal/ecbuild (tag: 3.3.2.jcsda3)
+
+macro (ecbuild_declare_project)
+
+  include (GNUInstallDirs)
+  set  (PROJECT_TARGETS_FILE "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-targets.cmake")
+  file (REMOVE ${PROJECT_TARGETS_FILE})
+
+endmacro ()

--- a/ESMF/UFS/cmake/ufs_ecbuild_install_project.cmake
+++ b/ESMF/UFS/cmake/ufs_ecbuild_install_project.cmake
@@ -1,0 +1,11 @@
+# UFS/GOCART interface
+#
+# UFS porting of ecBuild package.
+# See original version at: https://github.com/JCSDA-internal/ecbuild (tag: 3.3.2.jcsda3)
+
+macro (ecbuild_install_project)
+
+  install (EXPORT ${PROJECT_NAME}-targets
+           DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+endmacro ()

--- a/ESMF/UFS/cmake/ufs_esma.cmake
+++ b/ESMF/UFS/cmake/ufs_esma.cmake
@@ -1,0 +1,16 @@
+# UFS/GOCART interface
+#
+# UFS porting of ESMA_cmake package.
+# See original version at: https://github.com/GEOS-ESM/ESMA_cmake (tag: v3.4.2)
+
+# esma_set_this
+include (ufs_esma_set_this)
+
+# esma_add_subdirectories
+include (ufs_esma_add_subdirectories)
+
+# esma_add_library
+include (ufs_esma_add_library)
+
+# esma_generate_automatic_code
+include (ufs_esma_generate_automatic_code)

--- a/ESMF/UFS/cmake/ufs_esma_add_library.cmake
+++ b/ESMF/UFS/cmake/ufs_esma_add_library.cmake
@@ -1,0 +1,118 @@
+# UFS/GOCART interface
+#
+# UFS porting of ESMA_cmake package.
+# See original version at: https://github.com/GEOS-ESM/ESMA_cmake (tag: v3.4.2)
+
+macro (esma_add_library this)
+
+  set (options EXCLUDE_FROM_ALL NOINSTALL)
+  set (oneValueArgs
+    # shared with ecbuild
+    TYPE)
+  set (multiValueArgs
+    # esma unique
+    SUBCOMPONENTS SUBDIRS NEVER_STUB PRIVATE_DEFINITIONS PUBLIC_DEFINITIONS
+    # shared with ecbuild (and not deprecated)
+    SOURCES DEPENDS PUBLIC_LIBS
+    # deprecated in esma (produces explicit warnings)
+    SRCS INCLUDES DEPENDENCIES
+    # deprecated in ecbuild
+    PUBLIC_INCLUDES
+    )
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if (ARGS_UNPARSED_ARGUMENTS)
+      message (WARNING "Unrecognized keyword arguments passed to esma_add_library: ${ARGS_UNPARSED_ARGUMENTS}")
+  endif ()
+
+  # Subdirs must exist and should be configured prior to subcomponents.
+  foreach (subdir ${ARGS_SUBDIRS})
+    add_subdirectory(${subdir})
+  endforeach()
+
+  # Handle deprecated
+  if (ARGS_SRCS)
+    set (ARGS_SOURCES ${ARGS_SRCS})
+  endif ()
+  if (ARGS_INCLUDES)
+    set (ARGS_PUBLIC_INCLUDES ${ARGS_INCLUDES})
+  endif ()
+  if (ARGS_DEPENDENCIES)
+    set (ARGS_PUBLIC_LIBS ${ARGS_DEPENDENCIES})
+  endif ()
+
+  # Configure subcomponents.  These can be stubbed and may have a
+  # different name than the directory they reside in.  (Most
+  # unfortunate.)
+  set (non_stubbed)
+  foreach (subdir ${ARGS_SUBCOMPONENTS})
+
+    string(REPLACE "@" "" mod_name ${subdir})
+
+    if (NOT rename_${subdir}) # usual case
+      set (module_name ${mod_name})
+    else ()
+      set(module_name ${rename_${mod_name}})
+    endif ()
+
+    esma_add_subdirectory(${mod_name} FOUND found)
+    if (found)
+      list (APPEND non_stubbed ${mod_name})
+    else ()
+      message(WARNING "sub-component ${module_name} NOT FOUND")
+    endif ()
+
+  endforeach ()
+
+  # This library depends on all DEPENDENCIES and _non-stubbed_ subcomponents.
+  set (all_dependencies ${ARGS_PUBLIC_LIBS} ${non_stubbed})
+  if (ARGS_TYPE)
+    set(ARGS_TYPE TYPE ${ARGS_TYPE})
+  endif()
+  if (ARGS_NOINSTALL)
+    set(NOINSTALL_ "NOINSTALL")
+  endif()
+
+  add_library(${this} ${ARGS_SOURCES})
+  target_link_libraries (${this} PUBLIC ${all_dependencies} )
+  target_include_directories (${this} PUBLIC ${ARGS_PUBLIC_INCLUDES} )
+
+  set (CPP_DEBUG_${this} "" CACHE STRING "List of files to pass -DDEBUG")
+  foreach (file ${CPP_DEBUG_${this}})
+    message (STATUS "setting debug option for ${file}")
+    set_source_files_properties (${file} PROPERTIES COMPILE_DEFINITIONS -DDEBUG)
+  endforeach()
+
+  set_target_properties (${this} PROPERTIES EXCLUDE_FROM_ALL ${ARGS_EXCLUDE_FROM_ALL})
+  set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${_ufs_esma_include}/${this})
+
+  set (install_dir include/${this})
+  # Export target  include directories for other targets
+  target_include_directories(${this} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # stubs
+# modules and copied *.h, *.inc
+    $<BUILD_INTERFACE:${_ufs_esma_include}/${this}>
+    $<INSTALL_INTERFACE:${install_dir}>
+    )
+
+  if (ARGS_PUBLIC_INCLUDES)
+    target_include_directories(${this} PUBLIC $<BUILD_INTERFACE:${ARGS_PUBLIC_INCLUDES}>)
+  endif ()
+
+  if (ARGS_PRIVATE_DEFINITIONS)
+    target_compile_definitions(${this} PRIVATE ${ARGS_PRIVATE_DEFINITIONS})
+  endif ()
+  if (ARGS_PUBLIC_DEFINITIONS)
+    target_compile_definitions(${this} PUBLIC ${ARGS_PUBLIC_DEFINITIONS})
+  endif ()
+
+  export (TARGETS ${this} APPEND FILE "${PROJECT_TARGETS_FILE}" )
+
+  install ( TARGETS ${this}
+            EXPORT  ${PROJECT_NAME}-targets
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+
+endmacro ()

--- a/ESMF/UFS/cmake/ufs_esma_add_subdirectories.cmake
+++ b/ESMF/UFS/cmake/ufs_esma_add_subdirectories.cmake
@@ -1,0 +1,37 @@
+# UFS/GOCART interface
+#
+# UFS porting of ESMA_cmake package.
+# See original version at: https://github.com/GEOS-ESM/ESMA_cmake (tag: v3.4.2)
+
+function (esma_add_subdirectory dir)
+
+  set (options)
+  set (oneValueArgs FOUND)
+  set (multiValueArgs)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if (ARGS_FOUND)
+    set (${ARGS_FOUND} FALSE PARENT_SCOPE)
+  endif ()
+
+  if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
+    add_subdirectory (${dir})
+    if (ARGS_FOUND)
+      set (${ARGS_FOUND} TRUE PARENT_SCOPE)
+    endif ()
+  else ()
+    message(STATUS "Directory not found ${dir} (possibly sparse checkout)")
+  endif ()
+
+endfunction ()
+
+function (esma_add_subdirectories dirs)
+
+  set (dirs_ ${dirs} ${ARGN})
+  message (DEBUG "esma_add_subdirectories:  ${dirs}")
+
+  foreach (subdir ${dirs_})
+    esma_add_subdirectory (${subdir})
+  endforeach()
+
+endfunction ()

--- a/ESMF/UFS/cmake/ufs_esma_generate_automatic_code.cmake
+++ b/ESMF/UFS/cmake/ufs_esma_generate_automatic_code.cmake
@@ -1,0 +1,53 @@
+# UFS/GOCART interface
+#
+# UFS porting of ESMA_cmake package.
+# See original version at: https://github.com/GEOS-ESM/ESMA_cmake (tag: v3.4.2)
+
+set (acg_flags -v)
+
+macro (new_ufs_esma_generate_automatic_code
+    target registry headers rcs rcs_destination flags)
+
+  find_file (generator
+    NAME mapl_acg.pl
+    )
+
+  add_custom_command (
+    OUTPUT ${rcs}
+    BYPRODUCTS ${headers}
+    COMMAND ${generator} ${acg_flags} ${flags} ${CMAKE_CURRENT_SOURCE_DIR}/${registry}
+    COMMAND ${CMAKE_COMMAND} -E copy ${rcs} ${rcs_destination}
+    COMMAND touch foo
+    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${registry}
+    DEPENDS ${generator}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating automated code for ${registry}"
+    )
+  add_custom_target (phony_${target} DEPENDS ${rcs})
+  add_dependencies (${target} phony_${target})
+  install(FILES ${rcs_destination}/${rcs} DESTINATION etc)
+
+endmacro ()
+
+macro (esma_generate_gocart_code target flags)
+
+  string (REPLACE "_GridComp" "" name ${target})
+
+  set (automatic_headers
+    ${name}_ExportSpec___.h
+    ${name}_GetPointer___.h
+    )
+  set (automatic_rc
+    ${name}_History___.rc
+    )
+
+  set (registry ${name}_Registry.rc)
+
+  new_ufs_esma_generate_automatic_code (
+    ${target} ${registry}
+    "${automatic_headers}" "${automatic_rc}"
+    ${_ufs_esma_etc}
+    ${flags}
+  )
+
+endmacro ()

--- a/ESMF/UFS/cmake/ufs_esma_set_this.cmake
+++ b/ESMF/UFS/cmake/ufs_esma_set_this.cmake
@@ -1,0 +1,40 @@
+# UFS/GOCART interface
+#
+# UFS porting of ESMA_cmake package.
+# See original version at: https://github.com/GEOS-ESM/ESMA_cmake (tag: v3.4.2)
+
+set (_ufs_esma_include  ${CMAKE_BINARY_DIR}/include CACHE PATH "include directory")
+set (_ufs_esma_etc      ${CMAKE_BINARY_DIR}/etc     CACHE PATH "etc directory")
+
+file (MAKE_DIRECTORY ${_ufs_esma_include})
+file (MAKE_DIRECTORY ${_ufs_esma_etc})
+
+# set for compatibility
+set (esma_include ${_ufs_esma_include})
+
+macro (esma_set_this)
+
+  set (options OPTIONAL EXCLUDE_FROM_ALL)
+  set (oneValueArgs OVERRIDE)
+  set (multiValueArgs)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if (ARGS_UNPARSED_ARGUMENTS)
+    message (FATAL_ERROR "esma_set_this unparsed arguments: ${ARGS_UNPARSED_ARGUMENTS}")
+  endif ()
+
+  # (re) define variable "this"
+  if (ARGS_OVERRIDE)
+    set (this ${ARGS_OVERRIDE})
+  else ()
+    get_filename_component (dir "${CMAKE_CURRENT_BINARY_DIR}" NAME)
+    string(REPLACE "@" "" this ${dir})
+  endif ()
+
+  set (include_${this} ${_ufs_esma_include}/${this})
+
+  file (MAKE_DIRECTORY ${_ufs_esma_include}/${this})
+  file (MAKE_DIRECTORY ${_ufs_esma_etc}/${this})
+
+endmacro ()
+


### PR DESCRIPTION
This PR introduces  the following set of changes, which are needed for integration with the UFS weather model:

- The `BUILD_UFS` CMake flag is renamed `UFS_GOCART` to avoid confusion in the UFS build system
- The `UFS` CMake library target is renamed `UFS_Aerosols` to prevent conflicts within the UFS build system
- A minimal set of custom CMake macros and functions is included to remove GOCART's dependency on ecBuild and ESMA_cmake when building with `UFS_GOCART=ON`. This was required by UFS code managers.
- Relaxed PFLOGGER dependency requirement outside Baselibs, since the UFS builds without pFlogger.

All changes have been tested on the NOAA RDHPCS Hera platform within the UFS weather model.