### PR TITLE
Fixes #184. Remove unneeded GFE find_package calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,21 @@ workflows:
           mepodevelop: true
           develop_repos: GMAO_Shared
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
+      # Build GOCART like UFS
+      - ci/build:
+          name: build-GOCART2G-like-UFS-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          baselibs_version: *baselibs_version
+          repo: GOCART
+          buildtarget: GOCART2G_GridComp
+          mepodevelop: true
+          develop_repos: GMAO_Shared
+          extra_cmake_options: "-DBUILD_WITH_FLAP=OFF -DBUILD_WITH_PFLOGGER=OFF -DBUILD_SHARED_MAPL=OFF -DUSE_EXTDATA2G=OFF"
+          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
       # Build GEOSgcm
       - ci/build:
           name: build-GEOSgcm-on-<< matrix.compiler >>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Fixed  
+### Fixed
 
 ### Changed
 
+## [2.1.1] - 2022-09-16
+
+### Fixed
+
+- Remove GOCART requirement for gFTL, pFlogger and yaFyaml. These are requirements of MAPL. (#184)
+
+### Added
+
+- Added CI test for building GOCART like UFS does
 
 ## [2.1.0] - 2022-08-24
 
@@ -22,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This matches the styles currently used in MAPL (2 space indents in CMake and yaml, 4 spaces for Python)
 - Add YAML validator GitHub Action
   - This action makes sure all YAML files are valid (to a relaxed standard)
-- Initial implementation of offline simulator for 3D profiles of extinction based on the new GOCART2G-Mie interface. Work for the 2D simulator in progress. 
- 
+- Initial implementation of offline simulator for 3D profiles of extinction based on the new GOCART2G-Mie interface. Work for the 2D simulator in progress.
+
 ### Fixed
 
 - Added protection guard for pointer DU_SRC. fixed issue #148

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
         GOCART
-        VERSION 2.0.7
+        VERSION 2.1.1
         LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -57,14 +57,10 @@ if (NOT Baselibs_FOUND)
   if (NOT ESMF_FOUND)
     find_package (ESMF REQUIRED)
   endif ()
-
-  find_package (GFTL REQUIRED)
-  find_package (GFTL_SHARED REQUIRED)
-  find_package (PFLOGGER QUIET)
-  find_package (YAFYAML REQUIRED)
 endif ()
 
 if (UFS_GOCART)
+  find_package (GFTL_SHARED REQUIRED)
   find_package (MAPL REQUIRED)
   include(mapl_acg)
 elseif (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/ESMF/Shared/MAPL@")

--- a/ESMF/UFS/Aerosol_Internal_Mod.F90
+++ b/ESMF/UFS/Aerosol_Internal_Mod.F90
@@ -1,8 +1,6 @@
 module Aerosol_Internal_Mod
 
   use MAPL
-  use gFTL_StringIntegerMap
-  use gFTL_StringStringMap
 
   use Aerosol_Tracer_Mod, only: Aerosol_Tracer_T
 


### PR DESCRIPTION
Closes #184 

This removes some unneeded `find_package` calls for GFE libraries. These are needed by MAPL not GOCART and so are redundant here (and as @rmontuoro pointed out, bad).

This also adds a new CI test to build GOCART like UFS.