### PR TITLE
Update CI to Baselibs 6.2.8 and GCC 11.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gcc-build-env:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-N/A
+### Changed
+
+- Update CI to Baselibs 6.2.8 and GCC 11.2
 
 ## [2.0.1] - 2021-10-20 
 
@@ -18,6 +20,7 @@ etc.
 - Updated rc files to reflect new ExtData structure
 
 ## Removed
+
 - Removed aerosols from legacy GOCART
 
 ### Fixed


### PR DESCRIPTION
This PR updates the CI to use Baselibs 6.2.8. This is futureproofing for MAPL development which needs a newer version of gFTL that doesn't affect GEOS as a whole yet.

This is still zero-diff for GEOS.

This also moves to use GCC 11.2 which is the current GCC for GEOS. (I'll look at adding Intel soon)