### PR TITLE
Fixes #239. Use global dims for Chem_UtilResVal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix dims passed to `Chem_UtilResVal` as they must be global (see #239)
+
 ### Added
 
 ### Changed

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -374,7 +374,7 @@ contains
     type (DU2G_GridComp), pointer        :: self
 
     integer, allocatable                 :: mieTable_pointer(:)
-    integer                              :: i, dims(3), km
+    integer                              :: i, dims(3), km, global_dims(3)
     integer                              :: instance
     type (ESMF_Field)                    :: field, fld
     character (len=ESMF_MAXSTR)          :: bin_index, prefix
@@ -409,11 +409,11 @@ contains
     VERIFY_(STATUS)
     self => wrap%ptr
 
-    call MAPL_GridGet (grid, localCellCountPerDim=dims, __RC__ )
+    call MAPL_GridGet (grid, localCellCountPerDim=dims, globalCellCountPerDim=global_dims, __RC__ )
 
 !   Dust emission tuning coefficient [kg s2 m-5]. NOT bin specific.
 !   ---------------------------------------------------------------
-    self%Ch_DU = Chem_UtilResVal(dims(1), dims(2), self%Ch_DU_res(:), __RC__)
+    self%Ch_DU = Chem_UtilResVal(global_dims(1), global_dims(2), self%Ch_DU_res(:), __RC__)
     self%Ch_DU = self%Ch_DU * 1.0e-9
 
 !   Dust emission size distribution for FENGSHA

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -328,7 +328,7 @@ contains
     type (SS2G_GridComp), pointer        :: self
 
     integer, allocatable                 :: mieTable_pointer(:)
-    integer                              :: i, dims(3), km
+    integer                              :: i, dims(3), km, global_dims(3)
     integer                              :: instance
     type (ESMF_Field)                    :: field, fld
     character (len=ESMF_MAXSTR)          :: prefix, bin_index
@@ -369,14 +369,14 @@ contains
 
 !   Get dimensions
 !   ---------------
-    call MAPL_GridGet (grid, localCellCountPerDim=dims, __RC__ )
+    call MAPL_GridGet (grid, localCellCountPerDim=dims, globalCellCountPerDim=global_dims, __RC__ )
     km = dims(3)
     self%km = km
 
 !   Scaling factor to multiply calculated
 !   emissions by.  Applies to all size bins.
 !   ----------------------------------------
-    self%emission_scale = Chem_UtilResVal(dims(1), dims(2), self%emission_scale_res(:), __RC__)
+    self%emission_scale = Chem_UtilResVal(global_dims(1), global_dims(2), self%emission_scale_res(:), __RC__)
 
 !   Get DTs
 !   -------


### PR DESCRIPTION
Closes #239 

This is a hotfix onto `main` to try and fix #239 by passing global dimensions into Chem_UtilResVal (as it expects global dims). 

Labeling as non-zero-diff as it would change answers though probably a bugfix "good" diff.

I'll keep draft until @vbuchard can test. 

Also note to @sdrabenh, this bug is probably in sdr_v2.1.2.6 as well, so we'd need a new tag there for v11