### PR TITLE
Persist emissions after 2019 using ExtData2G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 -removed lines for anthropogenic emissions of OC, BC, SO2, SO4, and NH3 in their repsective ExtData yaml files.
-
+-used ExtData2G to persist aircraft emissions and MERRA-2 GMI inputs after 2019 to eliminate the need for duplicate files for future years
 
 ## [2.1.3] - 2023-02-27
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -1,8 +1,10 @@
 Collections:
   CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   CA2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
   CA2G_merra2.aer_Nx.2003-2015.2008%m2clm.nc4:
@@ -32,13 +34,17 @@ Samplings:
     update_frequency: PT24H
     update_offset: PT12H
     update_reference_time: '0'
+  CA2G_sample_3:
+    extrapolation: clim
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+    source_time: "2019-01-15T12:00/2019-12-15T12:00"
 
 Exports:
   BC_AIRCRAFT:
-    collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: CA2G_sample_1
-    variable: bc_aviation
+    - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_aviation}
+    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_aviation} 
   BC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -111,10 +117,8 @@ Exports:
     sample: CA2G_sample_2
     variable: terpene
   OC_AIRCRAFT:
-    collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: CA2G_sample_1
-    variable: oc_aviation
+    - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_aviation}
+    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_aviation} 
   OC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -44,7 +44,7 @@ Samplings:
 Exports:
   BC_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_aviation}
-    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_aviation} 
+    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_aviation}
   BC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -118,7 +118,7 @@ Exports:
     variable: terpene
   OC_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_aviation}
-    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_aviation} 
+    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_aviation}
   OC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -7,6 +7,7 @@ Collections:
     template: /discover/nobackup/projects/gmao/gmao_ops/pub/fp/das/Y%y4/M%m2/D%d2/GEOS.fp.asm.inst3_3d_aer_Nv.%y4%m2%d2_%h2%n2.V01.nc4
   NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
     template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.006.%y4%m2%d2.nc4
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
@@ -28,6 +29,12 @@ Samplings:
     update_reference_time: '0'
   NI2G_sample_3:
     extrapolation: persist_closest
+  NI2G_sample_4:
+    extrapolation: clim
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+    source_time: "2019-01-15T12:00:00/2019-12-17T00:00:00"
 
 Exports:
   EMI_NH3_AG:
@@ -59,12 +66,8 @@ Exports:
     sample: NI2G_sample_2
     variable: nh3_emis
   NITRATE_HNO3:
-    collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
-    linear_transformation:
-      - 0.0
-      - 0.2
-    sample: NI2G_sample_1
-    variable: hno3
+    - {starting: "1979-01-15T12:00:00", collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, linear_transformation: [0.0, 0.2], regrid: CONSERVE, sample: NI2G_sample_1, variable: hno3} 
+    - {starting: "2019-12-15T12:00:00", collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, linear_transformation: [0.0, 0.2], regrid: CONSERVE, sample: NI2G_sample_4, variable: hno3} 
   NI_regionMask:
     collection: NI2G_ARCTAS.region_mask.x540_y361.2008.nc
     regrid: VOTE

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -66,8 +66,8 @@ Exports:
     sample: NI2G_sample_2
     variable: nh3_emis
   NITRATE_HNO3:
-    - {starting: "1979-01-15T12:00:00", collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, linear_transformation: [0.0, 0.2], regrid: CONSERVE, sample: NI2G_sample_1, variable: hno3} 
-    - {starting: "2019-12-15T12:00:00", collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, linear_transformation: [0.0, 0.2], regrid: CONSERVE, sample: NI2G_sample_4, variable: hno3} 
+    - {starting: "1979-01-15T12:00:00", collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, linear_transformation: [0.0, 0.2], regrid: CONSERVE, sample: NI2G_sample_1, variable: hno3}
+    - {starting: "2019-12-15T12:00:00", collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, linear_transformation: [0.0, 0.2], regrid: CONSERVE, sample: NI2G_sample_4, variable: hno3}
   NI_regionMask:
     collection: NI2G_ARCTAS.region_mask.x540_y361.2008.nc
     regrid: VOTE

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -40,7 +40,7 @@ Samplings:
 Exports:
   SU_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_1, variable: so2_aviation}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_aviation} 
+    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_aviation}
   SU_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -3,8 +3,10 @@ Collections:
     template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
   SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
     template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   SU2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
   SU2G_merra2.aer_Nx.2003-2015.2008%m2clm.nc4:
@@ -28,13 +30,17 @@ Samplings:
     update_frequency: PT24H
     update_offset: PT12H
     update_reference_time: '0'
+  SU2G_sample_3:
+    extrapolation: clim
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+    source_time: "2019-01-15T12:00/2019-12-15T12:00"
 
 Exports:
   SU_AIRCRAFT:
-    collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: SU2G_sample_1
-    variable: so2_aviation
+    - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_1, variable: so2_aviation}
+    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_aviation} 
   SU_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -59,20 +65,14 @@ Exports:
     sample: SU2G_sample_2
     variable: conc
   SU_H2O2:
-    collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: SU2G_sample_1
-    variable: h2o2
+    - {starting: "1979-01-15T12:00", collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: h2o2}
+    - {starting: "2019-12-15T12:00", collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: h2o2}
   SU_NO3:
-    collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: SU2G_sample_1
-    variable: no3
+    - {starting: "1979-01-15T12:00", collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: no3}
+    - {starting: "2019-12-15T12:00", collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, sample: SU2G_sample_3, regrid: CONSERVE, variable: no3}
   SU_OH:
-    collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: SU2G_sample_1
-    variable: oh
+    - {starting: "1979-01-15T12:00", collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: oh}
+    - {starting: "2019-12-15T12:00", collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4, sample: SU2G_sample_3, regrid: CONSERVE, variable: oh}
   climSO4:
     collection: SU2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4
     sample: SU2G_sample_0


### PR DESCRIPTION
ExtData yaml files were modified for SU, CA, and NI to add rules for persisting 2019 after the datasets end for CEDS and MERRA-2 GMI. This means that duplicate input files are no longer needed for years after 2019.