### PR TITLE
Fixes #176. Add extra esmf dependencies to CMake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # Anchors to prevent forgetting to update a version
 baselibs_version: &baselibs_version v7.5.0
-bcs_version: &bcs_version v10.22.3
+bcs_version: &bcs_version v10.22.5
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added protection guard for pointer DU_SRC. fixed issue #148
 - Initialized pointers by allocation instead of assignment. fixed issue #127
 - Removed ExtData2G yaml files from all AMIP.20C directories as these are not needed anymore
+- Added extra `esmf` to CMake files for UFS
 
 ### Changed
 

--- a/ESMF/GOCART2G_GridComp/GA_Environment/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/CMakeLists.txt
@@ -2,5 +2,5 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPL Chem_Shared2G Process_Library
+  DEPENDENCIES MAPL Chem_Shared2G Process_Library esmf
   )

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/CMakeLists.txt
@@ -2,10 +2,10 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library)
+  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library esmf)
 
-mapl_acg (${this}   SU2G_StateSpecs.rc 
-          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 
+mapl_acg (${this}   SU2G_StateSpecs.rc
+          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
           GET_POINTERS DECLARE_POINTERS)
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)

--- a/ESMF/Shared/CMakeLists.txt
+++ b/ESMF/Shared/CMakeLists.txt
@@ -4,9 +4,9 @@ set (srcs
   Chem_AeroGeneric.F90
   )
 
-esma_add_library(${this} 
-  SRCS ${srcs} 
-  DEPENDENCIES MAPL)
+esma_add_library(${this}
+  SRCS ${srcs}
+  DEPENDENCIES MAPL esmf)
 
 if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/@GSW )
     set (gsw_ECBUILD_SYSTEM_INCLUDED TRUE)


### PR DESCRIPTION
This PR is an attempt to fix an issue seen by our UFS colleagues building GOCART, see:

#174 
#176 

I have tested this and it is zero-diff since, well, the model built and I only changed CMake.

I guess what I need is @benjamin-cash or someone on the UFS side to test and see if it fixes their issue.