### PR TITLE
Feature/vbuchard/total aback toa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Extinction exports with RH=20% and RH=80%
+- Extinction/Scattering profile exports at model RH at wavelengths_profile
+- Extinction/Scattering profile exports with RH=20% and RH=80% at wavelengths_profile
+- Aerosol single scattering backscatter coefficient for each instances and total at wavelengths_profile
+- Total (molecular + aerosols) attenuated backscatter coefficient from TOA and sfc at 532nm
 
 ### Fixed
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1023,8 +1023,8 @@ contains
                              sfcmass=SMASS, colmass=CMASS, mass=MASS,&
                              exttau=EXTTAU,stexttau=STEXTTAU, scatau=SCATAU, stscatau=STSCATAU,&
                              fluxu=FLUXU, fluxv=FLUXV, &
-                             conc=CONC, extcoef=EXTCOEF, scacoef=SCACOEF, angstrom=ANGSTR, aerindx=AERIDX,&
-                             NO3nFlag=.false., __RC__)
+                             conc=CONC, extcoef=EXTCOEF, scacoef=SCACOEF, bckcoef=BCKCOEF, angstrom=ANGSTR,&
+                             aerindx=AERIDX, NO3nFlag=.false., __RC__)
 
 
     i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -82,6 +82,7 @@ category: EXPORT
  *SCACOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Scattering Coefficient
  *SCACOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Scattering Coefficient - Fixed RH=20%
  *SCACOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Scattering Coefficient - Fixed RH=80%
+ *BCKCOEF     | m-1 sr-1     | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Backscatter Coefficient
 #............ | ............ | ..... | ..... | .......                        | ............................................
  *EM          | kg m-2 s-1   | xy    | N     | nbins                          | Carbonaceous Aerosol Emission (Bin %d)
  *SD          | kg m-2 s-1   | xy    | N     | nbins                          | Carbonaceous Aerosol Sedimentation (Bin %d)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -961,7 +961,7 @@ contains
                             DUSMASS, DUCMASS, DUMASS, DUEXTTAU, DUSTEXTTAU, DUSCATAU,DUSTSCATAU, &
                             DUSMASS25, DUCMASS25, DUMASS25, DUEXTT25, DUSCAT25, &
                             DUFLUXU, DUFLUXV, DUCONC, DUEXTCOEF, DUSCACOEF, &
-                            DUEXTTFM, DUSCATFM, DUANGSTR, DUAERIDX, NO3nFlag=.false., __RC__ )
+                            DUBCKCOEF,DUEXTTFM, DUSCATFM, DUANGSTR, DUAERIDX, NO3nFlag=.false., __RC__ )
 
 
    i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -67,6 +67,7 @@ category: EXPORT
  DUSCACOEF     | m-1        | xyz  | C    | size(self%wavelengths_profile) | Dust Scattering Coefficient
  DUSCACOEFRH20 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Dust Scattering Coefficient - Fixed RH=20%
  DUSCACOEFRH80 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Dust Scattering Coefficient - Fixed RH=80%
+ DUBCKCOEF     | m-1 sr-1   | xyz  | C    | size(self%wavelengths_profile) | Dust Backscatter Coefficient
 #........................................................................................
  DUSMASS       | kg m-3     | xy   | N    |                                | Dust Surface Mass Concentration
  DUCMASS       | kg m-2     | xy   | N    |                                | Dust Column Mass Density

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -204,7 +204,6 @@ contains
 
 #include "GOCART2G_Export___.h"
 #include "GOCART2G_Import___.h"
-#include "GOCART2G_Internal___.h"
 
 !   Add connectivities for Nitrate component
 !   Nitrate currently only supports one Nitrate component. Nitrate only 
@@ -1142,7 +1141,7 @@ contains
 
 !  Calculate the total (molecular + aer) single scattering attenuated backscater coef from the TOA
     if(associated(totabcktoa).or.associated(totabcksfc)) then
-        if (.not.associated(totextcoef) .and. .not. associated(totbckcoef)) then
+        if (.not.associated(totextcoef) .or. .not.associated(totbckcoef)) then
              print*,trim(Iam),' : TOTEXTCOEF and TOTBCKCOEF and their children needs to be requested in HISTORY.rc.',&
                            ' Cannot produce TOTABCKTOA or TOTABCKSFC variables without these exports.'
              VERIFY_(100)

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -203,7 +203,8 @@ contains
 
 
 #include "GOCART2G_Export___.h"
-
+#include "GOCART2G_Import___.h"
+#include "GOCART2G_Internal___.h"
 
 !   Add connectivities for Nitrate component
 !   Nitrate currently only supports one Nitrate component. Nitrate only 
@@ -584,6 +585,7 @@ contains
     real, pointer, dimension(:,:,:,:) :: duextcoef, duscacoef
     real, pointer, dimension(:,:,:,:) :: duextcoefrh20, duextcoefrh80
     real, pointer, dimension(:,:,:,:) :: duscacoefrh20, duscacoefrh80
+    real, pointer, dimension(:,:,:,:) :: dubckcoef
     real, pointer, dimension(:,:)   :: duangstr, dusmass,  &
                                        dusmass25
     real, pointer, dimension(:,:,:) :: ssexttau, ssstexttau, &
@@ -593,6 +595,7 @@ contains
     real, pointer, dimension(:,:,:,:) :: ssextcoef, ssscacoef
     real, pointer, dimension(:,:,:,:) :: ssextcoefrh20, ssextcoefrh80
     real, pointer, dimension(:,:,:,:) :: ssscacoefrh20, ssscacoefrh80
+    real, pointer, dimension(:,:,:,:) :: ssbckcoef
     real, pointer, dimension(:,:)   :: ssangstr, sssmass,  &
                                        sssmass25
     real, pointer, dimension(:,:,:) :: niexttau, nistexttau, &
@@ -602,6 +605,7 @@ contains
     real, pointer, dimension(:,:,:,:) :: niextcoef, niscacoef
     real, pointer, dimension(:,:,:,:) :: niextcoefrh20, niextcoefrh80
     real, pointer, dimension(:,:,:,:) :: niscacoefrh20, niscacoefrh80
+    real, pointer, dimension(:,:,:,:) :: nibckcoef
     real, pointer, dimension(:,:)   :: niangstr, nismass,  &
                                        nismass25
     real, pointer, dimension(:,:)   :: nh4smass
@@ -610,26 +614,37 @@ contains
     real, pointer, dimension(:,:,:,:) :: suextcoef, suscacoef
     real, pointer, dimension(:,:,:,:) :: suextcoefrh20, suextcoefrh80
     real, pointer, dimension(:,:,:,:) :: suscacoefrh20, suscacoefrh80
+    real, pointer, dimension(:,:,:,:) :: subckcoef
     real, pointer, dimension(:,:)   :: suangstr, so4smass
     real, pointer, dimension(:,:,:) :: bcexttau, bcstexttau, bcscatau, bcstscatau 
     real, pointer, dimension(:,:,:,:) :: bcextcoef, bcscacoef
     real, pointer, dimension(:,:,:,:) :: bcextcoefrh20, bcextcoefrh80
     real, pointer, dimension(:,:,:,:) :: bcscacoefrh20, bcscacoefrh80
+    real, pointer, dimension(:,:,:,:) :: bcbckcoef
     real, pointer, dimension(:,:)   :: bcangstr, bcsmass
     real, pointer, dimension(:,:,:) :: ocexttau, ocstexttau, ocscatau, ocstscatau
     real, pointer, dimension(:,:,:,:) :: ocextcoef, ocscacoef
     real, pointer, dimension(:,:,:,:) :: ocextcoefrh20, ocextcoefrh80
     real, pointer, dimension(:,:,:,:) :: ocscacoefrh20, ocscacoefrh80
+    real, pointer, dimension(:,:,:,:) :: ocbckcoef
     real, pointer, dimension(:,:)   :: ocangstr, ocsmass
     real, pointer, dimension(:,:,:) :: brexttau, brstexttau, brscatau, brstscatau
     real, pointer, dimension(:,:,:,:) :: brextcoef, brscacoef
     real, pointer, dimension(:,:,:,:) :: brextcoefrh20, brextcoefrh80
     real, pointer, dimension(:,:,:,:) :: brscacoefrh20, brscacoefrh80
+    real, pointer, dimension(:,:,:,:) :: brbckcoef
     real, pointer, dimension(:,:)   :: brangstr, brsmass
     real, pointer, dimension(:,:,:) :: pso4
+    real, allocatable               :: aerabcktoa(:,:,:), molabcktoa(:,:,:)
     real, allocatable               :: tau1(:,:), tau2(:,:)
+    real, allocatable               :: backscat_mol(:,:,:)
+    real, allocatable               :: P(:,:,:), delz(:,:,:)
+    real, allocatable               :: tau_mol_layer(:,:,:), tau_aer_layer(:,:,:)
+    real, allocatable               :: tau_mol(:,:), tau_aer(:,:)
     real                            :: c1, c2, c3
-    integer                         :: ind550
+    real, parameter                 :: pi = 3.141529265     
+    integer                         :: ind550, ind532
+    integer                         :: i1, i2, j1, j2, km, k,kk
 
 #include "GOCART2G_DeclarePointer___.h"
 
@@ -669,19 +684,20 @@ contains
     if(associated(totscat25)) totscat25 = 0.
     if(associated(totexttfm)) totexttfm = 0.
     if(associated(totscatfm)) totscatfm = 0.
-    if(associated(totextcoef)) totextcoef = 0.
+    if(associated(totextcoef))     totextcoef = 0.
     if(associated(totextcoefrh20)) totextcoefrh20 = 0.
     if(associated(totextcoefrh80)) totextcoefrh80 = 0.
-    if(associated(totscacoef)) totscacoef = 0.
+    if(associated(totscacoef))     totscacoef = 0.
     if(associated(totscacoefrh20)) totscacoefrh20 = 0.
     if(associated(totscacoefrh80)) totscacoefrh80 = 0.
+    if(associated(totbckcoef))     totbckcoef = 0.
+    if(associated(totabcktoa))     totabcktoa = 0.
     if(associated(pm))        pm(:,:)        = 0.
     if(associated(pm25))      pm25(:,:)      = 0.
     if(associated(pm_rh35))   pm_rh35(:,:)   = 0.
     if(associated(pm25_rh35)) pm25_rh35(:,:) = 0.
     if(associated(pm_rh50))   pm_rh50(:,:)   = 0.
     if(associated(pm25_rh50)) pm25_rh50(:,:) = 0.
-
     if(associated(pso4tot))   pso4tot(:,:,:) = 0.
 
 !   Run the children
@@ -722,6 +738,7 @@ contains
        c3 = -log(470./870.)
     end if
 
+
 !   Dust
     do n = 1, size(self%DU%instances)
        if ((self%DU%instances(n)%is_active) .and. (index(self%DU%instances(n)%name, 'data') == 0 )) then
@@ -735,6 +752,7 @@ contains
           call MAPL_GetPointer (gex(self%DU%instances(n)%id), duscacoef, 'DUSCACOEF', __RC__)
           call MAPL_GetPointer (gex(self%DU%instances(n)%id), duscacoefrh20, 'DUSCACOEFRH20', __RC__)
           call MAPL_GetPointer (gex(self%DU%instances(n)%id), duscacoefrh80, 'DUSCACOEFRH80', __RC__)
+          call MAPL_GetPointer (gex(self%DU%instances(n)%id), dubckcoef, 'DUBCKCOEF', __RC__)
           call MAPL_GetPointer (gex(self%DU%instances(n)%id), duextt25, 'DUEXTT25', __RC__)
           call MAPL_GetPointer (gex(self%DU%instances(n)%id), duscat25, 'DUSCAT25', __RC__)
           call MAPL_GetPointer (gex(self%DU%instances(n)%id), duexttfm, 'DUEXTTFM', __RC__)
@@ -760,6 +778,7 @@ contains
              if(associated(totscacoef) .and. associated(duscacoef)) totscacoef(:,:,:,w) = totscacoef(:,:,:,w)+duscacoef(:,:,:,w)
              if(associated(totscacoefrh20) .and. associated(duscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+duscacoefrh20(:,:,:,w)
              if(associated(totscacoefrh80) .and. associated(duscacoefrh80)) totscacoefrh80(:,:,:,w) = totscacoefrh80(:,:,:,w)+duscacoefrh80(:,:,:,w)
+             if(associated(totbckcoef) .and. associated(dubckcoef)) totbckcoef(:,:,:,w) = totbckcoef(:,:,:,w)+dubckcoef(:,:,:,w)
           end do
           
           call MAPL_GetPointer (gex(self%DU%instances(n)%id), dusmass,   'DUSMASS',   __RC__)
@@ -791,6 +810,7 @@ contains
           call MAPL_GetPointer (gex(self%SS%instances(n)%id), ssscacoef, 'SSSCACOEF', __RC__)
           call MAPL_GetPointer (gex(self%SS%instances(n)%id), ssscacoefrh20, 'SSSCACOEFRH20', __RC__)
           call MAPL_GetPointer (gex(self%SS%instances(n)%id), ssscacoefrh80, 'SSSCACOEFRH80', __RC__)
+          call MAPL_GetPointer (gex(self%SS%instances(n)%id), ssbckcoef, 'SSBCKCOEF', __RC__)
           call MAPL_GetPointer (gex(self%SS%instances(n)%id), ssextt25, 'SSEXTT25', __RC__)
           call MAPL_GetPointer (gex(self%SS%instances(n)%id), ssscat25, 'SSSCAT25', __RC__)
           call MAPL_GetPointer (gex(self%SS%instances(n)%id), ssexttfm, 'SSEXTTFM', __RC__)
@@ -816,6 +836,7 @@ contains
              if(associated(totscacoef) .and. associated(ssscacoef)) totscacoef(:,:,:,w) = totscacoef(:,:,:,w)+ssscacoef(:,:,:,w)
              if(associated(totscacoefrh20) .and. associated(ssscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+ssscacoefrh20(:,:,:,w)
              if(associated(totscacoefrh80) .and. associated(ssscacoefrh80)) totscacoefrh80(:,:,:,w) = totscacoefrh80(:,:,:,w)+ssscacoefrh80(:,:,:,w)
+             if(associated(totbckcoef) .and. associated(ssbckcoef)) totbckcoef(:,:,:,w) = totbckcoef(:,:,:,w)+ssbckcoef(:,:,:,w)
           enddo
     
           call MAPL_GetPointer (gex(self%SS%instances(n)%id), sssmass,   'SSSMASS',   __RC__)
@@ -847,6 +868,7 @@ contains
           call MAPL_GetPointer (gex(self%NI%instances(n)%id), niscacoef, 'NISCACOEF', __RC__)
           call MAPL_GetPointer (gex(self%NI%instances(n)%id), niscacoefrh20, 'NISCACOEFRH20', __RC__)
           call MAPL_GetPointer (gex(self%NI%instances(n)%id), niscacoefrh80, 'NISCACOEFRH80', __RC__)
+          call MAPL_GetPointer (gex(self%NI%instances(n)%id), nibckcoef, 'NIBCKCOEF', __RC__)
           call MAPL_GetPointer (gex(self%NI%instances(n)%id), niextt25, 'NIEXTT25', __RC__)
           call MAPL_GetPointer (gex(self%NI%instances(n)%id), niscat25, 'NISCAT25', __RC__)
           call MAPL_GetPointer (gex(self%NI%instances(n)%id), niexttfm, 'NIEXTTFM', __RC__)
@@ -872,6 +894,7 @@ contains
              if(associated(totscacoef) .and. associated(niscacoef)) totscacoef(:,:,:,w) = totscacoef(:,:,:,w)+niscacoef(:,:,:,w)
              if(associated(totscacoefrh20) .and. associated(niscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+niscacoefrh20(:,:,:,w)
              if(associated(totscacoefrh80) .and. associated(niscacoefrh80)) totscacoefrh80(:,:,:,w) = totscacoefrh80(:,:,:,w)+niscacoefrh80(:,:,:,w)
+             if(associated(totbckcoef) .and. associated(nibckcoef)) totbckcoef(:,:,:,w) = totbckcoef(:,:,:,w)+nibckcoef(:,:,:,w)
           end do
           
           call MAPL_GetPointer (gex(self%NI%instances(n)%id), nismass,   'NISMASS',   __RC__)
@@ -901,6 +924,7 @@ contains
           call MAPL_GetPointer (gex(self%SU%instances(n)%id), suscacoef, 'SUSCACOEF', __RC__)
           call MAPL_GetPointer (gex(self%SU%instances(n)%id), suscacoefrh20, 'SUSCACOEFRH20', __RC__)
           call MAPL_GetPointer (gex(self%SU%instances(n)%id), suscacoefrh80, 'SUSCACOEFRH80', __RC__)
+          call MAPL_GetPointer (gex(self%SU%instances(n)%id), subckcoef, 'SUBCKCOEF', __RC__)
           call MAPL_GetPointer (gex(self%SU%instances(n)%id), sustexttau, 'SUSTEXTTAU', __RC__)
           call MAPL_GetPointer (gex(self%SU%instances(n)%id), suscatau, 'SUSCATAU', __RC__)
           call MAPL_GetPointer (gex(self%SU%instances(n)%id), sustscatau, 'SUSTSCATAU', __RC__)
@@ -925,6 +949,7 @@ contains
              if(associated(totscacoef) .and. associated(suscacoef)) totscacoef(:,:,:,w) = totscacoef(:,:,:,w)+suscacoef(:,:,:,w)
              if(associated(totscacoefrh20) .and. associated(suscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+suscacoefrh20(:,:,:,w)
              if(associated(totscacoefrh80) .and. associated(suscacoefrh80)) totscacoefrh80(:,:,:,w) = totscacoefrh80(:,:,:,w)+suscacoefrh80(:,:,:,w)
+             if(associated(totbckcoef) .and. associated(subckcoef)) totbckcoef(:,:,:,w) = totbckcoef(:,:,:,w)+subckcoef(:,:,:,w)
           end do
           
           call MAPL_GetPointer (gex(self%SU%instances(n)%id), pso4, 'PSO4', __RC__)
@@ -971,6 +996,7 @@ contains
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), bcscacoef, 'CA.bcSCACOEF', __RC__)
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), bcscacoefrh20, 'CA.bcSCACOEFRH20', __RC__)
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), bcscacoefrh80, 'CA.bcSCACOEFRH80', __RC__)
+          call MAPL_GetPointer (gex(self%CA%instances(n)%id), bcbckcoef, 'CA.bcBCKCOEF', __RC__)
 
           !   Iterate over the wavelengths
           do w = 1, size(self%wavelengths_vertint)
@@ -991,6 +1017,7 @@ contains
              if(associated(totscacoef) .and. associated(bcscacoef)) totscacoef(:,:,:,w) = totscacoef(:,:,:,w)+bcscacoef(:,:,:,w)
              if(associated(totscacoefrh20) .and. associated(bcscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+bcscacoefrh20(:,:,:,w)
              if(associated(totscacoefrh80) .and. associated(bcscacoefrh80)) totscacoefrh80(:,:,:,w) = totscacoefrh80(:,:,:,w)+bcscacoefrh80(:,:,:,w)
+             if(associated(totbckcoef) .and. associated(bcbckcoef)) totbckcoef(:,:,:,w) = totbckcoef(:,:,:,w)+bcbckcoef(:,:,:,w)
           end do
 
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), bcsmass, 'CA.bcSMASS', __RC__)
@@ -1019,6 +1046,7 @@ contains
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), ocscacoef, 'CA.ocSCACOEF', __RC__)
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), ocscacoefrh20, 'CA.ocSCACOEFRH20', __RC__)
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), ocscacoefrh80, 'CA.ocSCACOEFRH80', __RC__)
+          call MAPL_GetPointer (gex(self%CA%instances(n)%id), ocbckcoef, 'CA.ocBCKCOEF', __RC__)
 
           !   Iterate over the wavelengths
           do w = 1, size(self%wavelengths_vertint)
@@ -1038,7 +1066,8 @@ contains
              if(associated(totextcoefrh80) .and. associated(ocextcoefrh80)) totextcoefrh80(:,:,:,w) = totextcoefrh80(:,:,:,w)+ocextcoefrh80(:,:,:,w)
              if(associated(totscacoef) .and. associated(ocscacoef)) totscacoef(:,:,:,w) = totscacoef(:,:,:,w)+ocscacoef(:,:,:,w)
              if(associated(totscacoefrh20) .and. associated(ocscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+ocscacoefrh20(:,:,:,w)
-             if(associated(totscacoefrh80) .and. associated(ocscacoefrh80)) totscacoefrh80(:,:,:,w) = totscacoefrh80(:,:,:,w)+ocscacoefrh80(:,:,:,w)
+             if(associated(totscacoefrh20) .and. associated(ocscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+ocscacoefrh20(:,:,:,w)
+             if(associated(totbckcoef) .and. associated(ocbckcoef)) totbckcoef(:,:,:,w) = totbckcoef(:,:,:,w)+ocbckcoef(:,:,:,w)
           end do
          
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), ocsmass, 'CA.ocSMASS', __RC__)
@@ -1067,6 +1096,7 @@ contains
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), brscacoef, 'CA.brSCACOEF', __RC__)
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), brscacoefrh20, 'CA.brSCACOEFRH20', __RC__)
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), brscacoefrh80, 'CA.brSCACOEFRH80', __RC__)
+          call MAPL_GetPointer (gex(self%CA%instances(n)%id), brbckcoef, 'CA.brBCKCOEF', __RC__)
 
           !   Iterate over the wavelengths
           do w = 1, size(self%wavelengths_vertint)
@@ -1087,6 +1117,7 @@ contains
              if(associated(totscacoef) .and. associated(brscacoef)) totscacoef(:,:,:,w) = totscacoef(:,:,:,w)+brscacoef(:,:,:,w)
              if(associated(totscacoefrh20) .and. associated(brscacoefrh20)) totscacoefrh20(:,:,:,w) = totscacoefrh20(:,:,:,w)+brscacoefrh20(:,:,:,w)
              if(associated(totscacoefrh80) .and. associated(brscacoefrh80)) totscacoefrh80(:,:,:,w) = totscacoefrh80(:,:,:,w)+brscacoefrh80(:,:,:,w)
+             if(associated(totbckcoef) .and. associated(brbckcoef)) totbckcoef(:,:,:,w) = totbckcoef(:,:,:,w)+brbckcoef(:,:,:,w)
           end do
           
           call MAPL_GetPointer (gex(self%CA%instances(n)%id), brsmass, 'CA.brSMASS', __RC__)
@@ -1108,6 +1139,72 @@ contains
     if(associated(totangstr)) then  
        totangstr = log(tau1/tau2)/c3
     end if
+
+!  Calculate the total (molecular + aer) single scattering attenuated backscater coef from the TOA
+    if(associated(totabcktoa) .and. associated(totextcoef) .and. associated(totbckcoef)) then
+       ind532 = 0
+       do w = 1, size(self%wavelengths_profile) ! find index for 532nm to compute TBA
+          if ((self%wavelengths_profile(w)*1.e-9 .ge. 5.31e-7) .and. &
+              (self%wavelengths_profile(w)*1.e-9 .le. 5.33e-7)) then
+             ind532 = w
+             exit
+          end if
+       end do
+
+       if (ind532 == 0) then
+          print*,trim(Iam),' : 532nm wavelengths is not present in GOCART2G_GridComp.rc.',&
+                           ' Cannot produce TOTBCKCOEF variable without 532nm wavelength.'
+          VERIFY_(100)
+       end if
+
+        ! Pressure at layer edges (ple shape (im,jm, km+1) on the edge 
+
+       i1 = lbound(ple, 1); i2 = ubound(ple, 1)
+       j1 = lbound(ple, 2); j2 = ubound(ple, 2)
+                            km = ubound(ple, 3) ! km =72 index starts at 0 
+       ! Pressure for each layer
+       allocate(P(i1:i2,j1:j2,km), __STAT__)
+       do k = 1, km
+           P(:,:,k) = 0.5 * (ple(:,:,k-1) + ple(:,:,k))   ! in Pa
+       enddo
+
+      !molecular backscattering cross section for each layer at 532nm: Cair  * P(Pa) / T(K)
+      !Cair = 4.51944e-9 at 532nm # unit K Pa-1 m-1 sr-1 http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19960051003.pdf
+       allocate(backscat_mol(i1:i2,j1:j2,km), __STAT__)
+       backscat_mol = 5.45e-32/1.380648e-23 * (532./550.)**(-4.0)  * P / T
+       ! tau mol for each layer
+       allocate(tau_mol_layer(i1:i2,j1:j2,km), delz(i1:i2,j1:j2,km),__STAT__)
+       delz  = delp / (MAPL_GRAV * airdens)
+       tau_mol_layer = backscat_mol * 8.* pi /3. * delz  
+
+       ! tau aer for each layer
+       allocate(tau_aer_layer(i1:i2,j1:j2,km), __STAT__)
+       tau_aer_layer = totextcoef(:,:,:,ind532) * delz
+
+       allocate(molabcktoa(i1:i2,j1:j2,km), __STAT__)
+       allocate(aerabcktoa(i1:i2,j1:j2,km), __STAT__)
+
+       allocate(tau_aer(i1:i2,j1:j2), __STAT__)
+       allocate(tau_mol(i1:i2,j1:j2), __STAT__)
+       ! top layer 
+       totabcktoa(:,:,1) = (totbckcoef(:,:,1,ind532) + backscat_mol(:,:,1)) * exp(-tau_aer_layer(:,:,1)) * exp(-tau_mol_layer(:,:,1))
+       aerabcktoa(:,:,1) = totbckcoef(:,:,1,ind532) * exp(-tau_aer_layer(:,:,1)) 
+       molabcktoa(:,:,1) = backscat_mol(:,:,1)  * exp(-tau_mol_layer(:,:,1))
+       ! layer 2 to the layer at the surface(km-1)
+       do k = 2, km
+           tau_aer = 0.
+           tau_mol = 0. ! for each layer
+           do kk = 1, k 
+             tau_aer = tau_aer + tau_aer_layer(:,:,kk) 
+             tau_mol = tau_mol + tau_mol_layer(:,:,kk) 
+           enddo
+           tau_aer = tau_aer + 0.5 *  tau_aer_layer(:,:,k)
+           tau_mol = tau_mol + 0.5 *  tau_mol_layer(:,:,k)
+           totabcktoa(:,:,k) = (totbckcoef(:,:,k,ind532) + backscat_mol(:,:,k)) * exp(-tau_aer) * exp(-tau_mol)
+           aerabcktoa(:,:,k) = totbckcoef(:,:,k,ind532) * exp(-2*tau_aer) 
+           molabcktoa(:,:,k) = backscat_mol(:,:,k) * exp(-2*tau_mol) 
+       enddo
+   endif ! end of total attenuated backscatter coef calculation
 
     RETURN_(ESMF_SUCCESS)
 

--- a/ESMF/GOCART2G_GridComp/GOCART2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_StateSpecs.rc
@@ -5,10 +5,13 @@ category: IMPORT
 #----------------------------------------------------------------------------------------
 #  VARIABLE       | DIMENSIONS  |          Additional Metadata
 #----------------------------------------------------------------------------------------
-     NAME | UNITS | DIMS | VLOC | COND | LONG NAME
+     NAME   | UNITS    | DIMS | VLOC | RESTART | LONG NAME
 #----------------------------------------------------------------------------------------
-# DELP    | Pa    | xyz  | C    |      | pressure_thickness
-# RH2     | 1     | xyz  | C    |      | Rel_Hum_after_moist
+ DELP       | Pa       | xyz  | C    |         | pressure_thickness
+# RH2       | 1        | xyz  | C    |         | Rel_Hum_after_moist
+ AIRDENS    | kg/m^3   | xyz  | C    | OPT     | moist_air_density
+ T          | K        | xyz  | C    | OPT     | air_temperature
+ PLE        | Pa       | xyz  | E    | OPT     | air_pressure
 
 category: EXPORT
 #----------------------------------------------------------------------------------------
@@ -33,6 +36,8 @@ category: EXPORT
  TOTSCACOEF     | m-1        | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Scattering coefficient
  TOTSCACOEFRH20 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Scattering coefficient - Fixed RH=20%
  TOTSCACOEFRH80 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Scattering coefficient - Fixed RH=80%
+ TOTBCKCOEF     | m-1 sr-1   | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Single Scattering Backscatter coefficient
+ TOTABCKTOA     | m-1 sr-1   | xyz  | C    |                                | Total Attenuated Backscatter Coefficient [532nm]
  PM             | kg m-3     | xy   | N    |            | Total reconstructed PM
  PM_RH35        | kg m-3     | xy   | N    |            | Total reconstructed PM(RH=35%)
  PM_RH50        | kg m-3     | xy   | N    |            | Total reconstructed PM(RH=50%)

--- a/ESMF/GOCART2G_GridComp/GOCART2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_StateSpecs.rc
@@ -37,7 +37,8 @@ category: EXPORT
  TOTSCACOEFRH20 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Scattering coefficient - Fixed RH=20%
  TOTSCACOEFRH80 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Scattering coefficient - Fixed RH=80%
  TOTBCKCOEF     | m-1 sr-1   | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Single Scattering Backscatter coefficient
- TOTABCKTOA     | m-1 sr-1   | xyz  | C    |                                | Total Attenuated Backscatter Coefficient [532nm]
+ TOTABCKTOA     | m-1 sr-1   | xyz  | C    |                                | Total Attenuated Backscatter Coefficient from TOA [532nm]
+ TOTABCKSFC     | m-1 sr-1   | xyz  | C    |                                | Total Attenuated Backscatter Coefficient from surface [532nm]
  PM             | kg m-3     | xy   | N    |            | Total reconstructed PM
  PM_RH35        | kg m-3     | xy   | N    |            | Total reconstructed PM(RH=35%)
  PM_RH50        | kg m-3     | xy   | N    |            | Total reconstructed PM(RH=50%)

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -970,7 +970,7 @@ contains
                             delp=delp, ple=ple, tropp=tropp,sfcmass=NISMASS, colmass=NICMASS, mass=NIMASS, conc=NICONC, &
                             exttau=NIEXTTAU, stexttau=NISTEXTTAU,scatau=NISCATAU, stscatau=NISTSCATAU,&
                             fluxu=NIFLUXU, fluxv=NIFLUXV, extcoef=NIEXTCOEF, scacoef=NISCACOEF, &
-                            angstrom=NIANGSTR, __RC__ )
+                            bckcoef=NIBCKCOEF,angstrom=NIANGSTR, __RC__ )
 
    i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)
    j1 = lbound(RH2, 2); j2 = ubound(RH2, 2)

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
@@ -61,6 +61,7 @@ category: EXPORT
   NISCACOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Scattering Coefficient
   NISCACOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Scattering Coefficient - fixed RH=20%
   NISCACOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Scattering Coefficient - fixed RH=80%
+  NIBCKCOEF     | m-1 sr-1     | xyz   | C     | size(self%wavelengths_profile) | Nitrate Backscatter Coefficient
 # ............. | ............ | ..... | ..... | ...........                    | ..................................
   NIPNO3AQ      | kg m-2 s-1   | xy    | N     |                                | Nitrate Production from Aqueous Chemistry
   NIPNH4AQ      | kg m-2 s-1   | xy    | N     |                                | Ammonium Production from Aqueous Chemistry

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -812,7 +812,7 @@ contains
                              self%wavelengths_vertint*1.0e-9, SS, MAPL_GRAV, t, airdens,rh2, u, v, &
                              delp, ple, tropp,SSSMASS, SSCMASS, SSMASS, SSEXTTAU,SSSTEXTTAU, SSSCATAU,SSSTSCATAU, &
                              SSSMASS25, SSCMASS25, SSMASS25, SSEXTT25, SSSCAT25, &
-                             SSFLUXU, SSFLUXV, SSCONC, SSEXTCOEF, SSSCACOEF,    &
+                             SSFLUXU, SSFLUXV, SSCONC, SSEXTCOEF, SSSCACOEF, SSBCKCOEF,    &
                              SSEXTTFM, SSSCATFM ,SSANGSTR, SSAERIDX, NO3nFlag=.false.,__RC__)
 
     i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_StateSpecs.rc
@@ -50,6 +50,7 @@ category: EXPORT
  SSSCACOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Scattering Coefficient
  SSSCACOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Scattering Coefficient - Fixed RH=20%
  SSSCACOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Scattering Coefficient - Fixed RH=80%
+ SSBCKCOEF     | m-1 sr-1     | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Backscatter Coefficient
 #............. | ............ | ..... | ..... | ............                   | ..................................
  SSEM          | kg m-2 s-1   | xy    | N     | self%nbins                     | Sea Salt Emission (Bin %d)
  SSSD          | kg m-2 s-1   | xy    | N     | self%nbins                     | Sea Salt Sedimentation (Bin %d)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1093,7 +1093,7 @@ contains
                             SO2SMASS, SO2CMASS, &
                             SO4SMASS, SO4CMASS, &
                             SUEXTTAU, SUSTEXTTAU,SUSCATAU,SUSTSCATAU, SO4MASS, SUCONC, SUEXTCOEF, &
-                            SUSCACOEF, SUANGSTR, SUFLUXU, SUFLUXV, SO4SAREA, SO4SNUM, __RC__)
+                            SUSCACOEF, SUBCKCOEF,SUANGSTR, SUFLUXU, SUFLUXV, SO4SAREA, SO4SNUM, __RC__)
 
     i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)
     j1 = lbound(RH2, 2); j2 = ubound(RH2, 2)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
@@ -90,6 +90,7 @@ category: EXPORT
  SUSCACOEF     | m-1        | xyz  | C    | size(self%wavelengths_profile) | SO4 Scattering Coefficient
  SUSCACOEFRH20 | m-1        | xyz  | C    | size(self%wavelengths_profile) | SO4 Scattering Coefficient - Fixed RH=20%
  SUSCACOEFRH80 | m-1        | xyz  | C    | size(self%wavelengths_profile) | SO4 Scattering Coefficient - Fixed RH=80%
+ SUBCKCOEF     | m-1 sr-1   | xyz  | C    | size(self%wavelengths_profile) | SO4 Backscatter Coefficient
  SUANGSTR      | 1          | xy   | N    |                                | SO4 Angstrom parameter [470-870 nm]
  SUFLUXU       | kg m-1 s-1 | xy   | N    |                                | SO4 column u-wind mass flux
  SUFLUXV       | kg m-1 s-1 | xy   | N    |                                | SO4 column v-wind mass flux

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3249,7 +3249,7 @@ CONTAINS
                                   grav, tmpu, rhoa, rh, u, v, delp, ple,tropp, &
                                   sfcmass, colmass, mass, exttau, stexttau, scatau, stscatau,&
                                   sfcmass25, colmass25, mass25, exttau25, scatau25, &
-                                  fluxu, fluxv, conc, extcoef, scacoef, &
+                                  fluxu, fluxv, conc, extcoef, scacoef, bckcoef,&
                                   exttaufm, scataufm, angstrom, aerindx, NO3nFlag, rc )
 
 ! !USES:
@@ -3297,6 +3297,7 @@ CONTAINS
    real, optional, dimension(:,:), intent(inout)   :: fluxv     ! Column mass flux in y direction
    real, optional, dimension(:,:,:,:), intent(inout) :: extcoef   ! 3d ext. coefficient, 1/m
    real, optional, dimension(:,:,:,:), intent(inout) :: scacoef   ! 3d scat.coefficient, 1/m
+   real, optional, dimension(:,:,:,:), intent(inout) :: bckcoef   ! 3d backscatter coefficient, m-1 sr-1
    real, optional, dimension(:,:,:), intent(inout)   :: exttaufm  ! fine mode (sub-micron) ext. AOT at 550 nm
    real, optional, dimension(:,:,:), intent(inout)   :: scataufm  ! fine mode (sub-micron) sct. AOT at 550 nm
    real, optional, dimension(:,:), intent(inout)   :: angstrom  ! 470-870 nm Angstrom parameter
@@ -3317,7 +3318,7 @@ CONTAINS
    integer :: i, j, k, n, w, ios, status
    integer :: i1 =1, i2, j1=1, j2
    integer :: ilam470, ilam870
-   real, allocatable, dimension(:,:,:) :: tau, ssa
+   real, allocatable, dimension(:,:,:) :: tau, ssa, bck
 !   real :: fPMfm(nbins)  ! fraction of bin with particles diameter < 1.0 um
 !   real :: fPM25(nbins)  ! fraction of bin with particles diameter < 2.5 um
    real, dimension(:), allocatable :: fPMfm  ! fraction of bin with particles diameter < 1.0 um
@@ -3470,18 +3471,21 @@ CONTAINS
 
    allocate(tau(i1:i2,j1:j2,km),source = 0.)
    allocate(ssa(i1:i2,j1:j2,km),source = 0.)
+   allocate(bck(i1:i2,j1:j2,km),source = 0.)
 !  Calculate the extinction and/or scattering AOD
    if( present(extcoef)  .or. &
-       present(scacoef) ) then
+       present(scacoef)  .or. &
+       present(bckcoef))   then
 
       if( present(extcoef) ) extcoef = 0.
       if( present(scacoef) ) scacoef = 0.
+      if( present(bckcoef) ) bckcoef = 0.
 
       do n = nbegin, nbins
         do w = 1, size(wavelengths_profile)
           call mie%Query(wavelengths_profile(w),n,   &
                          aerosol(:,:,:,n)*delp/grav, &
-                         rh, tau=tau, ssa=ssa, __RC__)
+                         rh, tau=tau, ssa=ssa, bbck=bck,__RC__)
 !         Calculate the total ext. and scat. coefficients
           if ( present(extcoef) ) then
              extcoef(:,:,:,w) = extcoef(:,:,:,w) + &
@@ -3490,6 +3494,11 @@ CONTAINS
           if ( present(scacoef) ) then
              scacoef(:,:,:,w) = scacoef(:,:,:,w) + &
                                ssa * tau * (grav * rhoa / delp)
+          endif
+          !calculate the backscatter coefficient
+          if ( present(bckcoef) ) then
+             bckcoef(:,:,:,w) = bckcoef(:,:,:,w) + &
+                               bck * aerosol(:,:,:,n)*rhoa
           endif
        enddo !wavelengths_profile
       enddo !nbins
@@ -6689,7 +6698,7 @@ K_LOOP: do k = km, 1, -1
                                  so2sfcmass, so2colmass, &
                                  so4sfcmass, so4colmass, &
                                  exttau, stexttau,scatau, stscatau,so4mass, so4conc, extcoef, &
-                                 scacoef, angstrom, fluxu, fluxv, sarea, snum, rc )
+                                 scacoef, bckcoef, angstrom, fluxu, fluxv, sarea, snum, rc )
 
 ! !USES:
    implicit NONE
@@ -6736,6 +6745,7 @@ K_LOOP: do k = km, 1, -1
    real, optional, dimension(:,:,:), intent(inout)  :: so4conc    ! 3D mass concentration, [kg/m3]
    real, optional, dimension(:,:,:,:), intent(inout)  :: extcoef    ! 3D ext. coefficient, [1/m]
    real, optional, dimension(:,:,:,:), intent(inout)  :: scacoef    ! 3D scat.coefficient, [1/m]
+   real, optional, dimension(:,:,:,:), intent(inout)  :: bckcoef    ! 3D backscatter coefficient, [m-1 sr-1]
    real, optional, dimension(:,:),   intent(inout)  :: angstrom   ! 470-870 nm Angstrom parameter
    real, optional, dimension(:,:),   intent(inout)  :: fluxu      ! Column mass flux in x direction
    real, optional, dimension(:,:),   intent(inout)  :: fluxv      ! Column mass flux in y direction
@@ -6755,7 +6765,7 @@ K_LOOP: do k = km, 1, -1
 
 ! !Local Variables
    integer :: i, j, k, w, i1=1, j1=1, i2, j2, status
-   real, dimension(:,:,:), allocatable :: tau, ssa
+   real, dimension(:,:,:), allocatable :: tau, ssa, bck
    real, dimension(:,:), allocatable :: tau470, tau870
    integer    :: ilam470, ilam870
    logical :: do_angstrom
@@ -6888,15 +6898,18 @@ K_LOOP: do k = km, 1, -1
 !  Calculate the extinction and/or scattering AOD
    allocate(tau(i1:i2,j1:j2,km), source = 0.)
    allocate(ssa(i1:i2,j1:j2,km), source = 0.)
-   if( present(extcoef) .or. present(scacoef) ) then
+   allocate(bck(i1:i2,j1:j2,km), source = 0.)
+   if( present(extcoef) .or. present(scacoef) .or. &
+       present(bckcoef)) then
 
       if (present(extcoef)) extcoef = 0.
       if (present(scacoef)) scacoef = 0.
+      if (present(bckcoef)) bckcoef = 0.
 
       do w = 1, size(wavelengths_profile)
          call mie%Query(wavelengths_profile(w), 1, & ! Only SO4 exists in the MieTable, so its index is 1
                         SO4*delp/grav, rh,         &
-                        tau=tau, ssa=ssa, __RC__)
+                        tau=tau, ssa=ssa, bbck=bck,__RC__)
 
 !         Calculate the total ext. and scat. coefficients
          if( present(extcoef) ) then
@@ -6906,6 +6919,10 @@ K_LOOP: do k = km, 1, -1
          if( present(scacoef) ) then
               scacoef(:,:,:,w) = scacoef(:,:,:,w) + &
                               ssa * tau * (grav * rhoa / delp)
+         endif
+         if( present(bckcoef) ) then
+              bckcoef(:,:,:,w) = bckcoef(:,:,:,w) + &
+                              bck * SO4 * rhoa 
          endif
       enddo
    endif


### PR DESCRIPTION
Adds:
- Aerosol single scattering backscatter coefficient for each instances and total at wavelengths_profile
- Total (molecular + aerosols) attenuated backscatter coefficient from TOA and sfc at 532nm.
This PR closes issue #183. The total attenuated backscatter coefficient calculation will be revisit later to include other wavelengths than 532nm.