### PR TITLE
remove yaFyaml from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ if (NOT Baselibs_FOUND)
   find_package (GFTL REQUIRED)
   find_package (GFTL_SHARED REQUIRED)
   find_package (PFLOGGER QUIET)
-  find_package (YAFYAML REQUIRED)
 endif ()
 
 if (UFS_GOCART)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if (NOT Baselibs_FOUND)
   find_package (GFTL REQUIRED)
   find_package (GFTL_SHARED REQUIRED)
   find_package (PFLOGGER QUIET)
+  find_package (YAFYAML QUIET)
 endif ()
 
 if (UFS_GOCART)


### PR DESCRIPTION
We need to go though rigid library approval process to get library installed on NCEP operational platform. Because of this we would like to reduce the library dependency as much as possible. At this time we are using standard version of ExtData in ufs-weather-model with .rc files, yaFyaml is not required to build MAPL or GOCART, we'd like to remove yaFyaml from CMakeLists.txt.