### PR TITLE
Edits to make GNU work with GOCART2G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Fixed
+
+- Fixes to allow GNU to run GOCART2G
+  - Changes to `if (present(foo)) .and. associated(foo))` construct which is ambiguous Fortarn
+
 ## [2.0.2] - 2021-1-07
 
 ### Changed
@@ -12,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update CI to Baselibs 6.2.8 and GCC 11.2
 - Updated dust emissions tuning to be consistent with current Ginoux default.
 
-## [2.0.1] - 2021-10-20 
+## [2.0.1] - 2021-10-20
 
 ### Changed
 
@@ -34,7 +41,7 @@ etc.
 
 - Added callbacks needed for GAAS2G. Removed diagnostic prints statements. Fixed bug with
   the creation of Diagnostic Mie tables.
-  
+
 - Updated `CODEOWNERS` to reflect changes in staffing
 - Updated `components.yaml`
   - Added fixture block
@@ -79,7 +86,7 @@ This release of GOCART is aimed at moving GOCART from GEOSchem_GridComp to its o
 To use this release, you need to use GEOSchem_GridComp v1.4.4 which has the changes necessary to move GOCART Legacy to this separate repository.
 
 Identical in code to v1.0.0-beta.1
- 
+
 ## [1.0.0-beta.1] - 2021-03-01
 
 ### Changed
@@ -102,11 +109,11 @@ Identical in code to v1.0.0-beta.1
 
 - Fixed bugs in the process library
 - Bug with how some optional `rc` arguments where handled in the Process Library.
- 
+
 ### Added
 
 - CircleCI configuration added
- 
+
 ## [0.9.0] - 2020-09-03
 
 ### Added

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -61,7 +61,7 @@
    public SulfateChemDriver
    public get_HenrysLawCts
    public NIthermo
-   public Chem_UtilResVal 
+   public Chem_UtilResVal
    public Chem_UtilIdow
    public Chem_UtilCdow
    public Chem_BiomassDiurnal
@@ -493,7 +493,7 @@ CONTAINS
 
 !  Calculate the threshold velocity of wind erosion [m/s] for each radius
 !  for a dry soil, as in Marticorena et al. [1997].
-!  The parameterization includes the air density which is assumed 
+!  The parameterization includes the air density which is assumed
 !  = 1.25 kg m-3 to speed the calculation.  The error in air density is
 !  small compared to errors in other parameters.
 
@@ -520,7 +520,7 @@ CONTAINS
                u_thresh = amax1(0.,u_thresh0* &
                (1.2+0.2*alog10(max(1.e-3,gwettop(i,j)))))
 
-               if(w10m .gt. u_thresh) then     
+               if(w10m .gt. u_thresh) then
 !                 Emission of dust [kg m-2 s-1]
                   emissions(i,j,n) = (1.-fraclake(i,j)) * w10m**2. * (w10m-u_thresh)
                endif
@@ -529,7 +529,7 @@ CONTAINS
       end do ! j
       emissions(:,:,n) = Ch_DU * du_src * emissions(:,:,n)
     end do ! n
- 
+
    rc = __SUCCESS__
 
    end subroutine DustEmissionGOCART2G
@@ -564,8 +564,8 @@ CONTAINS
    real, dimension(:,:), intent(in) :: z, u_z, v_z! hight and wind at this height
    real, dimension(:,:), intent(in) :: ustar      ! friction velocity
    real, dimension(:,:), intent(in) :: f_land     ! land fraction
-   real, dimension(:,:), intent(in) :: f_snow     ! snow fraction 
-   real, dimension(:,:), intent(in) :: f_src      ! dust source potential -- OBSOLETE  
+   real, dimension(:,:), intent(in) :: f_snow     ! snow fraction
+   real, dimension(:,:), intent(in) :: f_src      ! dust source potential -- OBSOLETE
    real, dimension(:,:), intent(in) :: f_sand     ! sand fraction
    real, dimension(:,:), intent(in) :: f_silt     ! silt fraction
    real, dimension(:,:), intent(in) :: f_clay     ! clay fraction
@@ -577,7 +577,7 @@ CONTAINS
    real, intent(in)                 :: Ch_DU      ! dust emission tuning coefficient [kg/(sec^2 m^5)]
    real,    intent(in)              :: f_w        ! factor to scale down soil moisture in the top 5cm to soil moisture in the top 1cm
    real,    intent(in)              :: f_c        ! scale down the wet sieving clay fraction to get it more in line with dry sieving measurements
-   real,    intent(in)              :: uts_gamma  ! threshold friction velocity parameter 'gamma' 
+   real,    intent(in)              :: uts_gamma  ! threshold friction velocity parameter 'gamma'
    real,    intent(in)              :: UNDEF      ! paramter for undefined varaible
    real,    intent(in)              :: GRAV       ! gravity
    real,    intent(in)              :: VON_KARMAN ! von karman constant
@@ -598,7 +598,7 @@ CONTAINS
 
    integer, intent(out) :: rc    ! Error return code:
                                  !  0 - all is well
-                                 !  1 - 
+                                 !  1 -
 
    character(len=*), parameter :: myname = 'DustEmissionK14'
 
@@ -656,7 +656,7 @@ CONTAINS
    allocate(w_g(i2,j2), w_gt(i2,j2), f_veg(i2,j2), clay(i2,j2), silt(i2,j2), k_gamma(i2,j2))
    allocate(z0s(i2,j2), Dp_size(i2,j2))
 
-   ! typical size of soil particles for optimal saltation is about 75e-6m 
+   ! typical size of soil particles for optimal saltation is about 75e-6m
    Dp_size = 75e-6
 
    ! typical density of soil particles, e.g. quartz grains
@@ -756,7 +756,7 @@ CONTAINS
    end select
 
 
-   ! roughness over smooth surface   
+   ! roughness over smooth surface
    z0s = 125e-6
    do j = j1, j2
        do i = i1, i2
@@ -766,7 +766,7 @@ CONTAINS
        end do
    end do
 
-   z0s = z0s / 30.0    ! z0s = MMD/x, where typically x is in the range 24--30; x=10 was recommended 
+   z0s = z0s / 30.0    ! z0s = MMD/x, where typically x is in the range 24--30; x=10 was recommended
                        ! as a more appropriate value for this parameter in a recent article
 
    ! drag partition correction
@@ -865,7 +865,7 @@ CONTAINS
    real, dimension(:,:), intent(in) :: u           ! friction velocity, 'm s-1'
    real, dimension(:,:), intent(in) :: u_t         ! threshold friction velocity, 'm s-1'
    real, dimension(:,:), intent(in) :: rho_air     ! air density, 'kg m-3'
-   real, dimension(:,:), intent(in) :: f_erod      ! erodibility 
+   real, dimension(:,:), intent(in) :: f_erod      ! erodibility
    real, dimension(:,:), intent(in) :: k_gamma     ! clay and silt dependent term that modulates the emissions
 
 ! !OUTPUT PARAMETERS:
@@ -890,7 +890,7 @@ CONTAINS
 !
 ! !REVISION HISTORY:
 !
-!  11Oct2011, Darmenov - For now use the GOCART emission scheme to 
+!  11Oct2011, Darmenov - For now use the GOCART emission scheme to
 !                        calculate the total emission
 !
 !EOP
@@ -1101,14 +1101,14 @@ CONTAINS
    integer, intent(in) :: flag     ! flag to control particle swelling (see note)
    real, intent(in)    :: cdt
    real, intent(in)    :: grav   ! gravity [m/sec^2]
-   real, intent(in)  :: radiusInp  ! particle radius [microns] 
+   real, intent(in)  :: radiusInp  ! particle radius [microns]
    real, intent(in)  :: rhopInp    ! soil class density [kg/m^3]
    real, dimension(:,:,:), intent(inout) :: int_qa  ! aerosol [kg/kg]
    real, pointer, dimension(:,:,:), intent(in)  :: tmpu   ! temperature [K]
    real, pointer, dimension(:,:,:), intent(in)  :: rhoa   ! air density [kg/m^3]
    real, pointer, dimension(:,:,:), intent(in)  :: rh     ! relative humidity [1]
    real, pointer, dimension(:,:,:), intent(in)  :: hghte  ! geopotential height [m]
-   real, pointer, dimension(:,:,:), intent(in)  :: delp   ! pressure level thickness [Pa]  
+   real, pointer, dimension(:,:,:), intent(in)  :: delp   ! pressure level thickness [Pa]
 
 ! !OUTPUT PARAMETERS:
 
@@ -1116,7 +1116,7 @@ CONTAINS
                                                   ! to surface, kg/m2/s
    integer, optional, intent(out)             :: rc         ! Error return code:
                                                   !  0 - all is well
-                                                  !  1 - 
+                                                  !  1 -
 !  Optionally output the settling velocity calculated
    real, pointer, optional, dimension(:,:,:)  :: vsettleOut
 
@@ -1126,9 +1126,9 @@ CONTAINS
    character(len=*), parameter :: myname = 'SettlingSimple'
 
 ! !DESCRIPTION: Gravitational settling of aerosol between vertical
-!               layers.  Assumes input radius in [m] and density (rhop) 
+!               layers.  Assumes input radius in [m] and density (rhop)
 !               in [kg m-3]. If flag is set, use the Fitzgerald 1975 (flag = 1)
-!               or Gerber 1985 (flag = 2) parameterization to update the 
+!               or Gerber 1985 (flag = 2) parameterization to update the
 !               particle radius for the calculation (local variables radius
 !               and rhop).
 !
@@ -1275,14 +1275,14 @@ CONTAINS
    integer, intent(in) :: flag     ! flag to control particle swelling (see note)
    real, intent(in)    :: cdt
    real, intent(in)    :: grav   ! gravity [m/sec^2]
-   real, intent(in)  :: radiusInp  ! particle radius [microns] 
+   real, intent(in)  :: radiusInp  ! particle radius [microns]
    real, intent(in)  :: rhopInp    ! soil class density [kg/m^3]
    real, dimension(:,:,:), intent(inout) :: int_qa  ! aerosol [kg/kg]
    real, pointer, dimension(:,:,:), intent(in)  :: tmpu   ! temperature [K]
    real, pointer, dimension(:,:,:), intent(in)  :: rhoa   ! air density [kg/m^3]
    real, pointer, dimension(:,:,:), intent(in)  :: rh     ! relative humidity [1]
    real, pointer, dimension(:,:,:), intent(in)  :: hghte  ! geopotential height [m]
-   real, pointer, dimension(:,:,:), intent(in)  :: delp   ! pressure level thickness [Pa]  
+   real, pointer, dimension(:,:,:), intent(in)  :: delp   ! pressure level thickness [Pa]
 
 ! !OUTPUT PARAMETERS:
 
@@ -1290,7 +1290,7 @@ CONTAINS
                                                   ! to surface, kg/m2/s
    integer, optional, intent(out)             :: rc         ! Error return code:
                                                   !  0 - all is well
-                                                  !  1 - 
+                                                  !  1 -
 !  Optionally output the settling velocity calculated
    real, pointer, optional, dimension(:,:,:)  :: vsettleOut
 
@@ -1300,9 +1300,9 @@ CONTAINS
    character(len=*), parameter :: myname = 'Settling'
 
 ! !DESCRIPTION: Gravitational settling of aerosol between vertical
-!               layers.  Assumes input radius in [m] and density (rhop) 
+!               layers.  Assumes input radius in [m] and density (rhop)
 !               in [kg m-3]. If flag is set, use the Fitzgerald 1975 (flag = 1)
-!               or Gerber 1985 (flag = 2) parameterization to update the 
+!               or Gerber 1985 (flag = 2) parameterization to update the
 !               particle radius for the calculation (local variables radius
 !               and rhop).
 !
@@ -1510,7 +1510,7 @@ CONTAINS
 
 !  Cunningham slip correction factor
 !  bpm = 1. + 1.246*rkn + 0.42*rkn*exp(-0.87/rkn)
-!  linearized form, Binkowski and Shankar (equation A27, 1995) 
+!  linearized form, Binkowski and Shankar (equation A27, 1995)
    bpm = 1 + 1.246*rkn
 
 !  Brownian diffusion coefficient
@@ -1709,7 +1709,7 @@ CONTAINS
 !       f2 = -6.7 + 15.5*sat -  9.2*sat*sat
 !       alpharat = 1. - f1*(1.-epsilon) - f2*(1.-epsilon**2.)
 !       alpha = alphaNaCl * (alpha1*alpharat)
-! instead, it is faster to do 
+! instead, it is faster to do
         alpha = alphaNaCl * alpha1
 
         radius(i,j,k) = alpha * radius_dry**beta
@@ -1897,14 +1897,14 @@ CONTAINS
    integer,    intent(in)    :: bin    ! aerosol bin index
    real,       intent(in)    :: grav   ! gravity [m/sec^2]
    real,       intent(in)    :: cdt    ! chemistry model time-step
-   real, intent(in)  :: radiusInp  ! particle radius [microns] 
+   real, intent(in)  :: radiusInp  ! particle radius [microns]
    real, intent(in)  :: rhopInp    ! soil class density [kg/m^3]
    real, dimension(:,:,:), intent(inout) :: int_qa  ! aerosol [kg/kg]
    real, pointer, dimension(:,:,:), intent(in)  :: tmpu   ! temperature [K]
    real, pointer, dimension(:,:,:), intent(in)  :: rhoa   ! air density [kg/m^3]
    real, pointer, dimension(:,:,:), intent(in)  :: rh     ! relative humidity [1]
    real, pointer, dimension(:,:,:), intent(in)  :: hghte  ! geopotential height [m]
-   real, pointer, dimension(:,:,:), intent(in)  :: delp   ! pressure level thickness [Pa]   
+   real, pointer, dimension(:,:,:), intent(in)  :: delp   ! pressure level thickness [Pa]
    logical, optional, intent(in)   :: correctionMaring
 
 
@@ -1917,9 +1917,9 @@ CONTAINS
    integer, optional, intent(out)   :: rc
 
 ! !DESCRIPTION: Gravitational settling of aerosol between vertical
-!               layers.  Assumes input radius in [m] and density (rhop) 
+!               layers.  Assumes input radius in [m] and density (rhop)
 !               in [kg m-3]. If flag is set, use the Fitzgerald 1975 (flag = 1)
-!               or Gerber 1985 (flag = 2) parameterization to update the 
+!               or Gerber 1985 (flag = 2) parameterization to update the
 !               particle radius for the calculation (local variables radius
 !               and rhop).
 !
@@ -1978,7 +1978,7 @@ CONTAINS
 
 !  Allocate arrays
 !  ---------------
-   allocate(dz, mold=rhoa); 
+   allocate(dz, mold=rhoa);
    allocate(dzd(i2,j2,km), vsd(i2,j2,km), qa(i2,j2,km), vsettle(i2,j2,km), qa_temp(i2,j2,km))
    allocate(cmass_before(i2,j2), cmass_after(i2,j2))
 
@@ -2021,7 +2021,7 @@ CONTAINS
 !           Fitzgerald
             select case(flag)
             case(1)
-               if (sat >= 0.80) then 
+               if (sat >= 0.80) then
 !              if(flag .eq. 1 .and. sat .ge. 0.80) then
 !              parameterization blows up for RH > 0.995, so set that as max
 !              rh needs to be scaled 0 - 1
@@ -2117,8 +2117,8 @@ CONTAINS
                qa(i,j,k) = qa(i,j,k) - qdel + qsrc
             end do
          end do  !itt
-      end do 
-    end do  
+      end do
+    end do
 
 !   Find the column dry mass after sedimentation and thus the loss flux
     do k = klid, km
@@ -2161,7 +2161,7 @@ CONTAINS
    real, intent(in) :: grav     ! gravity [m/sec^2]
 
 ! !OUTPUT PARAMETERS:
-   real, intent(out)   :: diff_coef  ! Brownian diffusion 
+   real, intent(out)   :: diff_coef  ! Brownian diffusion
                                      ! coefficient [m2/sec]
    real, intent(out)   :: vsettle    ! Layer fall speed [m s-1]
 
@@ -2237,7 +2237,7 @@ CONTAINS
 
 !==================================================================================
 !BOP
-! !IROUTINE: Chem_SettlingSimpleOrig 
+! !IROUTINE: Chem_SettlingSimpleOrig
 
    subroutine Chem_SettlingSimpleOrig ( km, klid, flag, grav, cdt, radiusInp, rhopInp, &
                                         int_qa, tmpu, rhoa, rh, delp, hghte, &
@@ -2487,7 +2487,7 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-   subroutine DryDeposition ( km, tmpu, rhoa, hghte, oro, ustar, pblh, shflux, & 
+   subroutine DryDeposition ( km, tmpu, rhoa, hghte, oro, ustar, pblh, shflux, &
                               von_karman, cpd, grav, z0h, drydepf, rc, &
                               radius, rhop, u10m, v10m, fraclake, gwettop )
 
@@ -2503,8 +2503,8 @@ CONTAINS
    real, pointer, dimension(:,:), intent(in)   :: ustar   ! friction speed [m/sec]
    real, pointer, dimension(:,:), intent(in)   :: pblh    ! PBL height [m]
    real, pointer, dimension(:,:), intent(in)   :: shflux  ! sfc. sens. heat flux [W m-2]
-   real, intent(in)                :: von_karman ! Von Karman constant [unitless] 
-   real, intent(in)                :: cpd       ! thermodynamic constant, specific heat of something? 
+   real, intent(in)                :: von_karman ! Von Karman constant [unitless]
+   real, intent(in)                :: cpd       ! thermodynamic constant, specific heat of something?
    real, intent(in)                :: grav      ! gravity [m/sec^2]
    real, pointer, dimension(:,:)   :: z0h       ! rough height, sens. heat [m]
 
@@ -2685,8 +2685,8 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
    integer, intent(in) :: i1, i2, j1, j2
-   real, intent(in) :: von_karman ! Von Karman constant [unitless] 
-   real, intent(in) :: cpd        ! thermodynamic constant, specific heat of something? 
+   real, intent(in) :: von_karman ! Von Karman constant [unitless]
+   real, intent(in) :: cpd        ! thermodynamic constant, specific heat of something?
    real, intent(in) :: grav       ! gravity [m/sec^2]
    real, dimension(i1:i2,j1:j2)  :: t         ! temperature [K]
    real, dimension(i1:i2,j1:j2)  :: rhoa      ! air density [kg/m^3]
@@ -2718,7 +2718,7 @@ CONTAINS
 !==================================================================================
 !BOP
 
-! !IROUTINE: WetRemovalGOCART2G 
+! !IROUTINE: WetRemovalGOCART2G
    subroutine WetRemovalGOCART2G ( km, klid, n1, n2, bin_ind, cdt, aero_type, kin, grav, fwet, &
                                    aerosol, ple, tmpu, rhoa, pfllsan, pfilsan, &
                                    precc, precl, fluxout, rc )
@@ -2772,7 +2772,7 @@ CONTAINS
    real :: F, B, BT                  ! temporary variables on cloud, freq.
    real :: WASHFRAC, WASHFRAC_F_14
    real, allocatable :: fd(:,:)      ! flux across layers [kg m-2]
-   real, allocatable :: dpfli(:,:,:)  ! vertical gradient of LS ice+rain precip flux 
+   real, allocatable :: dpfli(:,:,:)  ! vertical gradient of LS ice+rain precip flux
    real, allocatable :: DC(:)        ! scavenge change in mass mixing ratio
    real, allocatable, dimension(:,:,:) :: c_h2o, cldliq, cldice
 
@@ -2814,7 +2814,7 @@ CONTAINS
 
 !  Initialize local variables
 !  --------------------------
-!  c_h2o, cldliq, and cldice are respectively intended to be the 
+!  c_h2o, cldliq, and cldice are respectively intended to be the
 !  water mixing ratio (liquid or vapor?, in or out of cloud?)
 !  cloud liquid water mixing ratio
 !  cloud ice water mixing ratio
@@ -2901,7 +2901,7 @@ CONTAINS
      do k = LH, km
 
 !-----------------------------------------------------------------------------
-!   (1) LARGE-SCALE RAINOUT:             
+!   (1) LARGE-SCALE RAINOUT:
 !       Tracer loss by rainout = TC0 * F * exp(-B*dt)
 !         where B = precipitation frequency,
 !               F = fraction of grid box covered by precipitating clouds.
@@ -3007,7 +3007,7 @@ CONTAINS
             ! Rainwater content in the grid box (Eq. 17, Jacob et al, 2000)
             PP = (PFLLSAN(i,j,k)/1000d0 + PFILSAN(i,j,k)/917d0 )*100d0 ! from kg H2O/m2/s to cm3 H2O/cm2/s
             LP = ( PP * cdt ) / ( F * delz(i,j,k)*100.d0 )  ! DZ*100.d0 in cm
-            ! Compute liquid to gas ratio for H2O2, using the appropriate 
+            ! Compute liquid to gas ratio for H2O2, using the appropriate
             ! parameters for Henry's law -- also use rainwater content Lp
             ! (Eqs. 7, 8, and Table 1, Jacob et al, 2000)
             !CALL COMPUTE_L2G( Kstar298, H298_R, tmpu(i,j,k), LP, L2G )
@@ -3063,7 +3063,7 @@ CONTAINS
        BT = B * Td_cv
        if (BT.gt.10.) BT = 10.               !< Avoid overflow >
 
-!      Adjust du level: 
+!      Adjust du level:
        do n = 1, nbins
         effRemoval = fwet
         DC(n) = aerosol(i,j,k) * F * effRemoval * (1.-exp(-BT))
@@ -3134,7 +3134,7 @@ CONTAINS
 
 !-----------------------------------------------------------------------------
 !  (5) RE-EVAPORATION.  Assume that SO2 is re-evaporated as SO4 since it
-!      has been oxidized by H2O2 at the level above. 
+!      has been oxidized by H2O2 at the level above.
 !-----------------------------------------------------------------------------
 !     Add in the flux from above, which will be subtracted if reevaporation occurs
       if(k .gt. LH) then
@@ -3264,12 +3264,12 @@ CONTAINS
    real, dimension(:), intent(in)    :: channels
    real, dimension(:), intent(in)    :: wavelengths_profile
    real, dimension(:), intent(in)    :: wavelengths_vertint
-   real, dimension(:,:,:,:), intent(in) :: aerosol     ! 
+   real, dimension(:,:,:,:), intent(in) :: aerosol     !
    real, intent(in) :: grav
    real, pointer, dimension(:,:,:), intent(in) :: tmpu  ! temperature [K]
    real, pointer, dimension(:,:,:), intent(in) :: rhoa  ! air density [kg/m^3]
    real, pointer, dimension(:,:,:), intent(in) :: delp  ! pressure thickness [Pa]
-   real, pointer, dimension(:,:,:), intent(in) :: rh    ! relative humidity [1] 
+   real, pointer, dimension(:,:,:), intent(in) :: rh    ! relative humidity [1]
    real, pointer, dimension(:,:,:), intent(in) :: u     ! east-west wind [m/s]
    real, pointer, dimension(:,:,:), intent(in) :: v     ! north-south wind [m/s]
    real, pointer, dimension(:,:,:), intent(in) :: ple   ! level edge air pressure [Pa]
@@ -3278,38 +3278,38 @@ CONTAINS
 
 ! !OUTPUT PARAMETERS:
 !  Total mass
-   real, optional, pointer, dimension(:,:), intent(inout)   :: sfcmass   ! sfc mass concentration kg/m3
-   real, optional, pointer, dimension(:,:), intent(inout)   :: colmass   ! col mass density kg/m2
+   real, optional, dimension(:,:), intent(inout)   :: sfcmass   ! sfc mass concentration kg/m3
+   real, optional, dimension(:,:), intent(inout)   :: colmass   ! col mass density kg/m2
    real, pointer, dimension(:,:,:), intent(inout) :: mass      ! 3d mass mixing ratio kg/kg
    real, pointer, dimension(:,:,:), intent(inout) :: conc      ! 3d mass concentration, kg/m3
 !  Total optical properties
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: exttau    ! ext. AOT at 550 nm
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: stexttau  ! stratospheric ext. AOT at 550 nm
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: scatau    ! sct. AOT at 550 nm
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: stscatau  ! stratospheric sct. AOT at 550 nm
-   real, optional, pointer, dimension(:,:), intent(inout)   :: sfcmass25 ! sfc mass concentration kg/m3 (pm2.5)
-   real, optional, pointer, dimension(:,:), intent(inout)   :: colmass25 ! col mass density kg/m2 (pm2.5)
-   real, optional, pointer, dimension(:,:,:), intent(inout) :: mass25    ! 3d mass mixing ratio kg/kg (pm2.5)
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: exttau25  ! ext. AOT at 550 nm (pm2.5)
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: scatau25  ! sct. AOT at 550 nm (pm2.5)
-   real, optional, pointer, dimension(:,:),  intent(inout)  :: aerindx   ! TOMS UV AI
-   real, optional, pointer, dimension(:,:), intent(inout)   :: fluxu     ! Column mass flux in x direction
-   real, optional, pointer, dimension(:,:), intent(inout)   :: fluxv     ! Column mass flux in y direction
-   real, optional, pointer, dimension(:,:,:,:), intent(inout) :: extcoef   ! 3d ext. coefficient, 1/m
-   real, optional, pointer, dimension(:,:,:,:), intent(inout) :: scacoef   ! 3d scat.coefficient, 1/m
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: exttaufm  ! fine mode (sub-micron) ext. AOT at 550 nm
-   real, optional, pointer, dimension(:,:,:), intent(inout)   :: scataufm  ! fine mode (sub-micron) sct. AOT at 550 nm
-   real, optional, pointer, dimension(:,:), intent(inout)   :: angstrom  ! 470-870 nm Angstrom parameter
+   real, optional, dimension(:,:,:), intent(inout)   :: exttau    ! ext. AOT at 550 nm
+   real, optional, dimension(:,:,:), intent(inout)   :: stexttau  ! stratospheric ext. AOT at 550 nm
+   real, optional, dimension(:,:,:), intent(inout)   :: scatau    ! sct. AOT at 550 nm
+   real, optional, dimension(:,:,:), intent(inout)   :: stscatau  ! stratospheric sct. AOT at 550 nm
+   real, optional, dimension(:,:), intent(inout)   :: sfcmass25 ! sfc mass concentration kg/m3 (pm2.5)
+   real, optional, dimension(:,:), intent(inout)   :: colmass25 ! col mass density kg/m2 (pm2.5)
+   real, optional, dimension(:,:,:), intent(inout) :: mass25    ! 3d mass mixing ratio kg/kg (pm2.5)
+   real, optional, dimension(:,:,:), intent(inout)   :: exttau25  ! ext. AOT at 550 nm (pm2.5)
+   real, optional, dimension(:,:,:), intent(inout)   :: scatau25  ! sct. AOT at 550 nm (pm2.5)
+   real, optional, dimension(:,:),  intent(inout)  :: aerindx   ! TOMS UV AI
+   real, optional, dimension(:,:), intent(inout)   :: fluxu     ! Column mass flux in x direction
+   real, optional, dimension(:,:), intent(inout)   :: fluxv     ! Column mass flux in y direction
+   real, optional, dimension(:,:,:,:), intent(inout) :: extcoef   ! 3d ext. coefficient, 1/m
+   real, optional, dimension(:,:,:,:), intent(inout) :: scacoef   ! 3d scat.coefficient, 1/m
+   real, optional, dimension(:,:,:), intent(inout)   :: exttaufm  ! fine mode (sub-micron) ext. AOT at 550 nm
+   real, optional, dimension(:,:,:), intent(inout)   :: scataufm  ! fine mode (sub-micron) sct. AOT at 550 nm
+   real, optional, dimension(:,:), intent(inout)   :: angstrom  ! 470-870 nm Angstrom parameter
    integer, optional, intent(out)   :: rc        ! Error return code:
                                                  !  0 - all is well
-                                                 !  1 - 
+                                                 !  1 -
 
 ! !DESCRIPTION: Calculates some simple 2d diagnostics from the dust fields
 !
 ! !REVISION HISTORY:
 !
 !  16APR2004, Colarco
-!  11MAR2010, Nowottnick  
+!  11MAR2010, Nowottnick
 !  11AUG2020, E.Sherman - refactored to work for multiple aerosols
 
 ! !Local Variables
@@ -3331,7 +3331,9 @@ CONTAINS
 !-------------------------------------------------------------------------
 !  Begin...
 
-   if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) NO3nFlag_ = .true.
+   if( present(NO3nFlag) ) then
+      if (NO3nFlag) NO3nFlag_ = .true.
+   end if
 
 !  Initialize local variables
 !  --------------------------
@@ -3403,7 +3405,7 @@ CONTAINS
       ilam870 .ne. 0. .and. &
       ilam470 .ne. ilam870) do_angstrom = .true.
 
-   if( present(angstrom) .and. associated(angstrom) .and. do_angstrom ) then
+   if( present(angstrom) .and. do_angstrom ) then
       allocate(tau470(i1:i2,j1:j2), tau870(i1:i2,j1:j2))
    end if
 
@@ -3414,12 +3416,12 @@ CONTAINS
       call Aero_Binwise_PM_Fractions(fPM25, 1.25, rlow, rup, nbins)   ! 2*r < 2.5 um
    end if
 
-   if (present(aerindx) .and. associated(aerindx))  aerindx = 0.0  ! for now
+   if (present(aerindx))  aerindx = 0.0  ! for now
 
 !  Calculate the diagnostic variables if requested
 !  -----------------------------------------------
 !  Calculate the surface mass concentration
-   if( present(sfcmass) .and. associated(sfcmass) ) then
+   if( present(sfcmass) ) then
       sfcmass(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          sfcmass(i1:i2,j1:j2) &
@@ -3427,7 +3429,7 @@ CONTAINS
               + aerosol(i1:i2,j1:j2,km,n)*rhoa(i1:i2,j1:j2,km)
       end do
    endif
-   if( present(sfcmass25) .and. associated(sfcmass25) ) then
+   if( present(sfcmass25) ) then
       sfcmass25(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          sfcmass25(i1:i2,j1:j2) &
@@ -3437,7 +3439,7 @@ CONTAINS
    endif
 
 !  Calculate the aerosol column loading
-   if( present(colmass) .and. associated(colmass) ) then
+   if( present(colmass) ) then
       colmass(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
        do k = klid, km
@@ -3447,7 +3449,7 @@ CONTAINS
        end do
       end do
    endif
-   if( present(colmass25) .and. associated(colmass25)) then
+   if( present(colmass25) ) then
       colmass25(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          do k = klid, km
@@ -3477,7 +3479,7 @@ CONTAINS
            + aerosol(i1:i2,j1:j2,1:km,n)
       end do
    endif
-   if( present(mass25) .and. associated(mass25) ) then
+   if( present(mass25) ) then
       mass25(i1:i2,j1:j2,1:km) = 0.
       do n = nbegin, nbins
        mass25(i1:i2,j1:j2,1:km) &
@@ -3487,7 +3489,7 @@ CONTAINS
    endif
 
 !  Calculate the column mass flux in x direction
-   if( present(fluxu) .and. associated(fluxu) ) then
+   if( present(fluxu) ) then
       fluxu(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          do k = klid, km
@@ -3499,7 +3501,7 @@ CONTAINS
    endif
 
 !  Calculate the column mass flux in y direction
-   if( present(fluxv) .and. associated(fluxv) ) then
+   if( present(fluxv) ) then
       fluxv(i1:i2,j1:j2) = 0.
       do n = nbegin, nbins
          do k = klid, km
@@ -3511,11 +3513,11 @@ CONTAINS
    endif
 
 !  Calculate the extinction and/or scattering AOD
-   if( (present(extcoef) .and. associated(extcoef)) .or. &
-       (present(scacoef) .and. associated(scacoef)) ) then
+   if( present(extcoef)  .or. &
+       present(scacoef) ) then
 
-      if( present(extcoef) .and. associated(extcoef)) extcoef = 0.
-      if( present(scacoef) .and. associated(scacoef)) scacoef = 0.
+      if( present(extcoef) ) extcoef = 0.
+      if( present(scacoef) ) scacoef = 0.
 
       do n = nbegin, nbins
        do w = 1, size(wavelengths_profile)
@@ -3528,11 +3530,11 @@ CONTAINS
                  rh(i,j,k), tau=tau, ssa=ssa)
 
 !                Calculate the total ext. and scat. coefficients
-                 if( present(extcoef) .and. associated(extcoef) ) then
+                 if( present(extcoef) ) then
                      extcoef(i,j,k,w) = extcoef(i,j,k,w) + &
                                       tau * (grav * rhoa(i,j,k) / delp(i,j,k))
                  endif
-                 if( present(scacoef) .and. associated(scacoef) ) then
+                 if( present(scacoef) ) then
                     scacoef(i,j,k,w) = scacoef(i,j,k,w) + &
                                      ssa * tau * (grav * rhoa(i,j,k) / delp(i,j,k))
                  endif
@@ -3543,25 +3545,25 @@ CONTAINS
       enddo !nbins
     end if !present(extcoef)...
 
-   if( (present(exttau) .and. associated(exttau)) .or. &
-       (present(stexttau) .and. associated(stexttau)) .or. &
-       (present(scatau) .and. associated(scatau)) .or. &
-       (present(stscatau) .and. associated(stscatau)) .or. &
-       (present(exttau25) .and. associated(exttau25)) .or. &
-       (present(exttaufm) .and. associated(exttaufm)) .or. &
-       (present(scatau25) .and. associated(scatau25)) .or. &
-       (present(scataufm) .and. associated(scataufm)) ) then
+   if( present(exttau) .or. &
+       present(stexttau) .or. &
+       present(scatau) .or. &
+       present(stscatau) .or. &
+       present(exttau25) .or. &
+       present(exttaufm) .or. &
+       present(scatau25) .or. &
+       present(scataufm) ) then
 
-      if( present(exttau) .and. associated(exttau)) exttau = 0.
-      if( present(stexttau) .and. associated(stexttau)) stexttau = 0.
-      if( present(scatau) .and. associated(scatau)) scatau = 0.
-      if( present(stscatau) .and. associated(stscatau)) stscatau = 0.
+      if( present(exttau) ) exttau = 0.
+      if( present(stexttau) ) stexttau = 0.
+      if( present(scatau) ) scatau = 0.
+      if( present(stscatau) ) stscatau = 0.
 
-      if( present(exttau25) .and. associated(exttau25)) exttau25 = 0.
-      if( present(scatau25) .and. associated(scatau25)) scatau25 = 0.
+      if( present(exttau25) ) exttau25 = 0.
+      if( present(scatau25) ) scatau25 = 0.
 
-      if( present(exttaufm) .and. associated(exttaufm)) exttaufm = 0.
-      if( present(scataufm) .and. associated(scataufm)) scataufm = 0.
+      if( present(exttaufm) ) exttaufm = 0.
+      if( present(scataufm) ) scataufm = 0.
 
        do w = 1, size(wavelengths_vertint)
       do n = nbegin, nbins
@@ -3576,49 +3578,49 @@ CONTAINS
                  rh(i,j,k), tau=tau, ssa=ssa)
 
 !                Integrate in the vertical
-                 if( present(exttau) .and. associated(exttau) ) exttau(i,j,w) = exttau(i,j,w) + tau
-                 if( present(stexttau) .and. associated(stexttau) ) then
+                 if( present(exttau) ) exttau(i,j,w) = exttau(i,j,w) + tau
+                 if( present(stexttau) ) then
                     if (ple(i,j,k) .le. tropp(i,j)) then
                         stexttau(i,j,w) = stexttau(i,j,w) + tau
                     elseif(ple(i,j,k) .gt. tropp(i,j) .and. ple(i,j,k-1) .lt. tropp(i,j)) then
                         stexttau(i,j,w) = stexttau(i,j,w) + log(tropp(i,j)/ple(i,j,k-1))/log(ple(i,j,k)/ple(i,j,k-1))*tau
                     endif
                  endif
-  
-                 if( present(exttaufm) .and. associated(exttaufm)) then
-                    if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) then
+
+                 if( present(exttaufm) ) then
+                    if( NO3nFlag_ ) then
                        exttaufm(i,j,w) = exttaufm(i,j,w) + tau
                     else
                        exttaufm(i,j,w) = exttaufm(i,j,w) + tau * fPMfm(n)
                     end if
                  end if
 
-                 if( present(exttau25) .and. associated(exttau25)) then
-                    if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) then
+                 if( present(exttau25) ) then
+                    if( NO3nFlag_ ) then
                        exttau25(i,j,w) = exttau25(i,j,w) + tau
                     else
                        exttau25(i,j,w) = exttau25(i,j,w) + tau * fPM25(n)
                     end if
                  end if
 
-                 if( present(scatau) .and. associated(scatau) ) scatau(i,j,w) = scatau(i,j,w) + tau*ssa
-                 if( present(stscatau) .and. associated(stscatau) ) then
+                 if( present(scatau) ) scatau(i,j,w) = scatau(i,j,w) + tau*ssa
+                 if( present(stscatau) ) then
                     if (ple(i,j,k) .le. tropp(i,j)) then
                         stscatau(i,j,w) = stscatau(i,j,w) + tau*ssa
                     elseif(ple(i,j,k) .gt. tropp(i,j) .and. ple(i,j,k-1) .lt. tropp(i,j)) then
                         stscatau(i,j,w) = stscatau(i,j,w) + log(tropp(i,j)/ple(i,j,k-1))/log(ple(i,j,k)/ple(i,j,k-1))*tau*ssa
-                    endif 
+                    endif
                  endif
-                 if( present(scataufm) .and. associated(scataufm) ) then
-                    if( present(NO3nFlag) .and. (NO3nFlag)) then
+                 if( present(scataufm) ) then
+                    if( NO3nFlag_ ) then
                        scataufm(i,j,w) = scataufm(i,j,w) + tau * ssa
                     else
                        scataufm(i,j,w) = scataufm(i,j,w) + tau * ssa * fPMfm(n)
                     end if
                  end if
 
-                 if( present(scatau25) .and. associated(scatau25) ) then
-                    if( present(NO3nFlag) .and. (NO3nFlag .eqv. .true.)) then
+                 if( present(scatau25) ) then
+                    if( NO3nFlag_ ) then
                        scatau25(i,j,w) = scatau25(i,j,w) + tau * ssa
                     else
                        scatau25(i,j,w) = scatau25(i,j,w) + tau * ssa * fPM25(n)
@@ -3633,7 +3635,7 @@ CONTAINS
    endif !present(exttau)...
 
 !  Calculate the 470-870 Angstrom parameter
-   if( present(angstrom) .and. associated(angstrom) .and. do_angstrom ) then
+   if( present(angstrom) .and. do_angstrom ) then
 
       angstrom(i1:i2,j1:j2) = 0.
 !     Set tau to small number by default
@@ -3726,13 +3728,13 @@ CONTAINS
    implicit NONE
 
 ! !INPUT/OUTPUT PARAMETERS:
-   real, dimension(:,:), intent(inout) :: deep_lakes_mask      
+   real, dimension(:,:), intent(inout) :: deep_lakes_mask
 
 ! !INPUT PARAMETERS:
    real, pointer, dimension(:,:), intent(in)   :: lats ! latitude [radians]
    real, pointer, dimension(:,:), intent(in)   :: lons ! longtitude [radians]
    real, intent(in)                       :: radToDeg
-          
+
 ! !OUTPUT PARAMETERS:
    integer, optional, intent(out) :: rc
 !EOP
@@ -3778,10 +3780,10 @@ CONTAINS
   implicit NONE
 
 ! !INPUT/OUTPUT PARAMETERS:
-  real, dimension(:,:), intent(inout) :: fsstemis     ! 
+  real, dimension(:,:), intent(inout) :: fsstemis     !
 
 ! !INPUT PARAMETERS:
-   integer, intent(in)                       :: sstEmisFlag  ! 1 or 2 
+   integer, intent(in)                       :: sstEmisFlag  ! 1 or 2
    real, dimension(:,:), intent(in)          :: ts  ! surface temperature (K)
 
 ! !OUTPUT PARAMETERS:
@@ -3793,7 +3795,7 @@ CONTAINS
 !EOP
 !-------------------------------------------------------------------------
 !  Begin...
-  
+
    fsstemis = 1.0
 
    if (sstemisFlag == 1) then          ! SST correction folowing Jaegle et al. 2011
@@ -3812,7 +3814,7 @@ CONTAINS
       allocate( tskin_c, mold=fsstemis )
       tskin_c  = ts - 273.15
 
-      where(tskin_c < -0.1) tskin_c = -0.1    ! temperature range (0, 36) C 
+      where(tskin_c < -0.1) tskin_c = -0.1    ! temperature range (0, 36) C
       where(tskin_c > 36.0) tskin_c = 36.0    !
 
       fsstemis = (-1.107211 -0.010681*tskin_c -0.002276*tskin_c**2 + 60.288927*1.0/(40.0 - tskin_c))
@@ -3837,7 +3839,7 @@ CONTAINS
    implicit NONE
 
 ! !INPUT/OUTPUT PARAMETERS:
-   real(kind=DP), dimension(:,:), intent(inout)    :: gweibull 
+   real(kind=DP), dimension(:,:), intent(inout)    :: gweibull
 
 ! !INPUT PARAMETERS:
    logical, intent(in)                    :: weibullFlag
@@ -3897,10 +3899,10 @@ CONTAINS
 !=====================================================================================
 
  DOUBLE PRECISION function igamma(A, X, rc)
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 ! incomplete (upper) Gamma function
 ! \int_x^\infty t^{A-1}\exp(-t) dt
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
  IMPLICIT NONE
  double precision, intent(in) ::        A
  DOUBLE PRECISION, INTENT(IN) ::      X
@@ -3982,7 +3984,7 @@ CONTAINS
 ! !OUTPUT PARAMETERS:
    integer, intent(out)          :: rc              ! Error return code:
                                                     !  0 - all is well
-                                                    !  1 - 
+                                                    !  1 -
 ! !Local Variables
    integer       :: ir
    real, pointer :: w(:,:)                          ! Intermediary wind speed [m s-1]
@@ -4290,8 +4292,8 @@ CONTAINS
    real, dimension(:,:), intent(in) :: aviation_cds_src ! Climb/Descent aircraft fuel emission [1]
    real, dimension(:,:), intent(in) :: aviation_crs_src ! Cruise aircraft fuel emission [1]
    real, dimension(:,:), intent(in) :: aviation_lto_src ! Landing/Take-off aircraft fuel emission [1]
-   real, dimension(:,:), intent(in) :: biomass_src  
-   real, dimension(:,:), intent(in) :: terpene_src 
+   real, dimension(:,:), intent(in) :: biomass_src
+   real, dimension(:,:), intent(in) :: terpene_src
    real, dimension(:,:), intent(in) :: eocant1_src  ! anthropogenic emissions
    real, dimension(:,:), intent(in) :: eocant2_src  ! anthropogenic emissions
    real, dimension(:,:), intent(in) :: oc_ship_src  ! ship emissions
@@ -4308,7 +4310,7 @@ CONTAINS
    real, pointer, dimension(:,:)  :: OC_emisBG  ! OC emissions, kg/m2/s
    integer, optional, intent(out) :: rc         ! Error return code:
                                                 !  0 - all is well
-                                                !  1 - 
+                                                !  1 -
    character(len=*), parameter :: myname = 'CAEmission'
 
 ! !DESCRIPTION: Updates the OC concentration with emissions every timestep
@@ -4491,9 +4493,9 @@ K_LOOP_BB: do k = km, 1, -1
 
 
 !   Update concentrations at this layer
-!   The "1" element is hydrophobic 
+!   The "1" element is hydrophobic
 !   The "2" element is hydrophilic
-!   -----------------------------------    
+!   -----------------------------------
     factor = cdt * grav / delp(:,:,k)
 
     qa_bb_(1,:,:,k) = factor * srcHydrophobic
@@ -4623,9 +4625,9 @@ K_LOOP: do k = km, 1, -1
     end do  ! j
 
 !   Update concentrations at this layer
-!   The "1" element is hydrophobic 
+!   The "1" element is hydrophobic
 !   The "2" element is hydrophilic
-!   -----------------------------------    
+!   -----------------------------------
     factor = cdt * grav / delp(:,:,k)
 
     aerosolPhobic(:,:,k) = aerosolPhobic(:,:,k) &
@@ -4729,7 +4731,7 @@ K_LOOP: do k = km, 1, -1
                     end if
                 end do
             end if
-            ! distribute emissions in the vertical 
+            ! distribute emissions in the vertical
             emissions(i,j,:) = (w_ / sum(w_)) * emissions_layer(i,j)
         end do
     end do
@@ -4750,8 +4752,8 @@ K_LOOP: do k = km, 1, -1
    implicit NONE
 
 ! !INPUT PARAMETERS:
-   integer, intent(in)   :: km   ! total model level 
-   real, intent(in)      :: cdt  ! chemistry model time-step [sec] 
+   integer, intent(in)   :: km   ! total model level
+   real, intent(in)      :: cdt  ! chemistry model time-step [sec]
    real, intent(in)      :: grav ! [m/sec^2]
    real, dimension(:,:,:), intent(in)  :: delp  ! pressure thickness [Pa]
 
@@ -4988,7 +4990,7 @@ K_LOOP: do k = km, 1, -1
    subroutine HNO3_reaction_rate(i1, i2, j1, j2, km, klid, rmed, fnum, rhoa, temp, rh, q, kan, &
                                  AVOGAD, AIRMW, PI, RUNIV, fMassHNO3)
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 
 ! !USES:
    implicit NONE
@@ -4998,7 +5000,7 @@ K_LOOP: do k = km, 1, -1
    integer, intent(in)                 :: km     ! model levels
    integer, intent(in)                 :: klid   ! index for pressure lid
    real, intent(in)                    :: rmed   ! aerosol radius [um]
-   real, intent(in)                    :: fnum   ! number of aerosol particles per kg mass  
+   real, intent(in)                    :: fnum   ! number of aerosol particles per kg mass
    real, dimension(:,:,:), intent(in)  :: rhoa   ! Layer air density [kg/m^3]
    real, dimension(:,:,:), intent(in)  :: temp   ! Layer temperature [K]
    real, dimension(:,:,:), intent(in)  :: rh     ! relative humidity [1]
@@ -5027,7 +5029,7 @@ K_LOOP: do k = km, 1, -1
 
    f_ad = 1.e-6 * AVOGAD / AIRMW  ! air number density # cm-3 per unit air density
 
-   ! surface area per unit air density and unit aerosol mass mixing ratio 
+   ! surface area per unit air density and unit aerosol mass mixing ratio
    f_sad  = 0.01 * 4 * PI * rmed**2 * fnum
 
    ! radius in 'cm'
@@ -5056,7 +5058,7 @@ K_LOOP: do k = km, 1, -1
    subroutine SSLT_reaction_rate(i1, i2, j1, j2, km, klid, rmed, fnum, rhoa, temp, rh, q, kan, &
                                  AVOGAD, AIRMW, PI, RUNIV, fMassHNO3)
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 
 ! !USES:
    implicit NONE
@@ -5066,7 +5068,7 @@ K_LOOP: do k = km, 1, -1
    integer, intent(in)                 :: km     ! model levels
    integer, intent(in)                 :: klid   ! index for pressure lid
    real, intent(in)                    :: rmed   ! aerosol radius [um]
-   real, intent(in)                    :: fnum   ! number of aerosol particles per kg mass  
+   real, intent(in)                    :: fnum   ! number of aerosol particles per kg mass
    real, dimension(:,:,:), intent(in)  :: rhoa   ! Layer air density [kg/m^3]
    real, dimension(:,:,:), intent(in)  :: temp   ! Layer temperature [K]
    real, dimension(:,:,:), intent(in)  :: rh     ! relative humidity [1]
@@ -5095,7 +5097,7 @@ K_LOOP: do k = km, 1, -1
 
       f_ad = 1.e-6 * AVOGAD / AIRMW  ! air number density # cm-3 per unit air density
 
-      ! surface area per unit air density and unit aerosol mass mixing ratio 
+      ! surface area per unit air density and unit aerosol mass mixing ratio
       f_sad  = 0.01 * 4 * PI * rmed**2 * fnum
 
       ! radius in 'cm'
@@ -5122,7 +5124,7 @@ K_LOOP: do k = km, 1, -1
 ! !INTERFACE:
    subroutine apportion_reaction_rate (i1, i2, j1, j2, km, kan, kan_total)
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 
 ! !USES:
    implicit NONE
@@ -5149,15 +5151,15 @@ K_LOOP: do k = km, 1, -1
 !
 ! !IROUTINE: sktrs_hno3
 !
-! !INTERFACE: 
+! !INTERFACE:
    function sktrs_hno3 ( tk, rh, sad, ad, radA, pi, rgas, fMassHNO3 )
 
 ! !DESCRIPTION:
 ! Below are the series of heterogeneous reactions
 ! The reactions sktrs_hno3n1, sktrs_hno3n2, and sktrs_hno3n3 are provided
 ! as given by Huisheng Bian.  As written they depend on knowing the GOCART
-! structure and operate per column but the functions themselves are 
-! repetitive.  I cook up a single sktrs_hno3 function which is called per 
+! structure and operate per column but the functions themselves are
+! repetitive.  I cook up a single sktrs_hno3 function which is called per
 ! grid box per species with an optional parameter gamma being passed.
 ! Following is objective:
 ! loss rate (k = 1/s) of species on aerosol surfaces
@@ -5189,9 +5191,9 @@ K_LOOP: do k = km, 1, -1
 ! !Local Variables
    real, parameter :: fmassHNO3_hno3 = 63.013
 
-!   REAL,  PARAMETER :: GAMMA_HNO3 = 0.1 
+!   REAL,  PARAMETER :: GAMMA_HNO3 = 0.1
    REAL,  PARAMETER :: GAMMA_HNO3 = 1.0e-3
-!   REAL,  PARAMETER :: GAMMA_HNO3 = 5.0e-4 
+!   REAL,  PARAMETER :: GAMMA_HNO3 = 5.0e-4
 
    real :: dfkg
    real :: avgvel
@@ -5257,15 +5259,15 @@ K_LOOP: do k = km, 1, -1
 !
 ! !IROUTINE: sktrs_sslt
 !
-! !INTERFACE: 
+! !INTERFACE:
    function sktrs_sslt ( tk, sad, ad, radA, pi, rgas, fMassHNO3 )
 
 ! !DESCRIPTION:
 ! Below are the series of heterogeneous reactions
 ! The reactions sktrs_hno3n1, sktrs_hno3n2, and sktrs_hno3n3 are provided
 ! as given by Huisheng Bian.  As written they depend on knowing the GOCART
-! structure and operate per column but the functions themselves are 
-! repetitive.  I cook up a single sktrs_hno3 function which is called per 
+! structure and operate per column but the functions themselves are
+! repetitive.  I cook up a single sktrs_hno3 function which is called per
 ! grid box per species with an optional parameter gamma being passed.
 ! Following is objective:
 ! loss rate (k = 1/s) of species on aerosol surfaces
@@ -5348,7 +5350,7 @@ K_LOOP: do k = km, 1, -1
                                           aviation_layers,   &
                                           aviation_lto_src, &
                                           aviation_cds_src, &
-                                          aviation_crs_src, rc) 
+                                          aviation_crs_src, rc)
 
 ! !USES:
    implicit NONE
@@ -5450,7 +5452,7 @@ K_LOOP: do k = km, 1, -1
    srcSO4 = 0.0
    srcDMS = 0.0
 
-   if ((nVolc <= 0) .and. associated(SU_emis)) SU_emis = 0.0 !SU_emis is usually set to zero in SUvolcanicEmissions. 
+   if ((nVolc <= 0) .and. associated(SU_emis)) SU_emis = 0.0 !SU_emis is usually set to zero in SUvolcanicEmissions.
 !                                               !If there are no volcanic emissions, we need to set it to zero here.
    if (associated(SU_SO4eman)) SU_SO4eman = 0.0
    if (associated(SU_SO2eman)) SU_SO2eman = 0.0
@@ -5554,7 +5556,7 @@ K_LOOP: do k = km, 1, -1
        fPblh = (p0(i,j)-pPblh(i,j))/(ps(i,j)-pPblh(i,j))
 
 !     All source from files specified in kg SO2 m-2 s-1 (unless filename
-!     indicates otherwise!).  
+!     indicates otherwise!).
       srcSO4anthro(i,j) = fSO4ant * fMassSO4/fMassSO2 * &
                 (   f100 * so2anthro_l1_src(i,j) &
                   + f500 * so2anthro_l2_src(i,j)  )
@@ -5741,7 +5743,7 @@ K_LOOP: do k = km, 1, -1
   integer, optional, intent(out)   :: rc    ! Error return code:
                                             !  0 - all is well
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !
 ! !REVISION HISTORY:
 !
@@ -6059,7 +6061,7 @@ K_LOOP: do k = km, 1, -1
 
 !
 ! !REVISION HISTORY:
-! 29July2004 P.Colarco - legacy code 
+! 29July2004 P.Colarco - legacy code
 ! 23July2020 E.Sherman - ported to process library.
 
 ! !Local Variables
@@ -6175,7 +6177,7 @@ K_LOOP: do k = km, 1, -1
 
 !==================================================================================
 !BOP
-! !IROUTINE: SU_Wet_Removal 
+! !IROUTINE: SU_Wet_Removal
 
    subroutine SU_Wet_Removal ( km, nbins, klid, cdt, kin, grav, airMolWght, delp, fMassSO4, fMassSO2, &
                                h2o2_int, ple, rhoa, precc, precl, pfllsan, pfilsan, tmpu, &
@@ -6195,14 +6197,14 @@ K_LOOP: do k = km, 1, -1
    logical, intent(in) :: KIN   ! true for aerosol
    real, intent(in)    :: grav  ! gravity [m/sec]
    real, intent(in)    :: airMolWght ! air molecular weight [kg]
-   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]  
+   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]
    real, intent(in) :: fMassSO4, fMassSO2
    real, dimension(:,:,:) :: h2o2_int
    real, pointer, dimension(:,:,:), intent(in) :: ple     ! level edge air pressure
    real, pointer, dimension(:,:,:), intent(in) :: rhoa    ! air density, [kg m-3]
    real, pointer, dimension(:,:), intent(in)   :: precc   ! total convective precip, [mm day-1]
    real, pointer, dimension(:,:), intent(in)   :: precl   ! total large-scale prec,  [mm day-1]
-   real, pointer, dimension(:,:,:), intent(in) :: pfllsan ! 3D flux of liquid nonconvective precipitation [kg/(m^2 sec)] 
+   real, pointer, dimension(:,:,:), intent(in) :: pfllsan ! 3D flux of liquid nonconvective precipitation [kg/(m^2 sec)]
    real, pointer, dimension(:,:,:), intent(in) :: pfilsan ! 3D flux of ice nonconvective precipitation [kg/(m^2 sec)]
    real, pointer, dimension(:,:,:), intent(in) :: tmpu    ! temperature, [K]
    integer, intent(in) :: nDMS, nSO2, nSO4, nMSA !index position of sulfates
@@ -6236,7 +6238,7 @@ K_LOOP: do k = km, 1, -1
 !  will be a function of time of day and lat/lon.  For now we simply add
 !  this to the grid component before calculating it.  I bet this is
 !  somewhere else in the model.
- 
+
 !
 ! !REVISION HISTORY:
 !
@@ -6256,7 +6258,7 @@ K_LOOP: do k = km, 1, -1
    real*8 :: qmx, qd, A                ! temporary variables on moisture
    real*8 :: F, B, BT                  ! temporary variables on cloud, freq.
    real*8, allocatable :: fd(:,:)      ! flux across layers [kg m-2]
-   real*8, allocatable :: dpfli(:,:,:) ! 
+   real*8, allocatable :: dpfli(:,:,:) !
    real*8, allocatable :: DC(:)        ! scavenge change in mass mixing ratio
 !   real :: c_h2o(i1:i2,j1:j2,km), cldliq(i1:i2,j1:j2,km), cldice(i1:i2,j1:j2,km)
    real, dimension(:,:,:), allocatable :: c_h2o, cldliq, cldice
@@ -6289,7 +6291,7 @@ K_LOOP: do k = km, 1, -1
    allocate(cldice, mold=rhoa)
 !  Initialize local variables
 !  --------------------------
-!  c_h2o, cldliq, and cldice are respectively intended to be the 
+!  c_h2o, cldliq, and cldice are respectively intended to be the
 !  water mixing ratio (liquid or vapor?, in or out of cloud?)
 !  cloud liquid water mixing ratio
 !  cloud ice water mixing ratio
@@ -6304,7 +6306,7 @@ K_LOOP: do k = km, 1, -1
    i2 = dims(1); j2 = dims(2)
 
 !  check if doing MSA and define nbins_ accordingly
-!   if (associated(MSA)) then 
+!   if (associated(MSA)) then
 !      nbins_ = nbins
 !   else
 !      nbins_ = nbins - 1
@@ -6367,7 +6369,7 @@ K_LOOP: do k = km, 1, -1
      do k = LH, km
 
 !-----------------------------------------------------------------------------
-!   (1) LARGE-SCALE RAINOUT:             
+!   (1) LARGE-SCALE RAINOUT:
 !       Tracer loss by rainout = TC0 * F * exp(-B*dt)
 !         where B = precipitation frequency,
 !               F = fraction of grid box covered by precipitating clouds.
@@ -6406,11 +6408,11 @@ K_LOOP: do k = km, 1, -1
         if (DC(n).lt.0.) DC(n) = 0.
        end do
 
-       call updateAerosol(DMS(i,j,k), DC(nDMS)) 
-       call updateAerosol(SO2(i,j,k), DC(nSO2)) 
-       call updateAerosol(SO4(i,j,k), DC(nSO4)) 
+       call updateAerosol(DMS(i,j,k), DC(nDMS))
+       call updateAerosol(SO2(i,j,k), DC(nSO2))
+       call updateAerosol(SO4(i,j,k), DC(nSO4))
        if (associated(MSA)) then
-          call updateAerosol(MSA(i,j,k), DC(nMSA)) 
+          call updateAerosol(MSA(i,j,k), DC(nMSA))
        end if
 
 !      Flux down:  unit is kg m-2
@@ -6639,7 +6641,7 @@ K_LOOP: do k = km, 1, -1
 
 !-----------------------------------------------------------------------------
 !  (5) RE-EVAPORATION.  Assume that SO2 is re-evaporated as SO4 since it
-!      has been oxidized by H2O2 at the level above. 
+!      has been oxidized by H2O2 at the level above.
 !-----------------------------------------------------------------------------
 !     Add in the flux from above, which will be subtracted if reevaporation occurs
       if(k .gt. LH) then
@@ -6668,7 +6670,7 @@ K_LOOP: do k = km, 1, -1
           if (associated(MSA)) then
              DC(nMSA) = Fd(k-1,nMSA) / pdog(i,j,k) * A
           end if
-  
+
           do n = 1, nbins
            if (DC(n).lt.0.) DC(n) = 0.
           end do
@@ -6726,7 +6728,7 @@ K_LOOP: do k = km, 1, -1
 
      ! !USES:
      implicit NONE
-     ! !INPUT PARAMETERS:      
+     ! !INPUT PARAMETERS:
       real, intent(inout) :: aerosol
       real*8, intent(in)  :: DC
 
@@ -6772,13 +6774,13 @@ K_LOOP: do k = km, 1, -1
    real, pointer, dimension(:,:,:), intent(in) :: rhoa    ! air density [kg/m^3]
    real, pointer, dimension(:,:,:), intent(in) :: delp    ! pressure thickness [Pa]
    real, pointer, dimension(:,:,:), intent(in) :: ple   ! level edge air pressure [Pa]
-   real, pointer, dimension(:,:), intent(in)   :: tropp ! tropopause pressure [Pa]   
+   real, pointer, dimension(:,:), intent(in)   :: tropp ! tropopause pressure [Pa]
    real, pointer, dimension(:,:,:), intent(in) :: rh      ! relative humidity [1]
    real, pointer, dimension(:,:,:), intent(in) :: u       ! east-west wind [m s-1]
    real, pointer, dimension(:,:,:), intent(in) :: v       ! north-south wind [m s-1]
 
 ! !INOUTPUT PARAMETERS:
-   real, dimension(:,:,:), intent(inout) :: DMS  ! dimethyl sulfide [kg/kg] 
+   real, dimension(:,:,:), intent(inout) :: DMS  ! dimethyl sulfide [kg/kg]
    real, dimension(:,:,:), intent(inout) :: SO2  ! sulfer dioxide [kg/kg]
    real, dimension(:,:,:), intent(inout) :: SO4  ! sulfate aerosol [kg/kg]
    real, pointer, dimension(:,:,:), intent(inout)  :: MSA  ! methanesulphonic acid [kg/kg]
@@ -6805,7 +6807,7 @@ K_LOOP: do k = km, 1, -1
    real, pointer, dimension(:,:,:), intent(inout)  :: snum       ! Sulfate number density [# m-2]
    integer, optional, intent(out)   :: rc         ! Error return code:
                                                   !  0 - all is well
-                                                  !  1 - 
+                                                  !  1 -
 
 
 ! !DESCRIPTION: Calculates some simple 2d diagnostics from the SU fields
@@ -6871,7 +6873,7 @@ K_LOOP: do k = km, 1, -1
          print*,'wavelengths_profile of ',wavelengths_profile(i),' is an invalid value.'
          return
       end if
-   end do  
+   end do
 
    ! Channel values are 4.7e-7 5.5e-7 6.7e-7 8.7e-7 [meter]. Their indices are 1,2,3,4 respectively.
    do i = 1, size(wavelengths_vertint)
@@ -6887,7 +6889,7 @@ K_LOOP: do k = km, 1, -1
          print*,'wavelengths_profile of ',wavelengths_profile(i),' is an invalid value.'
          return
       end if
-   end do 
+   end do
 
 !  Determine if going to do Angstrom parameter calculation
 !  -------------------------------------------------------
@@ -6963,7 +6965,7 @@ K_LOOP: do k = km, 1, -1
    endif
 
 
-!  Calculate the mass concentration of sulfate 
+!  Calculate the mass concentration of sulfate
    if( associated(so4conc) ) then
       so4conc(i1:i2,j1:j2,1:km) = 0.
       so4conc(i1:i2,j1:j2,1:km) = SO4(i1:i2,j1:j2,1:km)*rhoa(i1:i2,j1:j2,1:km)
@@ -7025,7 +7027,7 @@ K_LOOP: do k = km, 1, -1
       enddo
    endif
 
-   if( associated(exttau) .or. associated(stexttau) .or. & 
+   if( associated(exttau) .or. associated(stexttau) .or. &
        associated(scatau) .or. associated(stscatau)) then
 
       if (associated(exttau)) exttau = 0.
@@ -7063,7 +7065,7 @@ K_LOOP: do k = km, 1, -1
                  stscatau(i,j,w) = stscatau(i,j,w) + tau*ssa
               elseif(ple(i,j,k) .gt. tropp(i,j) .and. ple(i,j,k-1) .lt. tropp(i,j)) then
                  stscatau(i,j,w) = stscatau(i,j,w) + log(tropp(i,j)/ple(i,j,k-1))/log(ple(i,j,k)/ple(i,j,k-1))*tau*ssa
-              endif 
+              endif
            endif
 
 
@@ -7155,7 +7157,7 @@ K_LOOP: do k = km, 1, -1
 ! !USES:
    implicit NONE
 
-! !INPUT PARAMETERS:  
+! !INPUT PARAMETERS:
    integer, intent(in) :: km     ! number of model levels
    integer, intent(in) :: klid   ! index for pressure lid
    real, intent(in)    :: cdt    ! chemisty model timestep [sec]
@@ -7166,17 +7168,17 @@ K_LOOP: do k = km, 1, -1
    real, intent(in)    :: airMolWght ! molecular weight of air [kg/kmol]
    real, intent(in)    :: cpd
    real, intent(in)    :: grav   ! gravity [m/sec]
-   real, intent(in)    :: fMassMSA, fMassDMS, fMassSO2, fMassSO4 ! gram molecular weights of species 
+   real, intent(in)    :: fMassMSA, fMassDMS, fMassSO2, fMassSO4 ! gram molecular weights of species
    integer, intent(in) :: nymd   ! model year month day
    integer, intent(in) :: nhms   ! model hour mintue second
    real, dimension(:,:), intent(in) :: lonRad   ! model grid lon [radians]
    real, dimension(:,:), intent(in) :: latRad   ! model grid lat [radians]
-   real, dimension(:,:,:), intent(inout) :: dms  ! dimethyl sulfide [kg/kg] 
+   real, dimension(:,:,:), intent(inout) :: dms  ! dimethyl sulfide [kg/kg]
    real, dimension(:,:,:), intent(inout) :: so2  ! sulfer dioxide [kg/kg]
    real, dimension(:,:,:), intent(inout) :: so4  ! sulfate aerosol [kg/kg]
    real, pointer, dimension(:,:,:), intent(inout) :: msa  ! methanesulphonic acid [kg/kg]
    integer, intent(in) :: nDMS, nSO2, nSO4, nMSA ! index position of sulfates
-   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]  
+   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]
    real, pointer, dimension(:,:,:), intent(in) :: tmpu   ! temperature [K]
    real, dimension(:,:,:), intent(in) :: cloud  ! cloud fraction for radiation [1]
    real, pointer, dimension(:,:,:), intent(in) :: rhoa   ! layer air density [kg/m^3]
@@ -7206,7 +7208,7 @@ K_LOOP: do k = km, 1, -1
 ! !OUTPUT PARAMETERS:
    integer, optional, intent(out)   :: rc         ! Error return code:
                                                   !  0 - all is well
-                                                  !  1 - 
+                                                  !  1 -
 
 ! !DESCRIPTION: Updates the SU concentration due to chemistry
 !  The SU grid component is currently established with 4 different
@@ -7369,20 +7371,20 @@ K_LOOP: do k = km, 1, -1
                                      fMassMSA, fMassDMS, fMassSO2, &
                                      qa, nDMS, xoh, xno3, &
                                      cossza, tmpu, rhoa, &
-                                     pSO2_DMS, pMSA_DMS, SU_dep, & 
+                                     pSO2_DMS, pMSA_DMS, SU_dep, &
                                      rc)
 
 ! !USES:
    implicit NONE
 
-! !INPUT PARAMETERS:  
+! !INPUT PARAMETERS:
    integer, intent(in) :: km     ! number of model levels
    integer, intent(in) :: klid   ! index for pressure lid
    real, intent(in)    :: cdt    ! chemisty model timestep [sec]
    real, intent(in)    :: nAvogadro  ! Avogadro's number [1/kmol]
    real, intent(in)    :: airMolWght ! molecular weight of air [kg/kmol]
    real, intent(in)    :: cpd
-   real, intent(in)    :: fMassMSA, fMassDMS, fMassSO2 ! gram molecular weights of species 
+   real, intent(in)    :: fMassMSA, fMassDMS, fMassSO2 ! gram molecular weights of species
    integer, intent(in) :: nDMS       !index position of sulfates
    real, dimension(:,:,:), intent(in) :: xoh, xno3  ! OH, NO3 respectievly [kg/kg]
    real, dimension(:,:), intent(in)   :: cossza
@@ -7391,7 +7393,7 @@ K_LOOP: do k = km, 1, -1
 
 
 ! !INOUTPUT PARAMETERS:
-   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg] 
+   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg]
    real, pointer, dimension(:,:,:), intent(inout) :: SU_dep ! Sulfate Dry Deposition All Bins [kg m-2 s-1]
 
 ! !OUTPUT PARAMETERS:
@@ -7453,7 +7455,7 @@ K_LOOP: do k = km, 1, -1
    allocate(pSO2_DMS, mold=tmpu)
    allocate(pMSA_DMS, mold=tmpu)
 
-!  spatial loop 
+!  spatial loop
    do k = klid, km
     do j = j1, j2
      do i = i1, i2
@@ -7542,7 +7544,7 @@ K_LOOP: do k = km, 1, -1
 ! !USES:
    implicit NONE
 
-! !INPUT PARAMETERS:  
+! !INPUT PARAMETERS:
    integer, intent(in) :: km     ! number of model levels
    integer, intent(in) :: klid   ! index for pressure lid
    real, intent(in)    :: cdt    ! chemisty model timestep [sec]
@@ -7550,18 +7552,18 @@ K_LOOP: do k = km, 1, -1
    real, intent(in)    :: airMolWght ! molecular weight of air [kg/kmol]
    real, intent(in)    :: cpd
    real, intent(in)    :: grav       ! gravity [m/sec]
-   real, intent(in)    :: fMassSO4, fMassSO2 ! gram molecular weights of species 
+   real, intent(in)    :: fMassSO4, fMassSO2 ! gram molecular weights of species
    integer, intent(in) :: nSO2       !index position of sulfates
    real, dimension(:,:,:), intent(in) :: tmpu   ! temperature [K]
    real, dimension(:,:,:), intent(in) :: rhoa   ! layer air density [kg/m^3]
-   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]  
+   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]
    real, dimension(:,:,:), intent(in) :: cloud  ! cloud fraction for radiation [1]
    real, dimension(:,:), intent(in)   :: drydepf  ! dry deposition frequency [s-1]
    real, pointer, dimension(:,:), intent(in) :: oro  ! land-ocean-ice mask
    real, dimension(:,:,:), intent(in) :: pSO2_DMS ! SO2 production from DMS oxidation [kg m-2 s-1]
 
 ! !INOUTPUT PARAMETERS:
-   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg] 
+   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg]
    real, dimension(:,:,:), intent(inout) :: xoh, xh2o2  ! OH, H2O2 respectievly [kg/kg]
    real, pointer, dimension(:,:,:), intent(inout) :: SU_dep ! Sulfate Dry Deposition All Bins [kg m-2 s-1]
 
@@ -7621,10 +7623,10 @@ K_LOOP: do k = km, 1, -1
 !  Conversion of SO2 mmr to SO2 vmr
    fMR = airMolWght / fMassSO2
 
-!  Initialize flux variable   
+!  Initialize flux variable
    fout = 0.
 
-!  spatial loop 
+!  spatial loop
    do k = klid, km
     do j = 1, j2
      do i = 1, i2
@@ -7735,19 +7737,19 @@ K_LOOP: do k = km, 1, -1
 ! !USES:
    implicit NONE
 
-! !INPUT PARAMETERS:  
+! !INPUT PARAMETERS:
    integer, intent(in) :: km     ! number of model levels
    integer, intent(in) :: klid   ! index for pressure lid
    real, intent(in)    :: cdt    ! chemisty model timestep [sec]
    real, intent(in)    :: grav   ! gravity [m/sec]
    integer, intent(in) :: nSO4   ! index position of sulfate
-   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]  
+   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]
    real, dimension(:,:), intent(in)   :: drydepf    ! dry deposition frequency [s-1]
    real, dimension(:,:,:), intent(in) :: pSO4g_SO2  ! SO4 production - gas phase [kg kg-1 s-1]
    real, dimension(:,:,:), intent(in) :: pSO4aq_SO2 ! SO4 production - aqueous [kg kg-1 s-1]
 
 ! !INOUTPUT PARAMETERS:
-   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg] 
+   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg]
    real, pointer, dimension(:,:,:), intent(inout) :: SU_dep ! Sulfate Dry Deposition All Bins [kg m-2 s-1]
 
 ! !OUTPUT PARAMETERS:
@@ -7787,7 +7789,7 @@ K_LOOP: do k = km, 1, -1
 !  Initialize flux variable
    fout = 0.
 
-!  spatial loop 
+!  spatial loop
    do k = klid, km
     do j = 1, j2
      do i = 1, i2
@@ -7837,24 +7839,24 @@ K_LOOP: do k = km, 1, -1
 ! !USES:
    implicit NONE
 
-! !INPUT PARAMETERS:  
+! !INPUT PARAMETERS:
    integer, intent(in) :: km     ! number of model levels
    integer, intent(in) :: klid   ! index for pressure lid
    real, intent(in)    :: cdt    ! chemisty model timestep [sec]
    real, intent(in)    :: grav   ! gravity [m/sec]
    integer, intent(in) :: nMSA   ! index position of sulfate
-   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]  
+   real, dimension(:,:,:), intent(in) :: delp   ! pressure thickness [Pa]
    real, dimension(:,:), intent(in)   :: drydepf   ! dry deposition frequency [s-1]
    real, dimension(:,:,:), intent(in) :: pMSA_DMS  ! MSA production - gas phase [kg kg-1 s-1]
 
 ! !INOUTPUT PARAMETERS:
-   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg] 
+   real, dimension(:,:,:), intent(inout) :: qa  ! dimethyl sulfide [kg/kg]
    real, pointer, dimension(:,:,:), intent(inout) :: SU_dep ! Sulfate Dry Deposition All Bins [kg m-2 s-1]
 
 ! !OUTPUT PARAMETERS:
    integer, optional, intent(out)   :: rc
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !
 !  MSA production:
 !    The only production term is due to DMS oxidation.
@@ -7884,7 +7886,7 @@ K_LOOP: do k = km, 1, -1
 
    allocate(fout(i2,j2))
 
-!  spatial loop 
+!  spatial loop
    do k = klid, km
     do j = 1, j2
      do i = 1, i2
@@ -7926,7 +7928,7 @@ K_LOOP: do k = km, 1, -1
 !BOP
 ! !IROUTINE: get_HenrysLawCts
 
-   subroutine get_HenrysLawCts(name,c1,c2,c3,c4,rc) 
+   subroutine get_HenrysLawCts(name,c1,c2,c3,c4,rc)
 
 ! !USES:
    implicit NONE
@@ -7952,7 +7954,7 @@ K_LOOP: do k = km, 1, -1
   INTEGER,PARAMETER :: nspecies_HL=051
   REAL   ,PARAMETER :: notfound = -1.
 
-  !Name of species 
+  !Name of species
   CHARACTER(LEN=8),PARAMETER,DIMENSION(nspecies_HL) :: spc_name=(/ &
       'O3  ' & !001
      ,'H2O2' & !002
@@ -8008,7 +8010,7 @@ K_LOOP: do k = km, 1, -1
    /)
 
 
-  !Number of each specie   
+  !Number of each specie
   INTEGER,PARAMETER :: O3  =001
   INTEGER,PARAMETER :: H2O2=002
   INTEGER,PARAMETER :: NO  =003
@@ -8065,11 +8067,11 @@ K_LOOP: do k = km, 1, -1
 !     Henrys law coefficient
 !     [KH298]=mole/(l atm)
 !     Referencias em R. Sander (1999)
-!     Compilation of Henry Law Constants 
-!     for Inorganic and Organic Species 
-!     of Potential Importance in 
-!     Environmental Chemistry (Version 3) 
-!     http://www.henrys-law.org 
+!     Compilation of Henry Law Constants
+!     for Inorganic and Organic Species
+!     of Potential Importance in
+!     Environmental Chemistry (Version 3)
+!     http://www.henrys-law.org
 !     * indica artigos nao encontrados nesse endereço eletronico
   REAL,PARAMETER,DIMENSION(nspecies_HL) :: hstar=(/&
     1.10E-2              ,   & ! O3 - 001
@@ -8130,10 +8132,10 @@ K_LOOP: do k = km, 1, -1
 !     [-DH/R]=K
 !     Referencias em R. Sander (1999)
 !     Compilation of Henry Law Constants
-!     for Inorganic and Organic Species 
-!     of Potential Importance in 
+!     for Inorganic and Organic Species
+!     of Potential Importance in
 !     Environmental Chemistry (Version 3)
-!     http://www.henrys-law.org 
+!     http://www.henrys-law.org
   REAL,PARAMETER,DIMENSION(nspecies_HL) :: dhr=(/&
     2400.         ,   & ! O3 - 001
     7400.         ,   & ! H2O2 - 002
@@ -8244,7 +8246,7 @@ K_LOOP: do k = km, 1, -1
    /)
 
 
-!    ACID DISSOCIATION CONSTANT AT 298K 
+!    ACID DISSOCIATION CONSTANT AT 298K
 !     [mole/liter of liquid water]
 !     Referencias: Barth et al. JGR 112, D13310 2007
 !     Martell and Smith, 1976, Critical stability
@@ -8372,7 +8374,7 @@ loop2: DO l = 1,nspecies_HL
           c2  =   dhr(l)
           c3  =   ak0(l)
           c4  =   dak(l)
-          found = 1     
+          found = 1
           EXIT loop2
         ENDIF
        enddo loop2
@@ -8424,7 +8426,7 @@ loop2: DO l = 1,nspecies_HL
    integer, optional, intent(out) :: rc                   ! Error return code:
 
 
-! !DESCRIPTION: Prepares variables and calls the RPMARES (thermodynamics module) 
+! !DESCRIPTION: Prepares variables and calls the RPMARES (thermodynamics module)
 !
 ! !REVISION HISTORY:
 !
@@ -8514,7 +8516,7 @@ loop2: DO l = 1,nspecies_HL
 ! !INPUT PARAMETERS:
    real(kind=DP) :: SO4              ! Total sulfate in micrograms / m**3
    real(kind=DP) :: GNO3             ! Gas-phase nitric acid in micrograms / m**3
-   real(kind=DP) :: GNH3             ! Gas-phase ammonia in micrograms / m**3 
+   real(kind=DP) :: GNH3             ! Gas-phase ammonia in micrograms / m**3
    real(kind=DP) :: RH               ! Fractional relative humidity
    real(kind=DP) :: TEMP             ! Temperature in Kelvin
    real(kind=DP) :: ASO4             ! Aerosol sulfate in micrograms / m**3
@@ -8627,15 +8629,15 @@ loop2: DO l = 1,nspecies_HL
 !   F.Binkowski 8/1/97    Changed minimum sulfate from 0.0 to 1.0e-6 i.e.
 !                         1 picogram per cubic meter
 !   F.Binkowski 2/23/98   Changes to code made by Ingmar Ackermann to
-!                         deal with precision problems on workstations 
+!                         deal with precision problems on workstations
 !                         incorporated in to this version.  Also included
-!                         are his improved descriptions of variables. 
-!  F. Binkowski 8/28/98   changed logic as follows: 
+!                         are his improved descriptions of variables.
+!  F. Binkowski 8/28/98   changed logic as follows:
 !                         If iterations fail, initial values of nitrate
-!                          are retained. 
+!                          are retained.
 !                         Total mass budgets are changed to account for gas
 !                         phase returned.
-!  F.Binkowski 10/01/98   Removed setting RATIO to 5 for low to 
+!  F.Binkowski 10/01/98   Removed setting RATIO to 5 for low to
 !                         to zero sulfate sulfate case.
 !  F.Binkowski 01/10/2000 reconcile versions
 !
@@ -8649,7 +8651,7 @@ loop2: DO l = 1,nspecies_HL
 !                          as REAL*8's.  Cleaned up comments.  Also now force
 !                          double precision explicitly with "D" exponents.
 !  P. Le Sager and        Bug fix for low ammonia case -- prevent floating
-!  R. Yantosca 04/10/2008  point underflow and NaN's. 
+!  R. Yantosca 04/10/2008  point underflow and NaN's.
 !  S. Steenrod 04/15/2010 Modified to include into GMI model
 !  E. Sherman  08/06/2020 Moved to GOCART2G process library
 
@@ -8812,7 +8814,7 @@ loop2: DO l = 1,nspecies_HL
                                !   NO3-); (3, HSO4-)  (moles / kg water)
    real(kind=DP)  :: CRUTES( 3 )      ! Coefficients and roots of
    real(kind=DP)  :: GAMS( 2, 3 )     ! Array of activity coefficients
-   real(kind=DP)  :: TMASSHNO3        ! Total nitrate (vapor and particle) 
+   real(kind=DP)  :: TMASSHNO3        ! Total nitrate (vapor and particle)
    real(kind=DP)  :: GNO3_IN, ANO3_IN
    character (len=75) :: err_msg
 
@@ -8824,7 +8826,7 @@ loop2: DO l = 1,nspecies_HL
 
       rc = __SUCCESS__
 
-      ! For extremely low relative humidity ( less than 1% ) set the 
+      ! For extremely low relative humidity ( less than 1% ) set the
       ! water content to a minimum and skip the calculation.
       IF ( RH .LT. 0.01 ) THEN
          AH2O = FLOOR
@@ -8873,7 +8875,7 @@ loop2: DO l = 1,nspecies_HL
       IRH = MIN( 99, IRH )
 
       !=================================================================
-      ! Specify the equilibrium constants at  correct temperature.  
+      ! Specify the equilibrium constants at  correct temperature.
       ! Also change units from ATM to MICROMOLE/M**3 (for KAN, KPH, and K3 )
       ! Values from Kim et al. (1993) except as noted.
       ! Equilibrium constant in Kim et al. (1993)
@@ -8889,7 +8891,7 @@ loop2: DO l = 1,nspecies_HL
 
       !=================================================================
       ! Equilibrium Relation
-      ! 
+      !
       ! HSO4-(aq)         = H+(aq)   + SO4--(aq)  ; K2SA
       ! NH3(g)            = NH3(aq)               ; KPH
       ! NH3(aq) + H2O(aq) = NH4+(aq) + OH-(aq)    ; K1A
@@ -8933,7 +8935,7 @@ loop2: DO l = 1,nspecies_HL
       GAMAAN = 1.0d0
       GAMOLD = 1.0d0
 
-      ! If there is very little sulfate and  nitrate 
+      ! If there is very little sulfate and  nitrate
       ! set concentrations to a very small value and return.
       IF ( ( TSO4 .LT. MINSO4 ) .AND. ( TNO3 .LT. MINNO3 ) ) THEN
          ASO4  = MAX( FLOOR, ASO4  )
@@ -8980,7 +8982,7 @@ loop2: DO l = 1,nspecies_HL
         IF ( WFRAC .LT. 0.2d0 ) THEN
 
            ! "dry" ammonium sulfate and ammonium nitrate
-           ! compute free ammonia 
+           ! compute free ammonia
            FNH3 = TNH4 - TWOSO4
            CC   = TNO3 * FNH3 - K3
 
@@ -8993,7 +8995,7 @@ loop2: DO l = 1,nspecies_HL
               DISC = BB * BB - 4.0d0 * CC
 
               ! Check for complex roots of the quadratic
-              ! set retain initial values of nitrate and RETURN 
+              ! set retain initial values of nitrate and RETURN
               ! if complex roots are found
               IF ( DISC .LT. 0.0d0 ) THEN
                  XNO3  = 0.0d0
@@ -9053,7 +9055,7 @@ loop2: DO l = 1,nspecies_HL
            BB    = TWOSO4 + KW2 * ( TNO3 + TNH4 - TWOSO4 )
            CC    = -KW2 * TNO3 * ( TNH4 - TWOSO4 )
 
-           ! This is a quadratic for XNO3 [MICROMOLES / M**3] 
+           ! This is a quadratic for XNO3 [MICROMOLES / M**3]
            ! of nitrate in solution
            DISC = BB * BB - 4.0d0 * AA * CC
 
@@ -9095,7 +9097,7 @@ loop2: DO l = 1,nspecies_HL
            CALL AWATER ( IRH, TSO4, YNH4, XNO3, AH2O )
 
            ! ZSR relationship is used to set water levels. Units are
-           ! 10**(-6) kg water/ (cubic meter of air).  The conversion 
+           ! 10**(-6) kg water/ (cubic meter of air).  The conversion
            ! from micromoles to moles is done by the units of WH2O.
            WH2O = 1.0d-3 * AH2O
 
@@ -9105,7 +9107,7 @@ loop2: DO l = 1,nspecies_HL
            MNH4 = 2.0d0 * MAS + MAN
            YNH4 = MNH4 * WH2O
 
-           ! MAS, MAN and MNH4 are the aqueous concentrations of sulfate, 
+           ! MAS, MAN and MNH4 are the aqueous concentrations of sulfate,
            ! nitrate, and ammonium in molal units (moles/(kg water) ).
            STION    = 3.0d0 * MAS + MAN
            CAT( 1 ) = 0.0d0
@@ -9152,12 +9154,12 @@ loop2: DO l = 1,nspecies_HL
         RETURN
 
       !================================================================
-      ! Low Ammonia Case 
+      ! Low Ammonia Case
       !
       ! Coded by Dr. Francis S. Binkowski 12/8/91.(4/26/95)
       ! modified 8/28/98
       ! modified 04/09/2001
-      !       
+      !
       ! All cases covered by this logic
       !=================================================================
       ELSE
@@ -9167,7 +9169,7 @@ loop2: DO l = 1,nspecies_HL
          WH2O = 1.0d-3 * AH2O
          ZH2O = AH2O
 
-         ! convert 10**(-6) kg water/(cubic meter of air) to micrograms 
+         ! convert 10**(-6) kg water/(cubic meter of air) to micrograms
          ! of water per cubic meter of air (1000 g = 1 kg)
          ! in sulfate rich case, preferred form is HSO4-
          !ASO4 = TSO4 * MWSO4
@@ -9180,13 +9182,13 @@ loop2: DO l = 1,nspecies_HL
 
          !==============================================================
          ! *** Examine special cases and return if necessary.
-         !         
-         ! FSB For values of RATIO less than 0.5 do no further 
-         ! calculations.  The code will cycle and still predict the 
-         ! same amount of ASO4, ANH4, ANO3, AH2O so terminate early 
+         !
+         ! FSB For values of RATIO less than 0.5 do no further
+         ! calculations.  The code will cycle and still predict the
+         ! same amount of ASO4, ANH4, ANO3, AH2O so terminate early
          ! to swame computation
          !==============================================================
-         IF ( RATIO .LT. 0.5d0 ) RETURN ! FSB 04/09/2001 
+         IF ( RATIO .LT. 0.5d0 ) RETURN ! FSB 04/09/2001
 
          ! Check for zero water.
          IF ( WH2O .EQ. 0.0d0 ) RETURN
@@ -9197,11 +9199,11 @@ loop2: DO l = 1,nspecies_HL
          ! greater than 11.0 because the model parameters break down
          !### IF ( ZSO4 .GT. 11.0 ) THEN
          !IF ( ZSO4 .GT. 9.0 ) THEN ! 18 June 97
-         !IF ( ZSO4 .GT. 9.d0 ) THEN ! H. Bian 24 June 2015 
-         IF ( ZSO4 .GT. 9.00 ) THEN ! H. Bian 24 June 2015 
+         !IF ( ZSO4 .GT. 9.d0 ) THEN ! H. Bian 24 June 2015
+         IF ( ZSO4 .GT. 9.00 ) THEN ! H. Bian 24 June 2015
             RETURN
          ENDIF
-         IF ( ZSO4 .GT. 0.1d0 .and. TEMP .le. 220.d0) THEN ! H. Bian 24 June 2015 
+         IF ( ZSO4 .GT. 0.1d0 .and. TEMP .le. 220.d0) THEN ! H. Bian 24 June 2015
             RETURN
          ENDIF
 
@@ -9269,7 +9271,7 @@ loop2: DO l = 1,nspecies_HL
             ! Update water
             CALL AWATER ( IRH, TSO4, YNH4, XNO3, AH2O )
 
-            ! Convert 10**(-6) kg water/(cubic meter of air) to micrograms 
+            ! Convert 10**(-6) kg water/(cubic meter of air) to micrograms
             ! of water per cubic meter of air (1000 g = 1 kg)
             WH2O     = 1.0d-3 * AH2O
             CAT( 1 ) = HPLUS
@@ -9287,8 +9289,8 @@ loop2: DO l = 1,nspecies_HL
 
             !------------------------------------------------------------
             ! Add robustness: now check if GAMANA or GAMAS1 is too small
-            ! for the division in RKNA and RK2SA. If they are, return w/ 
-            ! original values: basically replicate the procedure used 
+            ! for the division in RKNA and RK2SA. If they are, return w/
+            ! original values: basically replicate the procedure used
             ! after the current DO-loop in case of no-convergence
             ! (phs, bmy, rjp, 4/10/08)
             !--------------------------------------------------------------
@@ -9399,19 +9401,19 @@ loop2: DO l = 1,nspecies_HL
 !
 !     coded by Dr. Francis S. Binkowski, 4/8/96.
 !
-! *** modified 05/30/2000 
-!     The use of two values of mfs at an ammonium to sulfate ratio 
-!     representative of ammonium sulfate led to an minor inconsistancy 
+! *** modified 05/30/2000
+!     The use of two values of mfs at an ammonium to sulfate ratio
+!     representative of ammonium sulfate led to an minor inconsistancy
 !     in nitrate behavior as the ratio went from a value less than two
-!     to a value greater than two and vice versa with either ammonium 
-!     held constant and sulfate changing, or sulfate held constant and 
+!     to a value greater than two and vice versa with either ammonium
+!     held constant and sulfate changing, or sulfate held constant and
 !     ammonium changing. the value of Chan et al. (1992) is the only value
-!     now used. 
+!     now used.
 !
 ! *** Modified 09/25/2002
 !     Ported into "rpmares_mod.f".  Now declare all variables with REAL*8.
-!     Also cleaned up comments and made cosmetic changes.  Force double 
-!     precision explicitly with "D" exponents. 
+!     Also cleaned up comments and made cosmetic changes.  Force double
+!     precision explicitly with "D" exponents.
 !******************************************************************************
 !
       ! Arguments
@@ -9433,10 +9435,10 @@ loop2: DO l = 1,nspecies_HL
       REAL*8, PARAMETER :: MWANO3 = MWNO3 + MWNH4
 
       !=================================================================
-      ! The polynomials use data for aw as a function of mfs from Tang 
-      ! and Munkelwitz, JGR 99: 18801-18808, 1994.  The polynomials were 
+      ! The polynomials use data for aw as a function of mfs from Tang
+      ! and Munkelwitz, JGR 99: 18801-18808, 1994.  The polynomials were
       ! fit to Tang's values of water activity as a function of mfs.
-      ! 
+      !
       ! *** coefficients of polynomials fit to Tang and Munkelwitz data
       !     now give mfs as a function of water activity.
       !=================================================================
@@ -9515,16 +9517,16 @@ loop2: DO l = 1,nspecies_HL
          !
          ! Crystallization is done as follows:
          !
-         ! For 1.5 <= x, crystallization is assumed to occur 
+         ! For 1.5 <= x, crystallization is assumed to occur
          ! at rh = 0.4
          !
-         ! For x <= 1.0, crystallization is assumed to occur at an 
-         ! rh < 0.01, and since the code does not allow ar rh < 0.01, 
+         ! For x <= 1.0, crystallization is assumed to occur at an
+         ! rh < 0.01, and since the code does not allow ar rh < 0.01,
          ! crystallization is assumed not to occur in this range.
          !
-         ! For 1.0 <= x <= 1.5 the crystallization curve is a straignt 
-         ! line from a value of y15 at rh = 0.4 to a value of zero at 
-         ! y1. From point B to point A in the diagram.  The algorithm 
+         ! For 1.0 <= x <= 1.5 the crystallization curve is a straignt
+         ! line from a value of y15 at rh = 0.4 to a value of zero at
+         ! y1. From point B to point A in the diagram.  The algorithm
          ! does a double interpolation to calculate the amount of
          ! water.
          !
@@ -9575,11 +9577,11 @@ loop2: DO l = 1,nspecies_HL
       ELSE                                 ! 2.0 <= x changed 12/11/2000 by FSB
 
          !==============================================================
-         ! Regime where ammonium sulfate and ammonium nitrate are 
+         ! Regime where ammonium sulfate and ammonium nitrate are
          ! in solution.
-         ! 
+         !
          ! following cf&s for both ammonium sulfate and ammonium nitrate
-         ! check for crystallization here. their data indicate a 40% 
+         ! check for crystallization here. their data indicate a 40%
          ! value is appropriate.
          !==============================================================
          Y2 = 0.0d0
@@ -9625,7 +9627,7 @@ loop2: DO l = 1,nspecies_HL
       REAL*8             :: Y
 
       !=================================================================
-      ! nh3_POLY4 begins here! 
+      ! nh3_POLY4 begins here!
       !=================================================================
       Y = A(1) + X * ( A(2) + X * ( A(3) + X * ( A(4) )))
 
@@ -9643,7 +9645,7 @@ loop2: DO l = 1,nspecies_HL
       REAL*8             :: Y
 
       !=================================================================
-      ! nh3_POLY6 begins here! 
+      ! nh3_POLY6 begins here!
       !=================================================================
       Y = A(1) + X * ( A(2) + X * ( A(3) + X * ( A(4) +  &
      &           X * ( A(5) + X * ( A(6)  )))))
@@ -9666,7 +9668,7 @@ loop2: DO l = 1,nspecies_HL
 ! *** modified 2/23/98 by fsb to incorporate Dr. Ingmar Ackermann's
 !     recommendations for setting a0, a1,a2 as real*8 variables.
 !
-! Modified by Bob Yantosca (10/15/02) 
+! Modified by Bob Yantosca (10/15/02)
 ! - Now use upper case / white space
 ! - force double precision with "D" exponents
 ! - updated comments / cosmetic changes
@@ -9845,7 +9847,7 @@ loop2: DO l = 1,nspecies_HL
       ! ARGUMENTS and their descriptions
       !=================================================================
       REAL*8, optional   :: MOLNU            ! tot # moles of all ions
-      REAL*8, optional   :: PHIMULT          ! multicomponent paractical 
+      REAL*8, optional   :: PHIMULT          ! multicomponent paractical
                                              !   osmotic coef
       REAL*8             :: CAT(NCAT)        ! cation conc in moles/kg (input)
       REAL*8             :: AN(NAN)          ! anion conc in moles/kg (input)
@@ -10088,7 +10090,7 @@ loop2: DO l = 1,nspecies_HL
 ! !DESCRIPTION:
 !  Output error messages, and exits if requested.
 !
-! !AUTHOR: 
+! !AUTHOR:
 !  Jules Kouatchou
 !
 ! !REVISION HISTORY:
@@ -10147,14 +10149,14 @@ loop2: DO l = 1,nspecies_HL
 ! !INPUT/OUTPUT PARAMETERS:
    integer, intent(in) :: im_World, jm_World  ! number of global grid cells
    real,    intent(in) :: res_value(:)        ! array with the resolution dependent values:
-                                              ! the 'a', 'b', ..., 'e' resolution values have 
+                                              ! the 'a', 'b', ..., 'e' resolution values have
                                               ! indexes 1, 2, ..., 5.
 
 ! !OUTPUT PARAMETERS:
    integer, intent(inout) :: rc               ! return code
 
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !
 ! !REVISION HISTORY:
 !
@@ -10278,9 +10280,9 @@ loop2: DO l = 1,nspecies_HL
        integer, intent(in) :: nhms
        real, intent(in)    :: cdt       ! time step in seconds
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !
-!      Applies diurnal cycle to biomass emissions.       
+!      Applies diurnal cycle to biomass emissions.
 !
 ! !DESCRIPTION:
 !
@@ -10301,7 +10303,7 @@ loop2: DO l = 1,nspecies_HL
        integer, parameter :: N = 240
        real,    parameter :: DT = 86400. / N
 
-!      Apply flat diurnal cycle for boreal forests as a 
+!      Apply flat diurnal cycle for boreal forests as a
 !      temporary solution to prevent very high aerosol
 !      optical depth during the day
        real,    parameter :: Boreal(N) = 1.0
@@ -10345,7 +10347,7 @@ loop2: DO l = 1,nspecies_HL
 !         0.2497, 0.2412, 0.2326, 0.2240, 0.2153, 0.2066, &
 !         0.1979, 0.1894, 0.1809, 0.1726, 0.1643, 0.1562, &
 !         0.1482, 0.1404, 0.1326, 0.1250, 0.1175, 0.1101, &
-!         0.1028, 0.0956, 0.0886, 0.0818, 0.0751, 0.0687 /)       
+!         0.1028, 0.0956, 0.0886, 0.0818, 0.0751, 0.0687 /)
        real,    parameter :: NonBoreal(N) = &
        (/ 0.0121, 0.0150, 0.0172, 0.0185, 0.0189, 0.0184, &
           0.0174, 0.0162, 0.0151, 0.0141, 0.0133, 0.0126, &


### PR DESCRIPTION
Work by @aoloso has found that the GNU compiler does not work with GOCART2G. Part of the issue was in Chem::Achem and is detailed in https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/161

TL;DR This PR with https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/161 allows GNU to work and is zero-diff!

---

Here in GOCART we need another fix. The Fortran construct consisting of, for example:
```fortran
real, optional, pointer, dimension(:,:,:), intent(inout)   :: exttau    ! ext. AOT at 550 nm
...
if (present(exttau) .and. associated(exttau)) then
```
is a Fortran Gotcha. The reason is that the compiler is free to evaluate that if-test by testing the `associate()` first. And if the pointer is not `associated()`, then GNU (at least) is not happy as associated on a non-present pointer is...ill-defined at best?

But, thanks to @tclune reaching out to Fortran Committee, an interesting solution was presented. This construct:
```fortran
real, optional, dimension(:,:,:), intent(inout)   :: exttau    ! ext. AOT at 550 nm
...
if (present(exttau)) then
```
is allowed and legal. Per Malcolm Cohen (of NAG and [that book on your shelf](https://global.oup.com/academic/product/modern-fortran-explained-9780198811886?cc=us&lang=en&)):

> disassociated pointers are “absent” to nonpointer optionals

So this means we can remove the `pointer` declaration and then use the fact that the Standard says a null'd pointer passed as a nonpointer optional is not-present!


