### PR TITLE
Cleanup GOCART2G: nm-to-m and present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+### Fixed
+
+- Cleaned up the nanometer-to-meter handling (#73)
+- Fixed possible standards violation with `present` and `associated` (#72)
+
+### Removed
+### Added
+
 ## [2.0.0-rc.1] - 2021-08-06
 
 ### Changed

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -550,10 +550,13 @@ contains
     call ESMF_ConfigGetAttribute (universal_cfg, self%diag_MieTable(instance)%channels, &
                                   label= "aerosol_monochromatic_optics_wavelength_in_nm_from_LUT:", __RC__)
 
+!   Convert input wavelengths from nm to m for internal use
+    self%diag_MieTable(instance)%channels = self%diag_MieTable(instance)%channels * 1.0e-9
+
     allocate (self%diag_MieTable(instance)%mie_aerosol, __STAT__)
     self%diag_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%diag_MieTable(instance)%optics_file, __RC__ )
     call Chem_MieTableRead (self%diag_MieTable(instance)%mie_aerosol, self%diag_MieTable(instance)%nch, &
-                            self%diag_MieTable(instance)%channels*1.e-9, rc=status, nmom=self%diag_MieTable(instance)%nmom)
+                            self%diag_MieTable(instance)%channels, rc=status, nmom=self%diag_MieTable(instance)%nmom)
     VERIFY_(status)
 
 !   Finish creating AERO state
@@ -1031,7 +1034,7 @@ contains
     int_arr(:,:,:,2) = intPtr_philic
 
     call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, nbins=2, &
-                             channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
+                             channels=self%diag_MieTable(self%instance)%channels, &
                              wavelengths_profile=self%wavelengths_profile, &
                              wavelengths_vertint=self%wavelengths_vertint, aerosol=int_arr, grav=MAPL_GRAV, &
                              tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, delp=delp, ple=ple, tropp=tropp, &

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1032,8 +1032,8 @@ contains
 
     call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, nbins=2, &
                              channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                             wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                             wavelengths_vertint=self%wavelengths_vertint*1.0e-9, aerosol=int_arr, grav=MAPL_GRAV, &
+                             wavelengths_profile=self%wavelengths_profile, &
+                             wavelengths_vertint=self%wavelengths_vertint, aerosol=int_arr, grav=MAPL_GRAV, &
                              tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, delp=delp, ple=ple, tropp=tropp, &
                              sfcmass=CASMASS, colmass=CACMASS, mass=CAMASS,&
                              exttau=CAEXTTAU,stexttau=CASTEXTTAU, scatau=CASCATAU, stscatau=CASTSCATAU,&

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -553,10 +553,13 @@ contains
     call ESMF_ConfigGetAttribute (universal_cfg, self%diag_MieTable(instance)%channels, &
                                   label= "aerosol_monochromatic_optics_wavelength_in_nm_from_LUT:", __RC__) 
 
+!   Convert input wavelengths from nm to m for internal use
+    self%diag_MieTable(instance)%channels = self%diag_MieTable(instance)%channels * 1.0e-9
+
     allocate (self%diag_MieTable(instance)%mie_aerosol, __STAT__)
     self%diag_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%diag_MieTable(instance)%optics_file, __RC__ )
     call Chem_MieTableRead (self%diag_MieTable(instance)%mie_aerosol, self%diag_MieTable(instance)%nch, &
-                            self%diag_MieTable(instance)%channels*1.e-9, rc=status, nmom=self%diag_MieTable(instance)%nmom)
+                            self%diag_MieTable(instance)%channels, rc=status, nmom=self%diag_MieTable(instance)%nmom)
     VERIFY_(status)
 
 
@@ -977,9 +980,8 @@ contains
 
 !  Compute diagnostics
 !  -------------------
-!  Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
    call Aero_Compute_Diags (self%diag_MieTable(self%instance), self%km, self%klid, 1, self%nbins, self%rlow, &
-                            self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile, &
+                            self%rup, self%diag_MieTable(self%instance)%channels, self%wavelengths_profile, &
                             self%wavelengths_vertint, DU, MAPL_GRAV, t, airdens, &
                             rh2, u, v, delp, ple,tropp, &
                             DUSMASS, DUCMASS, DUMASS, DUEXTTAU, DUSTEXTTAU, DUSCATAU,DUSTSCATAU, &

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -979,8 +979,8 @@ contains
 !  -------------------
 !  Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
    call Aero_Compute_Diags (self%diag_MieTable(self%instance), self%km, self%klid, 1, self%nbins, self%rlow, &
-                            self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile*1.0e-9, &
-                            self%wavelengths_vertint*1.0e-9, DU, MAPL_GRAV, t, airdens, &
+                            self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile, &
+                            self%wavelengths_vertint, DU, MAPL_GRAV, t, airdens, &
                             rh2, u, v, delp, ple,tropp, &
                             DUSMASS, DUCMASS, DUMASS, DUEXTTAU, DUSTEXTTAU, DUSCATAU,DUSTSCATAU, &
                             DUSMASS25, DUCMASS25, DUMASS25, DUEXTT25, DUSCAT25, &

--- a/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
@@ -72,6 +72,11 @@ module GA_EnvironmentMod
        call ESMF_ConfigGetAttribute (universal_cfg, self%wavelengths_vertint, &
                                      label='wavelengths_for_vertically_integrated_aop_in_nm:', __RC__)
 
+       !   Convert input wavelengths from nm to m for internal use
+
+       self%wavelengths_profile = 1.0e-9 * self%wavelengths_profile
+       self%wavelengths_vertint = 1.0e-9 * self%wavelengths_vertint
+
     end subroutine load_from_config
 
 end module GA_EnvironmentMod

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -159,6 +159,11 @@ contains
     call MAPL_ConfigSetAttribute (cf, self%wavelengths_vertint, label='wavelengths_for_vertically_integrated_aop_in_nm:', __RC__)
     call MAPL_ConfigSetAttribute (cf, wavelengths_diagmie, label='aerosol_monochromatic_optics_wavelength_in_nm_from_LUT:', __RC__)
 
+!   Convert input wavelengths from nm to m for internal use
+
+    self%wavelengths_profile = 1.0e-9 * self%wavelengths_profile
+    self%wavelengths_vertint = 1.0e-9 * self%wavelengths_vertint
+
 !   Get instances to determine what children will be born
 !   -----------------------------------------------------
     call getInstances_('DU', myCF, species=self%DU, __RC__)
@@ -673,8 +678,8 @@ contains
     if(associated(totangstr)) then
     ind550 = 0
        do w = 1, size(self%wavelengths_vertint) ! find index for 550nm to compute total angstrom
-          if ((self%wavelengths_vertint(w)*1.e-9 .ge. 5.49e-7) .and. &
-              (self%wavelengths_vertint(w)*1.e-9 .le. 5.51e-7)) then
+          if ((self%wavelengths_vertint(w) .ge. 5.49e-7) .and. &
+              (self%wavelengths_vertint(w) .le. 5.51e-7)) then
              ind550 = w
              exit
           end if

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -957,8 +957,8 @@ contains
    aerosol(:,:,:,1) = NH4a
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
                             nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, ple=ple, tropp=tropp,&
                             sfcmass=NH4SMASS, colmass=NH4CMASS, mass=NH4MASS, conc=NH4CONC, __RC__)
@@ -966,8 +966,8 @@ contains
    aerosol(:,:,:,1) = NH3
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
                             nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, ple=ple, tropp=tropp,&
                             sfcmass=NH3SMASS, colmass=NH3CMASS, mass=NH3MASS, conc=NH3CONC, __RC__)
@@ -975,8 +975,8 @@ contains
    aerosol(:,:,:,1) = NO3an1
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
                             nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, ple=ple, tropp=tropp,&
                             sfcmass=NISMASS25, colmass=NICMASS25, mass=NIMASS25, conc=NICONC25, &
@@ -988,8 +988,8 @@ contains
    aerosol(:,:,:,3) = NO3an3
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
                             nbins=3, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            wavelengths_profile=self%wavelengths_profile*1.0e-9, &
-                            wavelengths_vertint=self%wavelengths_vertint*1.0e-9, &
+                            wavelengths_profile=self%wavelengths_profile, &
+                            wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
                             delp=delp, ple=ple, tropp=tropp,sfcmass=NISMASS, colmass=NICMASS, mass=NIMASS, conc=NICONC, &
                             exttau=NIEXTTAU, stexttau=NISTEXTTAU,scatau=NISCATAU, stscatau=NISTSCATAU,&

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -515,10 +515,13 @@ contains
     call ESMF_ConfigGetAttribute (universal_cfg, self%diag_MieTable(instance)%channels, &
                                   label= "aerosol_monochromatic_optics_wavelength_in_nm_from_LUT:", __RC__)
 
+!   Convert input wavelengths from nm to m for internal use
+    self%diag_MieTable(instance)%channels = self%diag_MieTable(instance)%channels * 1.0e-9
+
     allocate (self%diag_MieTable(instance)%mie_aerosol, __STAT__)
     self%diag_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%diag_MieTable(instance)%optics_file, __RC__ )
     call Chem_MieTableRead (self%diag_MieTable(instance)%mie_aerosol, self%diag_MieTable(instance)%nch, &
-                            self%diag_MieTable(instance)%channels*1.e-9, rc=status, nmom=self%diag_MieTable(instance)%nmom)
+                            self%diag_MieTable(instance)%channels, rc=status, nmom=self%diag_MieTable(instance)%nmom)
     VERIFY_(status)
 
     ! Mie Table instance/index
@@ -956,7 +959,7 @@ contains
    aerosol(:,:,:,:) = 0.0
    aerosol(:,:,:,1) = NH4a
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
+                            nbins=1, channels=self%diag_MieTable(self%instance)%channels, &
                             wavelengths_profile=self%wavelengths_profile, &
                             wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
@@ -965,7 +968,7 @@ contains
 
    aerosol(:,:,:,1) = NH3
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
+                            nbins=1, channels=self%diag_MieTable(self%instance)%channels, &
                             wavelengths_profile=self%wavelengths_profile, &
                             wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
@@ -974,7 +977,7 @@ contains
 
    aerosol(:,:,:,1) = NO3an1
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=1, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
+                            nbins=1, channels=self%diag_MieTable(self%instance)%channels, &
                             wavelengths_profile=self%wavelengths_profile, &
                             wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &
@@ -987,7 +990,7 @@ contains
    aerosol(:,:,:,2) = NO3an2
    aerosol(:,:,:,3) = NO3an3
    call Aero_Compute_Diags (mie_table=self%diag_MieTable(self%instance), km=self%km, klid=self%klid, nbegin=1, &
-                            nbins=3, channels=self%diag_MieTable(self%instance)%channels*1.0e-9, &
+                            nbins=3, channels=self%diag_MieTable(self%instance)%channels, &
                             wavelengths_profile=self%wavelengths_profile, &
                             wavelengths_vertint=self%wavelengths_vertint, &
                             aerosol=aerosol, grav=MAPL_GRAV, tmpu=t, rhoa=airdens, rh=rh2, u=u, v=v, &

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -500,10 +500,13 @@ contains
     call ESMF_ConfigGetAttribute (universal_cfg, self%diag_MieTable(instance)%channels, &
                                   label= "aerosol_monochromatic_optics_wavelength_in_nm_from_LUT:", __RC__)
 
+!   Convert input wavelengths from nm to m for internal use
+    self%diag_MieTable(instance)%channels = self%diag_MieTable(instance)%channels * 1.0e-9
+
     allocate (self%diag_MieTable(instance)%mie_aerosol, __STAT__)
     self%diag_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%diag_MieTable(instance)%optics_file, __RC__ )
     call Chem_MieTableRead (self%diag_MieTable(instance)%mie_aerosol, self%diag_MieTable(instance)%nch, &
-                            self%diag_MieTable(instance)%channels*1.e-9, rc=status, nmom=self%diag_MieTable(instance)%nmom)
+                            self%diag_MieTable(instance)%channels, rc=status, nmom=self%diag_MieTable(instance)%nmom)
     VERIFY_(status)
 
     ! Mie Table instance/index
@@ -830,9 +833,8 @@ contains
 
 !   Compute diagnostics
 !   -------------------
-!   Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
     call Aero_Compute_Diags (self%diag_MieTable(self%instance), self%km, self%klid, 1, self%nbins, self%rlow, &
-                             self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile, &
+                             self%rup, self%diag_MieTable(self%instance)%channels, self%wavelengths_profile, &
                              self%wavelengths_vertint, SS, MAPL_GRAV, t, airdens,rh2, u, v, &
                              delp, ple, tropp,SSSMASS, SSCMASS, SSMASS, SSEXTTAU,SSSTEXTTAU, SSSCATAU,SSSTSCATAU, &
                              SSSMASS25, SSCMASS25, SSMASS25, SSEXTT25, SSSCAT25, &

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -832,8 +832,8 @@ contains
 !   -------------------
 !   Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
     call Aero_Compute_Diags (self%diag_MieTable(self%instance), self%km, self%klid, 1, self%nbins, self%rlow, &
-                             self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile*1.0e-9, &
-                             self%wavelengths_vertint*1.0e-9, SS, MAPL_GRAV, t, airdens,rh2, u, v, &
+                             self%rup, self%diag_MieTable(self%instance)%channels*1.0e-9, self%wavelengths_profile, &
+                             self%wavelengths_vertint, SS, MAPL_GRAV, t, airdens,rh2, u, v, &
                              delp, ple, tropp,SSSMASS, SSCMASS, SSMASS, SSEXTTAU,SSSTEXTTAU, SSSCATAU,SSSTSCATAU, &
                              SSSMASS25, SSCMASS25, SSMASS25, SSEXTT25, SSSCAT25, &
                              SSFLUXU, SSFLUXV, SSCONC, SSEXTCOEF, SSSCACOEF,    &

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1110,7 +1110,7 @@ contains
     call SU_Compute_Diags ( self%km, self%klid, self%radius(nSO4), self%sigma(nSO4), self%rhop(nSO4), &
                             MAPL_GRAV, MAPL_PI, nSO4, self%diag_MieTable(self%instance), &
                             self%diag_MieTable(self%instance)%channels*1.0e-9, &
-                            self%wavelengths_profile*1.0e-9, self%wavelengths_vertint*1.0e-9, &
+                            self%wavelengths_profile, self%wavelengths_vertint, &
                             t, airdens, delp, ple,tropp, rh2, u, v, DMS, SO2, SO4, dummyMSA, &
                             DMSSMASS, DMSCMASS, &
                             MSASMASS, MSACMASS, &

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -613,10 +613,13 @@ contains
     call ESMF_ConfigGetAttribute (universal_cfg, self%diag_MieTable(instance)%channels, &
                                   label= "aerosol_monochromatic_optics_wavelength_in_nm_from_LUT:", __RC__)
 
+!   Convert input wavelengths from nm to m for internal use
+    self%diag_MieTable(instance)%channels = self%diag_MieTable(instance)%channels * 1.0e-9
+
     allocate (self%diag_MieTable(instance)%mie_aerosol, __STAT__)
     self%diag_MieTable(instance)%mie_aerosol = Chem_MieTableCreate (self%diag_MieTable(instance)%optics_file, __RC__ )
     call Chem_MieTableRead (self%diag_MieTable(instance)%mie_aerosol, self%diag_MieTable(instance)%nch, &
-                            self%diag_MieTable(instance)%channels*1.e-9, rc=status, nmom=self%diag_MieTable(instance)%nmom)
+                            self%diag_MieTable(instance)%channels, rc=status, nmom=self%diag_MieTable(instance)%nmom)
     VERIFY_(status)
 
     ! Mie Table instance/index
@@ -1106,10 +1109,9 @@ contains
                           nDMS, nSO2, nSO4, nMSA, DMS, SO2, SO4, dummyMSA, &
                           SUWT, SUPSO4, SUPSO4WT, PSO4, PSO4WET, __RC__ )
 
-!   Certain variables are multiplied by 1.0e-9 to convert from nanometers to meters
     call SU_Compute_Diags ( self%km, self%klid, self%radius(nSO4), self%sigma(nSO4), self%rhop(nSO4), &
                             MAPL_GRAV, MAPL_PI, nSO4, self%diag_MieTable(self%instance), &
-                            self%diag_MieTable(self%instance)%channels*1.0e-9, &
+                            self%diag_MieTable(self%instance)%channels, &
                             self%wavelengths_profile, self%wavelengths_vertint, &
                             t, airdens, delp, ple,tropp, rh2, u, v, DMS, SO2, SO4, dummyMSA, &
                             DMSSMASS, DMSCMASS, &

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3261,9 +3261,9 @@ CONTAINS
    integer,    intent(in)    :: klid   ! index for pressure lid
    real, optional, dimension(:), intent(in)    :: rlow   ! bin radii - low bounds
    real, optional, dimension(:), intent(in)    :: rup    ! bin radii - upper bounds
-   real, dimension(:), intent(in)    :: channels
-   real, dimension(:), intent(in)    :: wavelengths_profile
-   real, dimension(:), intent(in)    :: wavelengths_vertint
+   real, dimension(:), intent(in)    :: channels   ! [m]
+   real, dimension(:), intent(in)    :: wavelengths_profile ! [m]
+   real, dimension(:), intent(in)    :: wavelengths_vertint ! [m]
    real, dimension(:,:,:,:), intent(in) :: aerosol     ! 
    real, intent(in) :: grav
    real, pointer, dimension(:,:,:), intent(in) :: tmpu  ! temperature [K]
@@ -6761,9 +6761,9 @@ K_LOOP: do k = km, 1, -1
    real, intent(in)    :: pi    ! pi constant
    integer, intent(in) :: nSO4  ! index of SO4 relative to other internal variables
    type(Chem_Mie), intent(in) :: mie_table   ! mie table
-   real, dimension(:), intent(in)  :: channels
-   real, dimension(:), intent(in)  :: wavelengths_profile
-   real, dimension(:), intent(in)  :: wavelengths_vertint
+   real, dimension(:), intent(in)  :: channels ! [m]
+   real, dimension(:), intent(in)  :: wavelengths_profile ! [m]
+   real, dimension(:), intent(in)  :: wavelengths_vertint ! [m]
    real, pointer, dimension(:,:,:), intent(in) :: tmpu    ! temperature [K]
    real, pointer, dimension(:,:,:), intent(in) :: rhoa    ! air density [kg/m^3]
    real, pointer, dimension(:,:,:), intent(in) :: delp    ! pressure thickness [Pa]

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -8,6 +8,7 @@
 #define __IOSTAT__ iostat=status); __VERIFY__(status
 #define __RETURN__(x) if (present(rc)) rc=x; return
 #define __ASSERT__(expr) if(.not. (expr)) then; if (present(rc)) rc=-1; return; endif
+#define __PRESENT_AND_ASSOCIATED__(ptr,res) if(present(ptr)) then; res=associated(ptr); else; res=.false.; endif
 !-------------------------------------------------------------------------
 !
 ! !MODULE: GOCART2G_Process -- GOCART2G process library
@@ -3327,6 +3328,15 @@ CONTAINS
    real, dimension(:,:), allocatable :: tau470, tau870
    logical   :: NO3nFlag_  !local version of the input
 
+   logical :: has_angstrom
+   logical :: has_aerindx
+   logical :: has_sfcmass
+   logical :: has_sfcmass25
+   logical :: has_colmass
+   logical :: has_colmass25
+   logical :: has_mass25
+   logical :: has_fluxu
+   logical :: has_fluxv
    logical :: has_extcoef
    logical :: has_scacoef
    logical :: has_exttau
@@ -3417,7 +3427,8 @@ CONTAINS
       ilam870 .ne. 0. .and. &
       ilam470 .ne. ilam870) do_angstrom = .true.
 
-   if( present_and_associated(angstrom) .and. do_angstrom ) then
+   __PRESENT_AND_ASSOCIATED__(angstrom,has_angstrom)
+   if( has_angstrom .and. do_angstrom ) then
       allocate(tau470(i1:i2,j1:j2), tau870(i1:i2,j1:j2))
    end if
 
@@ -3428,12 +3439,15 @@ CONTAINS
       call Aero_Binwise_PM_Fractions(fPM25, 1.25, rlow, rup, nbins)   ! 2*r < 2.5 um
    end if
 
-   if ( present_and_associated(aerindx) )  aerindx = 0.0  ! for now
+   __PRESENT_AND_ASSOCIATED__(aerindx,has_aerindx)
+   if ( has_aerindx )  aerindx = 0.0  ! for now
 
 !  Calculate the diagnostic variables if requested
 !  -----------------------------------------------
 !  Calculate the surface mass concentration
-   if( present_and_associated(sfcmass) ) then
+
+   __PRESENT_AND_ASSOCIATED__(sfcmass,has_sfcmass)
+   if( has_sfcmass ) then
       sfcmass(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          sfcmass(i1:i2,j1:j2) &
@@ -3441,7 +3455,9 @@ CONTAINS
               + aerosol(i1:i2,j1:j2,km,n)*rhoa(i1:i2,j1:j2,km)
       end do
    endif
-   if( present_and_associated(sfcmass25) ) then
+
+   __PRESENT_AND_ASSOCIATED__(sfcmass25,has_sfcmass25)
+   if( has_sfcmass25 ) then
       sfcmass25(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          sfcmass25(i1:i2,j1:j2) &
@@ -3450,8 +3466,9 @@ CONTAINS
       end do
    endif
 
+   __PRESENT_AND_ASSOCIATED__(colmass,has_colmass)
 !  Calculate the aerosol column loading
-   if( present_and_associated(colmass) ) then
+   if( has_colmass ) then
       colmass(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
        do k = klid, km
@@ -3461,7 +3478,9 @@ CONTAINS
        end do
       end do
    endif
-   if( present_and_associated(colmass25) ) then
+
+   __PRESENT_AND_ASSOCIATED__(colmass25,has_colmass25)
+   if( has_colmass25 ) then
       colmass25(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          do k = klid, km
@@ -3491,7 +3510,9 @@ CONTAINS
            + aerosol(i1:i2,j1:j2,1:km,n)
       end do
    endif
-   if( present_and_associated(mass25) ) then
+
+   __PRESENT_AND_ASSOCIATED__(mass25,has_mass25)
+   if( has_mass25 ) then
       mass25(i1:i2,j1:j2,1:km) = 0.
       do n = nbegin, nbins
        mass25(i1:i2,j1:j2,1:km) &
@@ -3501,7 +3522,8 @@ CONTAINS
    endif
 
 !  Calculate the column mass flux in x direction
-   if( present_and_associated(fluxu) ) then
+   __PRESENT_AND_ASSOCIATED__(fluxu,has_fluxu)
+   if( has_fluxu ) then
       fluxu(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          do k = klid, km
@@ -3512,8 +3534,9 @@ CONTAINS
       end do
    endif
 
+   __PRESENT_AND_ASSOCIATED__(fluxv,has_fluxv)
 !  Calculate the column mass flux in y direction
-   if( present_and_associated(fluxv) ) then
+   if( has_fluxv ) then
       fluxv(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          do k = klid, km
@@ -3526,8 +3549,8 @@ CONTAINS
 
 !  Calculate the extinction and/or scattering AOD
 
-   has_extcoef = present_and_associated(extcoef)
-   has_scacoef = present_and_associated(scacoef)
+   __PRESENT_AND_ASSOCIATED__(extcoef,has_extcoef)
+   __PRESENT_AND_ASSOCIATED__(scacoef,has_scacoef)
 
    if( has_extcoef .or. has_scacoef ) then
 
@@ -3560,14 +3583,14 @@ CONTAINS
       enddo !nbins
     end if !present(extcoef)...
 
-   has_exttau   = present_and_associated(exttau)
-   has_stexttau = present_and_associated(stexttau)
-   has_scatau   = present_and_associated(scatau)
-   has_stscatau = present_and_associated(stscatau)
-   has_exttau25 = present_and_associated(exttau25)
-   has_exttaufm = present_and_associated(exttaufm)
-   has_scatau25 = present_and_associated(scatau25)
-   has_scataufm = present_and_associated(scataufm)
+   __PRESENT_AND_ASSOCIATED__(exttau,has_exttau)
+   __PRESENT_AND_ASSOCIATED__(stexttau,has_stexttau)
+   __PRESENT_AND_ASSOCIATED__(scatau,has_scatau)
+   __PRESENT_AND_ASSOCIATED__(stscatau,has_stscatau)
+   __PRESENT_AND_ASSOCIATED__(exttau25,has_exttau25)
+   __PRESENT_AND_ASSOCIATED__(exttaufm,has_exttaufm)
+   __PRESENT_AND_ASSOCIATED__(scatau25,has_scatau25)
+   __PRESENT_AND_ASSOCIATED__(scataufm,has_scataufm)
 
    if( has_exttau   .or. has_stexttau .or. has_scatau   .or. &
        has_stscatau .or. has_exttau25 .or. has_exttaufm .or. &
@@ -3654,7 +3677,7 @@ CONTAINS
    endif !present(exttau)...
 
 !  Calculate the 470-870 Angstrom parameter
-   if( present_and_associated(angstrom) .and. do_angstrom ) then
+   if( has_angstrom .and. do_angstrom ) then
 
       angstrom(i1:i2,j1:j2) = 0.
 !     Set tau to small number by default
@@ -3688,20 +3711,6 @@ CONTAINS
    endif
 
    __RETURN__(__SUCCESS__)
-
-   contains
-
-      logical function present_and_associated(p)
-         real, pointer, dimension(..), optional, intent(in) :: p
-
-         present_and_associated = .false.
-         if (present(p)) then
-            if (associated(p)) then
-               present_and_associated = .true.
-            end if
-         end if
-      end function present_and_associated
-
    end subroutine Aero_Compute_Diags
 !====================================================================
 


### PR DESCRIPTION
This PR is an attempt to close #72 and #73 which were brought up by @rmontuoro.

First, the nm-to-m issue (#73 ), this solution looks a little different to that in #65 because testing showed it needed to be. However, I believe it accomplishes the same thing.

Now for the more "fun" one, the issue with `present()`, #72 . The current code _might_ or _probably_ is a Fortran Standard violation (@tclune can say for certain), but it definitely "looks wrong":
```fortran
   if (present(aerindx) .and. associated(aerindx))  aerindx = 0.0  ! for now
```

The "fun" part is that the preferred way to do this would have been with a function using an assumed-rank array:
```fortran
      logical function present_and_associated(p) result(a)
         real, pointer, dimension(..), optional, intent(in) :: p
         a = .false.
         if (present(p)) then
            if (associated(p)) then
               a = .true.
            end if
         end if
      end function present_and_associated
```
but it turns out [the Intel compiler has a probable bug with this](https://community.intel.com/t5/Intel-Fortran-Compiler/Possible-bug-with-assumed-rank-array/m-p/1305251/emcs_t/S2h8ZW1haWx8dG9waWNfc3Vic2NyaXB0aW9ufEtTNjRISjM0R1NZQjk4fDEzMDUyNTF8U1VCU0NSSVBUSU9OU3xoSw#M157115), though GNU is happy. 

So, after quite a bit of test coding by @tclune and myself, it turns out the best way to handle this for now is with a macro:
```fortran
#define __PRESENT_AND_ASSOCIATED__(ptr,res) if(present(ptr)) then; res=associated(ptr); else; res=.false.; endif
```
This is uglier since we now have to make a logical variable for each test and then use that variable. So this:
```fortran
   if (present(aerindx) .and. associated(aerindx))  aerindx = 0.0  ! for now
```
becomes:
```fortran
   logical :: has_aerindx
...
   __PRESENT_AND_ASSOCIATED__(aerindx,has_aerindx)
   if ( has_aerindx )  aerindx = 0.0  ! for now
```
instead of a nice clean:
```fortran
   if ( present_and_associated(aerindx) )  aerindx = 0.0  ! for now
```

That said, @tclune might see some way to make this cleaner. 

Still, hopefully this all works. My testing shows it is zero-diff in the Ginoux and K14 cases compared to `develop` (aka v2.0.0-rc.1)