### PR TITLE
Fix 3 hourly frequency update in go-cart to allow start/stop regression in less than 3 hour chances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - To do: remove hooks to old (legacy) GOCART.data instances in CHEM and setup scripts
 - Fixed rc file in legacy O3 component.
 - Fixed issue #223 where Global dimension was being used for allocating a local array	
-- 
+-    
 ### Added
 
 ### Changed

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -767,7 +767,6 @@ contains
     if (alarm_is_ringing) then
        xhno3 = NITRATE_HNO3
     end if
-    if (mapl_am_i_root()) write(*,*)"bmaa ni alarm ring ",alarm_is_ringing
 
     if (associated(NIPNO3AQ)) NIPNO3AQ(:,:) = 0.
     if (associated(NIPNH4AQ)) NIPNH4AQ(:,:) = 0.

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -728,11 +728,6 @@ contains
 !*****************************************************************************
 !   Begin... 
 
-    block
-       type(ESMF_TIME) :: currtime
-       call ESMF_ClockGet(clock,currtime=currtime,_RC)
-       if (mapl_am_i_root()) call ESMF_TimePrint(currtime,options='string',prestring='bmaa ni run2 time ')
-    end block
 !   Get my name and set-up traceback handle
 !   ---------------------------------------
     call ESMF_GridCompGet (GC, NAME=COMP_NAME, __RC__)

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -401,7 +401,6 @@ contains
        call ESMF_AttributeGet(field, name='radius', valueList=self%rmedSS, __RC__)
        call ESMF_AttributeGet(field, name='fnum', valueList=self%fnumSS, __RC__)
     end if
-
 !   Se HNO3 recycle alarm
     if (.not. data_driven) then
         call ESMF_ClockGet(clock, calendar=calendar, currTime=currentTime, __RC__)
@@ -409,14 +408,10 @@ contains
         call ESMF_TimeSet(ringTime, YY=year, MM=month, DD=day, H=0, M=0, S=0, __RC__)
         call ESMF_TimeIntervalSet(ringInterval, H=3, calendar=calendar, __RC__)
 
-        do while (ringTime < currentTime)! DO WE NEED THIS?
-            ringTime = currentTime + ringInterval
-        end do
-
         alarm_HNO3 = ESMF_AlarmCreate(Clock        = clock,        &
                                       Name         = 'HNO3_RECYCLE_ALARM', &
                                       RingInterval = ringInterval, &
-                                      RingTime     = currentTime,  &
+                                      RingTime     = ringTime,  &
                                       Enabled      = .true.   ,    &
                                       Sticky       = .false.  , __RC__)
     end if
@@ -789,7 +784,7 @@ contains
 !   Recycle HNO3 every 3 hours
     if (alarm_is_ringing) then
        xhno3 = NITRATE_HNO3
-       !call ESMF_AlarmRingerOff(alarm, __RC__)
+       call ESMF_AlarmRingerOff(alarm, __RC__)
     end if
 
     if (associated(NIPNO3AQ)) NIPNO3AQ(:,:) = 0.

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
@@ -112,7 +112,7 @@ category: INTERNAL
  NO3an1 |kg kg-1   | xyz  | C    | MAPL_RestartOptional | T | DYNAMICS:TURBULENCE:MOIST | Nitrate size bin 001
  NO3an2 |kg kg-1   | xyz  | C    | MAPL_RestartOptional | T | DYNAMICS:TURBULENCE:MOIST | Nitrate size bin 002
  NO3an3 |kg kg-1   | xyz  | C    | MAPL_RestartOptional | T | DYNAMICS:TURBULENCE:MOIST | Nitrate size bin 003
- XHNO3  |kg m-2 s-1| xyz  | C    | MAPL_RestartSkip | F |                           | buffer for NITRATE_HNO3
+ XHNO3  |kg m-2 s-1| xyz  | C    |                      | F |                           | buffer for NITRATE_HNO3
 
 #********************************************************
 #

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1044,7 +1044,7 @@ contains
 !   recycle H2O2 every 3 hours
     if (alarm_is_ringing) then
        workspace%recycle_h2o2 = ESMF_AlarmIsRinging(alarm, __RC__)
-       !call ESMF_AlarmRingerOff(alarm, __RC__)
+       call ESMF_AlarmRingerOff(alarm, __RC__)
     end if
 
     allocate(xoh, mold=airdens, __STAT__)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
@@ -112,7 +112,7 @@ category: INTERNAL
  SO2       |kg kg-1| xyz  | C    | MAPL_RestartOptional | T | DYNAMICS:TURBULENCE:MOIST | Sulphur dioxide
  SO4       |kg kg-1| xyz  | C    | MAPL_RestartOptional | T | DYNAMICS:TURBULENCE:MOIST | Sulphate aerosol
  MSA       |kg kg-1| xyz  | C    | MAPL_RestartOptional | T | DYNAMICS:TURBULENCE:MOIST | Methanesulphonic acid  
- H2O2_INIT |kg kg-1| xyz  | C    | MAPL_RestartSkip | F |                           | private H2O2 that is saved and used to initialize 
+ H2O2_INIT |kg kg-1| xyz  | C    |                      | F |                           | private H2O2 that is saved and used to initialize 
 
 
 #********************************************************


### PR DESCRIPTION
fixes #146

This fixes a long standing issue that one can not start and stop the model in anything less than 3 hour increments to test start/stop regression because of GOCART

I will not rehash why this occurring other than to say this is unacceptable. If you look in the issue you will see all the details. The one thing I had to do was remove ESFM alarms, the whole problem was that an alarm was made relative to the model start time which just can not be. But the problem is if the ESMF Alarm is created correctly, say at 0z of the day so that no matter when you start you get the same behavior, it does not work right as there are fundamental bugs in ESMF alarms. ESMF is aware of this and will fix it some day, but until then we must avoid using them. In it's place I made a simple function that says is my time some frequency from 0z during the day.

This is zero-diff in my test and allows one to do start/stop regression at less than 3 hour increments which is very, very useful for debugging when you need it and multiple people have wasted time doing regression tests and were not aware of this "bug". Plus this what was coded was fundamentally not right.

Note I made the same function in two routines as I did not see any common place in GOCART2G for helper procedures such as this to go, although if there is, or we should invent one, I can do that.