### PR TITLE
Updates for Spack Support, Round 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This matches the styles currently used in MAPL (2 space indents in CMake and yaml, 4 spaces for Python)
 
 ### Changed
+
 - Updated the CircleCI to use circleci-tools 0.13.0 orb
   - Moves CI to use Baselibs 6.2.13 needed by MAPL development
-- Update `components.yaml` to be in line with GEOSgcm v10.22.0
+- Update `components.yaml` to be in line with GEOSgcm v10.22.1
 - Updates to support Spack
 - Changed the handling of state variable names in multiple instances of component (see Issue #93)
 - Major refactoring of Mie table class. (see Issue #96)

--- a/ESMF/GOCART_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART_GridComp/CMakeLists.txt
@@ -16,16 +16,15 @@ set (srcs
 
 set (resource_files
    GOCARTdata_AerRegistry.rc
-   ) 
+   )
 
-install( FILES ${resource_files} 
+install( FILES ${resource_files}
    DESTINATION etc
    )
 
-set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu)
+set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu esmf)
 esma_add_library (${this}
   SRCS ${srcs}
   SUBCOMPONENTS ${alldirs}
-  DEPENDENCIES ${dependencies}
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES ${dependencies})
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GOCART:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v3.11.0
+  tag: v3.13.0
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.10.0
+  tag: v3.12.0
   develop: develop
 
 ecbuild:
@@ -22,17 +22,17 @@ ecbuild:
 HEMCO:
   local: ./ESMF/HEMCO_GridComp@
   remote: ../HEMCO.git
-  branch: geos/v2.2.2
+  branch: geos/v2.2.3
 
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.5.1
+  tag: v1.5.3
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.18.0
+  tag: v2.19.0
   develop: develop


### PR DESCRIPTION
Due to insufficient grepping on my part, some remnants of the
"not-canonical" CMake still remain. Apparently these were not necessary
changes for Spack, but they are changes that unify the CMake style of
GEOS to be more like "correct" CMake.

In this go-around, it is mainly finding `INC_ESMF` which I apparently
forgot to grep for last time (I was focused on NetCDF), and some
non-canonical OpenMP calls.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for the meta-issue.