### PR TITLE
Fix optical properties computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed return code handling
 - Fixed uninitialized rc in Cubic in process library
 - Fixed build issue with GNU 9.2.0
+- Fixed optical properties computation and set 'aerosol_monochromatic_optics_wavelength:' units as 'nm'.
 
 ### Removed
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1024,9 +1024,9 @@ contains
     int_arr(:,:,:,2) = intPtr_philic
 
     call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, nbins=2, &
-                             channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                             wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                             wavelengths_vertint=self%wavelengths_vertint*1.0e-9, aerosol=int_arr, grav=MAPL_GRAV, &
+                             channels=self%diag_MieTable(self%instance)%channels, &
+                             wavelengths_profile=self%wavelengths_profile, &
+                             wavelengths_vertint=self%wavelengths_vertint, aerosol=int_arr, grav=MAPL_GRAV, &
                              tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, delp=delp, sfcmass=CASMASS, colmass=CACMASS, &
                              mass=CAMASS, exttau=CAEXTTAU, scatau=CASCATAU, fluxu=CAFLUXU, fluxv=CAFLUXV, &
                              conc=CACONC, extcoef=CAEXTCOEF, scacoef=CASCACOEF, angstrom=CAANGSTR, aerindx=CAAERIDX,&

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -941,8 +941,8 @@ end do
 !  -------------------
 !  Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
    call Aero_Compute_Diags (self%diag_MieTable(self%instance), self%km, self%klid, 1, self%nbins, self%rlow, &
-                            self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile*1.0e-9, &
-                            self%wavelengths_vertint*1.0e-9, DU, MAPL_GRAV, t, airdens, &
+                            self%rup, self%diag_MieTable(self%instance)%channels, self%wavelengths_profile, &
+                            self%wavelengths_vertint, DU, MAPL_GRAV, t, airdens, &
                             rh2, u, v, delp, DUSMASS, DUCMASS, DUMASS, DUEXTTAU, DUSCATAU, &
                             DUSMASS25, DUCMASS25, DUMASS25, DUEXTT25, DUSCAT25, &
                             DUFLUXU, DUFLUXV, DUCONC, DUEXTCOEF, DUSCACOEF, &

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -110,7 +110,7 @@ contains
     type (wrap_)                                  :: wrap
 
     integer :: n_wavelengths_profile, n_wavelengths_vertint, n_wavelengths_diagmie
-    integer, allocatable, dimension(:) :: wavelengths_diagmie
+    real, allocatable, dimension(:) :: wavelengths_diagmie
 
     __Iam__('SetServices')
 
@@ -152,6 +152,12 @@ contains
     call ESMF_ConfigGetAttribute (myCF, self%wavelengths_profile, label='wavelengths_for_profile_aop_in_nm:', __RC__)
     call ESMF_ConfigGetAttribute (myCF, self%wavelengths_vertint, label='wavelengths_for_vertically_integrated_aop_in_nm:', __RC__)
     call ESMF_ConfigGetAttribute (myCF, wavelengths_diagmie, label='aerosol_monochromatic_optics_wavelength:', __RC__)
+
+!   Convert input wavelengths from nm to m for internal use
+
+    self%wavelengths_profile = 1.e-09 * self%wavelengths_profile
+    self%wavelengths_vertint = 1.e-09 * self%wavelengths_vertint
+    wavelengths_diagmie      = 1.e-09 * wavelengths_diagmie
 
 !   Set wavelengths in universal config
 

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -1048,9 +1048,9 @@ if(mapl_am_i_root()) print*,'NI recycle alarm sum(self%xhno3)',sum(self%xhno3)
    aerosol(:,:,:,:) = 0.0
    aerosol(:,:,:,1) = NH4a
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            nbins=1, channels=self%diag_MieTable(self%instance)%channels, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, sfcmass=NH4SMASS, colmass=NH4CMASS, mass=NH4MASS, conc=NH4CONC, __RC__)
 !if(mapl_am_i_root()) print*,'NI2G sum(NH4SMASS) = ',sum(NH4SMASS) 
@@ -1060,9 +1060,9 @@ if(mapl_am_i_root()) print*,'NI recycle alarm sum(self%xhno3)',sum(self%xhno3)
 
    aerosol(:,:,:,1) = NH3
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            nbins=1, channels=self%diag_MieTable(self%instance)%channels, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, sfcmass=NH3SMASS, colmass=NH3CMASS, mass=NH3MASS, conc=NH3CONC, __RC__)
 !if(mapl_am_i_root()) print*,'NI2G sum(NH3SMASS) = ',sum(NH3SMASS)
@@ -1072,9 +1072,9 @@ if(mapl_am_i_root()) print*,'NI recycle alarm sum(self%xhno3)',sum(self%xhno3)
 
    aerosol(:,:,:,1) = NO3an1
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            nbins=1, channels=self%diag_MieTable(self%instance)%channels, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, sfcmass=NISMASS25, colmass=NICMASS25, mass=NIMASS25, conc=NICONC25, &
                             exttau25=NIEXTT25, scatau25=NISCAT25, exttaufm=NIEXTTFM, scataufm=NISCATFM, &
@@ -1089,9 +1089,9 @@ if(mapl_am_i_root()) print*,'NI recycle alarm sum(self%xhno3)',sum(self%xhno3)
    aerosol(:,:,:,2) = NO3an2
    aerosol(:,:,:,3) = NO3an3
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=3, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            nbins=3, channels=self%diag_MieTable(self%instance)%channels, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, sfcmass=NISMASS, colmass=NICMASS, mass=NIMASS, conc=NICONC, &
                             exttau=NIEXTTAU, scatau=NISCATAU, &

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -838,8 +838,8 @@ contains
 !   -------------------
 !   Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
     call Aero_Compute_Diags (self%diag_MieTable(self%instance), self%km, self%klid, 1, self%nbins, self%rlow, &
-                             self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile*1.0e-9, &
-                             self%wavelengths_vertint*1.0e-9, SS, MAPL_GRAV, t, airdens, &
+                             self%rup, self%diag_MieTable(self%instance)%channels, self%wavelengths_profile, &
+                             self%wavelengths_vertint, SS, MAPL_GRAV, t, airdens, &
                              rh2, u, v, delp, SSSMASS, SSCMASS, SSMASS, SSEXTTAU, SSSCATAU,     &
                              SSSMASS25, SSCMASS25, SSMASS25, SSEXTT25, SSSCAT25, &
                              SSFLUXU, SSFLUXV, SSCONC, SSEXTCOEF, SSSCACOEF,    &

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1131,8 +1131,8 @@ if(mapl_am_i_root()) print*,trim(comp_name),'2G SetServices BEGIN'
 !   Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
     call SU_Compute_Diags ( self%km, self%klid, self%radius(nSO4), self%sigma(nSO4), self%rhop(nSO4), &
                             MAPL_GRAV, MAPL_PI, nSO4, self%diag_MieTable(self%instance), &
-                            self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            self%wavelengths_profile*1.0e-9, self%wavelengths_vertint*1.0e-9, &
+                            self%diag_MieTable(self%instance)%channels, &
+                            self%wavelengths_profile, self%wavelengths_vertint, &
                             t, airdens, delp, rh2, u, v, DMS, SO2, SO4, dummyMSA, &
                             DMSSMASS, DMSCMASS, &
                             MSASMASS, MSACMASS, &


### PR DESCRIPTION
This PR introduces changes addressing issue #64. 

`aerosol_monochromatic_optics_wavelength`s are now assumed to be provided in units of `nm` and internally converted to `m` for proper lookup using the diagnostic Mie table.

`aerosol_monochromatic_optics_wavelength` could be renamed as `aerosol_monochromatic_optics_wavelength_in_nm` for consistency with other configuration labels.


