### PR TITLE
Closes #161. Update CI and components.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ workflows:
           repo: GOCART
           buildtarget: GOCART2G_GridComp
           mepodevelop: true
+          develop_repos: GMAO_Shared
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
       # Build GEOSgcm
       - ci/build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+# Anchors to prevent forgetting to update a version
+baselibs_version: &baselibs_version v7.5.0
+bcs_version: &bcs_version v10.22.3
+
 orbs:
   ci: geos-esm/circleci-tools@1
 
@@ -14,6 +18,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+          baselibs_version: *baselibs_version
           repo: GOCART
           buildtarget: GOCART2G_GridComp
           mepodevelop: true
@@ -27,6 +32,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+          baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,64 +1,32 @@
 version: 2.1
 
 orbs:
-  circleci-tools: geos-esm/circleci-tools@0.13.0
+  ci: geos-esm/circleci-tools@1
 
 workflows:
   build-and-test:
     jobs:
-      - build-GOCART2G:
+      # Build GOCART
+      - ci/build:
           name: build-GOCART2G-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          context:
-            - docker-hub-creds
-      - build-GEOSgcm:
+          repo: GOCART
+          buildtarget: GOCART2G_GridComp
+          mepodevelop: true
+          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
+      # Build GEOSgcm
+      - ci/build:
           name: build-GEOSgcm-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          context:
-            - docker-hub-creds
-
-jobs:
-  build-GOCART2G:
-    parameters:
-      compiler:
-        type: string
-    executor: circleci-tools/<< parameters.compiler >>
-    working_directory: /root/project
-    steps:
-      - checkout:
-          path: GOCART
-      - circleci-tools/versions:
-          compiler: << parameters.compiler >>
-      - circleci-tools/mepoclone:
-          repo: GOCART
-      - circleci-tools/cmake:
-          repo: GOCART
-          compiler: << parameters.compiler >>
-      - circleci-tools/buildtarget:
-          repo: GOCART
-          target: GOCART2G_GridComp
-      - circleci-tools/compress_artifacts
-      - store_artifacts:
-          path: /logfiles
-
-  build-GEOSgcm:
-    parameters:
-      compiler:
-        type: string
-    executor: circleci-tools/<< parameters.compiler >>
-    working_directory: /root/project
-    steps:
-      - circleci-tools/checkout_fixture
-      - circleci-tools/mepoclone
-      - circleci-tools/mepodevelop
-      - circleci-tools/checkout_if_exists
-      - circleci-tools/cmake:
-          compiler: << parameters.compiler >>
-      - circleci-tools/buildinstall
-      - circleci-tools/compress_artifacts
-      - store_artifacts:
-          path: /logfiles
+          repo: GEOSgcm
+          checkout_fixture: true
+          mepodevelop: true
+          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This matches the styles currently used in MAPL (2 space indents in CMake and yaml, 4 spaces for Python)
 
 ### Fixed
+
 - Added protection guard for pointer DU_SRC. fixed issue #148
 - Initialized pointers by allocation instead of assignment. fixed issue #127
-- Removed ExtData2G yaml files from all AMIP.20C directories as these are not needed anymore 
+- Removed ExtData2G yaml files from all AMIP.20C directories as these are not needed anymore
 
 ### Changed
 
@@ -23,12 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in getAerosolSum
 - more hard-coded name changes for Issue #93
 - Fixed bug in MieQuery.H, shape of not present variable is used
-- remove logic dinosaur "goto" 
+- remove logic dinosaur "goto"
 - Removed some print statements that have been commented out.
 - Update `CODEOWNERS` file to make approvals less restrictive
-- Updated the CircleCI to use circleci-tools 0.13.0 orb
+- Updated the CircleCI to use circleci-tools v1 orb
   - Moves CI to use Baselibs 6.2.13 needed by MAPL development
-- Update `components.yaml` to be in line with GEOSgcm v10.22.1
+- Update `components.yaml` to be in line with GEOSgcm v10.22.3
 - Updates to support Spack
 - Changed the handling of state variable names in multiple instances of component (see Issue #93)
 - Major refactoring of Mie table class. (see Issue #96)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `CODEOWNERS` file to make approvals less restrictive
 - Updated the CircleCI to use circleci-tools v1 orb
   - Moves CI to use Baselibs 6.2.13 needed by MAPL development
-- Update `components.yaml` to be in line with GEOSgcm v10.22.3
+- Update `components.yaml` to be in line with GEOSgcm v10.22.4
 - Updates to support Spack
 - Changed the handling of state variable names in multiple instances of component (see Issue #93)
 - Major refactoring of Mie table class. (see Issue #96)

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.12.0
+  tag: v3.16.0
   develop: develop
 
 ecbuild:
@@ -27,12 +27,12 @@ HEMCO:
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.5.3
+  tag: v1.5.5
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.19.0
+  tag: v2.21.3
   develop: develop

--- a/components.yaml
+++ b/components.yaml
@@ -27,12 +27,12 @@ HEMCO:
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.5.5
+  tag: v1.5.6
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.23.0
+  tag: v2.23.1
   develop: develop

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GOCART:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v3.13.0
+  tag: v4.2.0
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.16.0
+  tag: v3.17.0
   develop: develop
 
 ecbuild:
@@ -34,5 +34,5 @@ GMAO_Shared:
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.21.3
+  tag: v2.23.0
   develop: develop


### PR DESCRIPTION
This PR does two things:

1. Updates the CI to use the new v1 orb like (most of) the rest of GEOS
2. Updates the `components.yaml` to match GEOSgcm v10.22.4