### PR TITLE
Update CODEOWNERS and update components to match GEOSgcm v10.22.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,28 +7,12 @@
 * @GEOS-ESM/aerosol-team
 
 # NOAA Extras are Tom, Weiyuan for now
-/CCPP/                  @tclune @weiyuan-jiang
-/ESMF/Aerosol_GridComp/ @tclune @weiyuan-jiang
-/ESMF/NUOPC/            @tclune @weiyuan-jiang
-/ESMF/Shared/           @tclune @weiyuan-jiang
-/ESMF/UFS/              @tclune @weiyuan-jiang
-
-/ESMF/GOCART_GridComp/   @GEOS-ESM/aerosol-team
-
-# GOCART2G is Elliot for now
-/ESMF/GOCART2G_GridComp/ @GEOS-ESM/aerosol-team
+/CCPP/                  @GEOS-ESM/mapl-team
+/ESMF/Aerosol_GridComp/ @GEOS-ESM/mapl-team
+/ESMF/NUOPC/            @GEOS-ESM/mapl-team
+/ESMF/UFS/              @GEOS-ESM/mapl-team
 
 # The CMake Team should know/approve these
 /.github/    @GEOS-ESM/cmake-team
 /.circleci/  @GEOS-ESM/cmake-team
 /.codebuild/ @GEOS-ESM/cmake-team
-
-# The GEOS CMake Team should be notified about and approve config changes
-/config/ @GEOS-ESM/cmake-team
-
-# The Python Transition Team will own Python files
-# until the Python 3 transition is completed
-*.py @GEOS-ESM/python-transition-team
-
-# The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,12 +7,12 @@
 * @GEOS-ESM/aerosol-team
 
 # NOAA Extras are Tom, Weiyuan for now
-/CCPP/                  @GEOS-ESM/mapl-team
-/ESMF/Aerosol_GridComp/ @GEOS-ESM/mapl-team
-/ESMF/NUOPC/            @GEOS-ESM/mapl-team
-/ESMF/UFS/              @GEOS-ESM/mapl-team
+/CCPP/                  @GEOS-ESM/mapl-team @amdasilva
+/ESMF/Aerosol_GridComp/ @GEOS-ESM/mapl-team @amdasilva
+/ESMF/NUOPC/            @GEOS-ESM/mapl-team @amdasilva
+/ESMF/UFS/              @GEOS-ESM/mapl-team @amdasilva
 
 # The CMake Team should know/approve these
-/.github/    @GEOS-ESM/cmake-team
-/.circleci/  @GEOS-ESM/cmake-team
-/.codebuild/ @GEOS-ESM/cmake-team
+/.github/    @GEOS-ESM/cmake-team @amdasilva
+/.circleci/  @GEOS-ESM/cmake-team @amdasilva
+/.codebuild/ @GEOS-ESM/cmake-team @amdasilva

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `CODEOWNERS` file to make approvals less restrictive
 - Updated the CircleCI to use circleci-tools 0.13.0 orb
   - Moves CI to use Baselibs 6.2.13 needed by MAPL development
-- Update `components.yaml` to be in line with GEOSgcm v10.22.0
+- Update `components.yaml` to be in line with GEOSgcm v10.22.1
 - Updates to support Spack
 - Changed the handling of state variable names in multiple instances of component (see Issue #93)
 - Major refactoring of Mie table class. (see Issue #96)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This matches the styles currently used in MAPL (2 space indents in CMake and yaml, 4 spaces for Python)
 
 ### Changed
+
+- Update `CODEOWNERS` file to make approvals less restrictive
 - Updated the CircleCI to use circleci-tools 0.13.0 orb
   - Moves CI to use Baselibs 6.2.13 needed by MAPL development
 - Update `components.yaml` to be in line with GEOSgcm v10.22.0

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GOCART:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v3.11.0
+  tag: v3.13.0
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.10.0
+  tag: v3.12.0
   develop: develop
 
 ecbuild:
@@ -22,17 +22,17 @@ ecbuild:
 HEMCO:
   local: ./ESMF/HEMCO_GridComp@
   remote: ../HEMCO.git
-  branch: geos/v2.2.2
+  branch: geos/v2.2.3
 
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.5.1
+  tag: v1.5.3
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.18.0
+  tag: v2.19.0
   develop: develop


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file so that PR approvals here are less onerous. Only the CI and weird CCPP/UFS directories will need approval from non-aerosol team members.

NOTE: I think this will not truly take effect until this change is in `main` due to the way GitHub works. (Only the `CODEOWNERS` on `main` matters to GitHub. Annoying, but it's how they do things.)

---

ETA: I've also updated `components.yaml` to match that of GEOSgcm v10.22.1. The main thing is to get MAPL 2.19.0 which is needed for the new AGC code that is in `develop`.