### PR TITLE
Fixes #165. Add SetVM to UFS Aerosol Cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This matches the styles currently used in MAPL (2 space indents in CMake and yaml, 4 spaces for Python)
 
 ### Fixed
+
 - Added protection guard for pointer DU_SRC. fixed issue #148
 - Initialized pointers by allocation instead of assignment. fixed issue #127
-- Removed ExtData2G yaml files from all AMIP.20C directories as these are not needed anymore 
+- Removed ExtData2G yaml files from all AMIP.20C directories as these are not needed anymore
 
 ### Changed
 
@@ -23,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in getAerosolSum
 - more hard-coded name changes for Issue #93
 - Fixed bug in MieQuery.H, shape of not present variable is used
-- remove logic dinosaur "goto" 
+- remove logic dinosaur "goto"
 - Removed some print statements that have been commented out.
 - Update `CODEOWNERS` file to make approvals less restrictive
 - Updated the CircleCI to use circleci-tools 0.13.0 orb
@@ -40,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up optional keyword arguments in call to Mie calculator for aerosol
   radiative forcing calculation; zero diff change
 - Simplified loading of radiation MieTables.
-
+- Added SetVM in UFS Aerosol Cap for ESMF managed threading
 
 ## [2.0.7] - 2021-04-29
 

--- a/ESMF/UFS/Aerosol_Cap.F90
+++ b/ESMF/UFS/Aerosol_Cap.F90
@@ -6,6 +6,7 @@ module Aerosol_Cap
   use NUOPC
   use NUOPC_Model, only : &
     NUOPC_ModelGet, &
+    SetVM, &
     model_routine_SS            => SetServices,          &
     model_routine_Run           => routine_Run,          &
     model_label_Advance         => label_Advance,        &
@@ -75,6 +76,7 @@ module Aerosol_Cap
   private
 
   public :: SetServices
+  public :: SetVM
 
 contains
 


### PR DESCRIPTION
Closes #165 

Per request of @junwang-noaa in #165, this adds `SetVM` to the UFS Aerosol Cap.

As long as this compiles, it should be fine for GEOS. We don't compile the UFS code, so it's a no-op for us.