### PR TITLE
Update sediment flux formulation in FENGSHA dust scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Updated FENGSHA dust flux according to Webb et al., Aeolian Res. 42 (2020) 100560
+
 ## [2.0.2] - 2021-1-07
 
 ### Changed

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -349,8 +349,9 @@ CONTAINS
    real                  :: h
    real                  :: kvh
    real                  :: q
+   real                  :: rustar
    real                  :: total_emissions
-   real                  :: u_thrs, u_thresh
+   real                  :: u_sum, u_thresh
 
 ! !CONSTANTS:
    real, parameter       :: ssm_thresh = 1.e-02    ! emit above this erodibility threshold [1]
@@ -403,7 +404,7 @@ CONTAINS
 
          !  Compute threshold wind friction velocity using drag partition
          !  -------------------------------------------------------------
-         u_thrs = uthrs(i,j) / rdrag(i,j)
+         rustar = rdrag(i,j) * ustar(i,j)
 
          !  Now compute size-dependent total emission flux
          !  ----------------------------------------------
@@ -414,12 +415,13 @@ CONTAINS
 
            ! Adjust threshold
            ! ----------------
-           u_thresh = u_thrs * h
+           u_thresh = uthrs(i,j) * h
 
-           ! Compute Horizontal Saltation Flux
-           ! ---------------------------------
-           q = max(0., ustar(i,j) * (ustar(i,j) - u_thresh) &
-                                  * (ustar(i,j) + u_thresh))
+           u_sum = rustar + u_thresh
+
+           ! Compute Horizontal Saltation Flux according to Eq (9) in Webb et al. (2020)
+           ! ---------------------------------------------------------------------------
+           q = max(0., rustar - u_thresh) * u_sum * u_sum
 
            ! Distribute emissions to bins and convert to mass flux (kg s-1)
            ! --------------------------------------------------------------

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -394,17 +394,10 @@ CONTAINS
          ! -----------------------
          emissions(i,j,nbins) = alpha * fracland * (ssm(i,j) ** gamma) &
                               * airdens(i,j) * kvh / grav
-       end if
 
-     end do
-   end do
-
-!  Now compute size-dependent total emission flux
-!  ----------------------------------------------
-   do n = 1, nbins
-     do j = ilb(2), iub(2)
-       do i = ilb(1), iub(1)
-         if (emissions(i,j,nbins) > 0.) then
+         !  Now compute size-dependent total emission flux
+         !  ----------------------------------------------
+         do n = 1, nbins
            ! Fecan moisture correction
            ! -------------------------
            h = moistureCorrectionFecan(slc(i,j), sand(i,j), clay(i,j), rhop(n))
@@ -420,8 +413,10 @@ CONTAINS
            ! Distribute emissions to bins and convert to mass flux (kg s-1)
            ! --------------------------------------------------------------
            emissions(i,j,n) = distribution(n) * emissions(i,j,nbins) * q
-         end if
-       end do
+         end do
+
+       end if
+
      end do
    end do
 


### PR DESCRIPTION
This PR implements an improvement to the streamwise sediment flux density formulation used by the FENGSHA dust scheme, based on recent work by Webb et al. (_Aeolian Research_, Vol. 42, 2020, 100560, https://doi.org/10.1016/j.aeolia.2019.100560).

The changes have been tested on NOAA RDHPCS platforms and validated by NOAA/ARL.