### PR TITLE
Fixes #109. Correct Dust ExtData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2021-02-28
+
+### Fixed
+
+- Fix for bad entries in `DU2G_GridComp_ExtData.rc` (see Issue #109)
+
 ## [2.0.4] - 2021-02-18
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
         GOCART
-        VERSION 2.0.4
+        VERSION 2.0.5
         LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridComp_ExtData.rc
@@ -22,30 +22,30 @@ climdu004           'kg kg-1'            Y        N               0             
 climdu005           'kg kg-1'            Y        N               0              0.0      1.0     du005      ExtData/chemistry/MERRAero/v0.0.0/L72/dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
 
 # DU data - 2D
-climDUDP001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP001    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUWT001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT001    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSD001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD001    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSV001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV001    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUDP001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP001    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUWT001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT001    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSD001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD001    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSV001         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV001    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
 
-climDUDP002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP002    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUWT002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT002    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSD002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD002    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSV002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV002    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUDP002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP002    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUWT002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT002    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSD002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD002    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSV002         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV002    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
 
-climDUDP003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP003    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUWT003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT003    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSD003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD003    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSV003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV003    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUDP003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP003    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUWT003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT003    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSD003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD003    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSV003         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV003    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
 
-climDUDP004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP004    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUWT004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT004    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSD004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD004    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSV004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV004    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUDP004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP004    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUWT004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT004    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSD004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD004    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSV004         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV004    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
 
-climDUDP005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP005    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUWT005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT005    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSD005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD005    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
-climDUSV005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV005    ExtData/chemistry/MERRAero/v0.0.0/sfcdR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUDP005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUDP005    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUWT005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUWT005    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSD005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSD005    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+climDUSV005         'kg m-2 s-1'         Y        N               0              0.0      1.0     DUSV005    ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
 
 %%
 


### PR DESCRIPTION
This PR fixes some ExtData lines for Dust by adding in a missing /.

This is zero-diff in the sense that nothing was ever using these lines (yet, seems to be for data_driven), but it is still a bug.

Closes #109 

NOTE: This is a hotfix onto `main` and will then need to be pulled into `develop`.