### PR TITLE
Feature/mmanyin/delete code artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added protection guard for pointer DU_SRC. fixed issue #148
 - Initialized pointers by allocation instead of assignment. fixed issue #127
 - Removed ExtData2G yaml files from all AMIP.20C directories as these are not needed anymore
+- Removed declaration of Disable_Convection, no longer needed
 
 ### Changed
 

--- a/ESMF/GOCART_GridComp/GOCART_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/GOCART_GridCompMod.F90
@@ -20,8 +20,6 @@
    use Chem_UtilMod, only: Chem_UtilNegFiller
    use Aero_GridCompMod      ! Parent Aerosol component with IRF methods but no SetServices()
 
-   use ConvectionMod, only: Disable_Convection
-
    implicit none
    private
 


### PR DESCRIPTION
This is zero diff.
Remove the declaration of the routine "disable_convection", which is no longer used.