### PR TITLE
Fixes #202. Add * to Long Name for CA Gridded Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `*` to CA State specs file to allow for ACG to substitute in the instance name
+
 ### Fixed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved to use GitHub Action for label enforcement
 - Updated CircleCI image to use Baselibs 7.7.0
 - Update `components.yaml` to reflect GEOSgcm
+- CA restarts will have a change in longname for `philic` and `phobic` variables due to addition of `*` in the CA State specs file
+  for the Internal state variables
 
 ## [2.1.2] - 2022-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `*` to CA State specs file to allow for ACG to substitute in the instance name
+- Added `*` to CA State specs file to allow for ACG to substitute in the long name
 
 ### Fixed
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -113,8 +113,8 @@ category: INTERNAL
 #--------------------------------------------------------------------------------------------------------------
   NAME   | UNITS   | DIMS | VLOC | RESTART              | ADD2EXPORT | FRIENDLYTO                | LONG NAME
 #--------------------------------------------------------------------------------------------------------------
- *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
- *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
+ *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophobic Aerosol Mixing Ratio
+ *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophilic Aerosol Mixing Ratio
 
 #********************************************************
 #

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -113,8 +113,8 @@ category: INTERNAL
 #--------------------------------------------------------------------------------------------------------------
   NAME   | UNITS   | DIMS | VLOC | RESTART              | ADD2EXPORT | FRIENDLYTO                | LONG NAME
 #--------------------------------------------------------------------------------------------------------------
- *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Aerosol Mixing Ratio
- *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Aerosol Mixing Ratio
+ *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophobic Aerosol Mixing Ratio
+ *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophilic Aerosol Mixing Ratio
 
 #********************************************************
 #

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -74,36 +74,36 @@ category: EXPORT
 #----------------------------------------------------------------------------------------
  NAME         | UNITS        | DIMS  | VLOC  | UNGRIDDED                      | LONG NAME
 #----------------------------------------------------------------------------------------
- *MASS        | kg kg-1      | xyz   | C     |                                | * Carbonaceous Aerosol Mass Mixing Ratio
- *CONC        | kg m-3       | xyz   | C     |                                | * Carbonaceous Aerosol Mass Concentration
- *EXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Extinction Coefficient
- *EXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Extinction Coefficient - Fixed RH=20%
- *EXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Extinction Coefficient - Fixed RH=80%
- *SCACOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Scattering Coefficient
- *SCACOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Scattering Coefficient - Fixed RH=20%
- *SCACOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Scattering Coefficient - Fixed RH=80%
+ *MASS        | kg kg-1      | xyz   | C     |                                | * Aerosol Mass Mixing Ratio
+ *CONC        | kg m-3       | xyz   | C     |                                | * Aerosol Mass Concentration
+ *EXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient
+ *EXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=20%
+ *EXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=80%
+ *SCACOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Scattering Coefficient
+ *SCACOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Scattering Coefficient - Fixed RH=20%
+ *SCACOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Scattering Coefficient - Fixed RH=80%
 #............ | ............ | ..... | ..... | .......                        | ............................................
- *EM          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Emission (Bin %d)
- *SD          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Sedimentation (Bin %d)
- *DP          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Dry Deposition (Bin %d)
- *WT          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Wet Deposition (Bin %d)
- *SV          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Convective Scavenging (Bin %d)
- *EMAN        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Anthropogenic Emissions
- *EMBB        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Biomass Burning Emissions
- *EMBF        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Biofuel Emissions
- *EMBG        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Biogenic Emissions
- *HYPHIL      | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Hydrophobic to Hydrophilic
- *PSOA        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol SOA Production
- *SMASS       | kg m-3       | xy    | N     |                                | * Carbonaceous Aerosol Surface Mass Concentration
- *CMASS       | kg m-2       | xy    | N     |                                | * Carbonaceous Aerosol Column Mass Density
- *EXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Extinction AOT
- *STEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Extinction AOT Stratosphere
- *SCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Scattering AOT
- *STSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Scattering AOT Stratosphere
- *ANGSTR      | 1            | xy    | N     |                                | * Carbonaceous Aerosol Angstrom parameter [470-870 nm]
- *FLUXU       | kg m-1 s-1   | xy    | N     |                                | * Carbonaceous Aerosol column u-wind mass flux
- *FLUXV       | kg m-1 s-1   | xy    | N     |                                | * Carbonaceous Aerosol column v-wind mass flux
- *AERIDX      | 1            | xy    | N     |                                | * Carbonaceous Aerosol TOMS UV Aerosol Index
+ *EM          | kg m-2 s-1   | xy    | N     | nbins                          | * Aerosol Emission (Bin %d)
+ *SD          | kg m-2 s-1   | xy    | N     | nbins                          | * Aerosol Sedimentation (Bin %d)
+ *DP          | kg m-2 s-1   | xy    | N     | nbins                          | * Aerosol Dry Deposition (Bin %d)
+ *WT          | kg m-2 s-1   | xy    | N     | nbins                          | * Aerosol Wet Deposition (Bin %d)
+ *SV          | kg m-2 s-1   | xy    | N     | nbins                          | * Aerosol Convective Scavenging (Bin %d)
+ *EMAN        | kg m-2 s-1   | xy    | N     |                                | * Aerosol Anthropogenic Emissions
+ *EMBB        | kg m-2 s-1   | xy    | N     |                                | * Aerosol Biomass Burning Emissions
+ *EMBF        | kg m-2 s-1   | xy    | N     |                                | * Aerosol Biofuel Emissions
+ *EMBG        | kg m-2 s-1   | xy    | N     |                                | * Aerosol Biogenic Emissions
+ *HYPHIL      | kg m-2 s-1   | xy    | N     |                                | * Aerosol Hydrophobic to Hydrophilic
+ *PSOA        | kg m-2 s-1   | xy    | N     |                                | * Aerosol SOA Production
+ *SMASS       | kg m-3       | xy    | N     |                                | * Aerosol Surface Mass Concentration
+ *CMASS       | kg m-2       | xy    | N     |                                | * Aerosol Column Mass Density
+ *EXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Extinction AOT
+ *STEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Extinction AOT Stratosphere
+ *SCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Scattering AOT
+ *STSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Scattering AOT Stratosphere
+ *ANGSTR      | 1            | xy    | N     |                                | * Aerosol Angstrom parameter [470-870 nm]
+ *FLUXU       | kg m-1 s-1   | xy    | N     |                                | * Aerosol column u-wind mass flux
+ *FLUXV       | kg m-1 s-1   | xy    | N     |                                | * Aerosol column v-wind mass flux
+ *AERIDX      | 1            | xy    | N     |                                | * Aerosol TOMS UV Aerosol Index
 
 
 
@@ -113,8 +113,8 @@ category: INTERNAL
 #--------------------------------------------------------------------------------------------------------------
   NAME   | UNITS   | DIMS | VLOC | RESTART              | ADD2EXPORT | FRIENDLYTO                | LONG NAME
 #--------------------------------------------------------------------------------------------------------------
- *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Carbonaceous Aerosol Mixing Ratio
- *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Carbonaceous Aerosol Mixing Ratio
+ *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Aerosol Mixing Ratio
+ *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Aerosol Mixing Ratio
 
 #********************************************************
 #

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -74,36 +74,36 @@ category: EXPORT
 #----------------------------------------------------------------------------------------
  NAME         | UNITS        | DIMS  | VLOC  | UNGRIDDED                      | LONG NAME
 #----------------------------------------------------------------------------------------
- *MASS        | kg kg-1      | xyz   | C     |                                | Carbonaceous Aerosol Mass Mixing Ratio
- *CONC        | kg m-3       | xyz   | C     |                                | Carbonaceous Aerosol Mass Concentration
- *EXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Extinction Coefficient
- *EXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Extinction Coefficient - Fixed RH=20%
- *EXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Extinction Coefficient - Fixed RH=80%
- *SCACOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Scattering Coefficient
- *SCACOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Scattering Coefficient - Fixed RH=20%
- *SCACOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Carbonaceous Aerosol Scattering Coefficient - Fixed RH=80%
+ *MASS        | kg kg-1      | xyz   | C     |                                | * Carbonaceous Aerosol Mass Mixing Ratio
+ *CONC        | kg m-3       | xyz   | C     |                                | * Carbonaceous Aerosol Mass Concentration
+ *EXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Extinction Coefficient
+ *EXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Extinction Coefficient - Fixed RH=20%
+ *EXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Extinction Coefficient - Fixed RH=80%
+ *SCACOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Scattering Coefficient
+ *SCACOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Scattering Coefficient - Fixed RH=20%
+ *SCACOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Carbonaceous Aerosol Scattering Coefficient - Fixed RH=80%
 #............ | ............ | ..... | ..... | .......                        | ............................................
- *EM          | kg m-2 s-1   | xy    | N     | nbins                          | Carbonaceous Aerosol Emission (Bin %d)
- *SD          | kg m-2 s-1   | xy    | N     | nbins                          | Carbonaceous Aerosol Sedimentation (Bin %d)
- *DP          | kg m-2 s-1   | xy    | N     | nbins                          | Carbonaceous Aerosol Dry Deposition (Bin %d)
- *WT          | kg m-2 s-1   | xy    | N     | nbins                          | Carbonaceous Aerosol Wet Deposition (Bin %d)
- *SV          | kg m-2 s-1   | xy    | N     | nbins                          | Carbonaceous Aerosol Convective Scavenging (Bin %d)
- *EMAN        | kg m-2 s-1   | xy    | N     |                                | Carbonaceous Aerosol Anthropogenic Emissions
- *EMBB        | kg m-2 s-1   | xy    | N     |                                | Carbonaceous Aerosol Biomass Burning Emissions
- *EMBF        | kg m-2 s-1   | xy    | N     |                                | Carbonaceous Aerosol Biofuel Emissions
- *EMBG        | kg m-2 s-1   | xy    | N     |                                | Carbonaceous Aerosol Biogenic Emissions
- *HYPHIL      | kg m-2 s-1   | xy    | N     |                                | Carbonaceous Aerosol Hydrophobic to Hydrophilic
- *PSOA        | kg m-2 s-1   | xy    | N     |                                | Carbonaceous Aerosol SOA Production
- *SMASS       | kg m-3       | xy    | N     |                                | Carbonaceous Aerosol Surface Mass Concentration
- *CMASS       | kg m-2       | xy    | N     |                                | Carbonaceous Aerosol Column Mass Density
- *EXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Carbonaceous Aerosol Extinction AOT
- *STEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Carbonaceous Aerosol Extinction AOT Stratosphere
- *SCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Carbonaceous Aerosol Scattering AOT
- *STSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Carbonaceous Aerosol Scattering AOT Stratosphere
- *ANGSTR      | 1            | xy    | N     |                                | Carbonaceous Aerosol Angstrom parameter [470-870 nm]
- *FLUXU       | kg m-1 s-1   | xy    | N     |                                | Carbonaceous Aerosol column u-wind mass flux
- *FLUXV       | kg m-1 s-1   | xy    | N     |                                | Carbonaceous Aerosol column v-wind mass flux
- *AERIDX      | 1            | xy    | N     |                                | Carbonaceous Aerosol TOMS UV Aerosol Index
+ *EM          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Emission (Bin %d)
+ *SD          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Sedimentation (Bin %d)
+ *DP          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Dry Deposition (Bin %d)
+ *WT          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Wet Deposition (Bin %d)
+ *SV          | kg m-2 s-1   | xy    | N     | nbins                          | * Carbonaceous Aerosol Convective Scavenging (Bin %d)
+ *EMAN        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Anthropogenic Emissions
+ *EMBB        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Biomass Burning Emissions
+ *EMBF        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Biofuel Emissions
+ *EMBG        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Biogenic Emissions
+ *HYPHIL      | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol Hydrophobic to Hydrophilic
+ *PSOA        | kg m-2 s-1   | xy    | N     |                                | * Carbonaceous Aerosol SOA Production
+ *SMASS       | kg m-3       | xy    | N     |                                | * Carbonaceous Aerosol Surface Mass Concentration
+ *CMASS       | kg m-2       | xy    | N     |                                | * Carbonaceous Aerosol Column Mass Density
+ *EXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Extinction AOT
+ *STEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Extinction AOT Stratosphere
+ *SCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Scattering AOT
+ *STSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Carbonaceous Aerosol Scattering AOT Stratosphere
+ *ANGSTR      | 1            | xy    | N     |                                | * Carbonaceous Aerosol Angstrom parameter [470-870 nm]
+ *FLUXU       | kg m-1 s-1   | xy    | N     |                                | * Carbonaceous Aerosol column u-wind mass flux
+ *FLUXV       | kg m-1 s-1   | xy    | N     |                                | * Carbonaceous Aerosol column v-wind mass flux
+ *AERIDX      | 1            | xy    | N     |                                | * Carbonaceous Aerosol TOMS UV Aerosol Index
 
 
 
@@ -113,8 +113,8 @@ category: INTERNAL
 #--------------------------------------------------------------------------------------------------------------
   NAME   | UNITS   | DIMS | VLOC | RESTART              | ADD2EXPORT | FRIENDLYTO                | LONG NAME
 #--------------------------------------------------------------------------------------------------------------
- *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
- *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
+ *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Carbonaceous Aerosol Mixing Ratio
+ *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Carbonaceous Aerosol Mixing Ratio
 
 #********************************************************
 #

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -113,8 +113,8 @@ category: INTERNAL
 #--------------------------------------------------------------------------------------------------------------
   NAME   | UNITS   | DIMS | VLOC | RESTART              | ADD2EXPORT | FRIENDLYTO                | LONG NAME
 #--------------------------------------------------------------------------------------------------------------
- *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophobic Aerosol Mixing Ratio
- *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophilic Aerosol Mixing Ratio
+ *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
+ *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
 
 #********************************************************
 #

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.21.0
+  tag: v3.24.0
   develop: develop
 
 ecbuild:
@@ -27,12 +27,12 @@ HEMCO:
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.6.2
+  tag: v1.6.3
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.32.0
+  tag: v2.34.0
   develop: develop


### PR DESCRIPTION
Closes #202 

With MAPL 2.34 now in GEOSgcm `main`, I feel confident about making this PR. To wit, this PR uses the updated *-expansion in MAPL's ACG to expand out the Long Name in the State Specs much like it does in the short name. Note that this is a bit different than might be expected[^compname].

Note I also changed the Internal state *-variables here:
```
 *phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
 *philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | Carbonaceous Aerosol Mixing Ratio
```
to:
```
*phobic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophobic Aerosol Mixing Ratio
*philic | kg kg-1 | xyz  | C    | MAPL_RestartOptional | T          | DYNAMICS:TURBULENCE:MOIST | * Hydrophilic Aerosol Mixing Ratio
```

because these are also added to Export (the `T` column). Thus, history output will have the right name. But because these are *Internal* state variables and changing could trigger a "non-zero-diff" in checkpoints. Now, It would only be the `long_name` attribute and not the actual data, but I wanted to be conservative.

I also took the time to update the `components.yaml` to match GEOSgcm `main` so it uses MAPL 2.34 as well.

[^compname]: In #202 (or rather the chain leading to it, see https://github.com/GEOS-ESM/MAPL/issues/1877), @amdasilva said:  
    > ![image](https://user-images.githubusercontent.com/2982494/207668579-607bc4e4-bae3-4834-a8ca-cbd3aae67b8e.png)
    > 
    > For the short name the “*” is replaced with the name of the component, thus BCEXTTAU, BRCEXTTAU, etc. A similar device was supposed to have been implemented for the long name but apparently it has not. In this case, we should have something like this:
    >  
    > Which would expand to “BC Extinction AOT”, “BRC Extinction AOT”, etc… Expanding BC to “Black Carbon” cannot be easily done with the ACG without introducing cumbersome syntax. Having ncks perform attribute renaming at the script level may be easier to implement.
    
    It turns out technically we cannot do this. When you use MAPL 2.34 with this PR, you get out:
    ```
    BCEM001:long_name = "CA.bc Aerosol Emission (Bin 001)" ;
    ```
    for, say, `BCEM001`. Note this does *NOT* say `"BC Aerosol Emission (Bin 001)"`. The reason is that this variable internally is `CA.bcEM001` and not `BCEM001` because the component is `CA.bc`; it's called `BCEM001` only because of aliasing in `HISTORY.rc`:
    ```
    'CA.bcEM'        , 'CA.bc'     , 'BCEM001;BCEM002' ,
    ```
    But, as far as the ACG is concerned, this is `CA.bc` and it has no way to know that someone renamed it in `HISTORY.rc`.
    
    I believe GEOS will need a postprocessing step with something like `ncatted` to convert `CA.bc` to either `BC` or `Black Carbon`.