### PR TITLE
ams: In dust and sea-salt, changed dimensions back to `globalCellCoun…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [v2.2.1] - 2023-05-30
+
+### Fixed
+
+- In dust and sea-salt, changed dimensions back to `globalCellCountPerDim` since these are needed to determine emission tuning parameters, not to allocate arrays.
+
+
 ## [v2.2.0] - 2023-05-18
 
 ### Fixed

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -409,10 +409,13 @@ contains
     VERIFY_(STATUS)
     self => wrap%ptr
 
-    call MAPL_GridGet (grid, localCellCountPerDim=dims, __RC__ )
+!   Global dimensions are needed here for choosing tuning parameters
+!   ----------------------------------------------------------------    
+    call MAPL_GridGet (grid, globalCellCountPerDim=dims, __RC__ ) 
 
 !   Dust emission tuning coefficient [kg s2 m-5]. NOT bin specific.
-!   ---------------------------------------------------------------
+!   TO DO: find a more robust way to implement resolution dependent tuning
+!   ----------------------------------------------------------------------
     self%Ch_DU = Chem_UtilResVal(dims(1), dims(2), self%Ch_DU_res(:), __RC__)
     self%Ch_DU = self%Ch_DU * 1.0e-9
 

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -367,15 +367,15 @@ contains
     VERIFY_(STATUS)
     self => wrap%ptr
 
-!   Get dimensions
-!   ---------------
-    call MAPL_GridGet (grid, localCellCountPerDim=dims, __RC__ )
+!   Global dimensions are needed here for choosing tuning parameters
+!   ----------------------------------------------------------------    
+    call MAPL_GridGet (grid, globalCellCountPerDim=dims, __RC__ )
     km = dims(3)
     self%km = km
 
-!   Scaling factor to multiply calculated
-!   emissions by.  Applies to all size bins.
-!   ----------------------------------------
+!   Scaling factor to multiply calculated emissions by.  Applies to all size bins.
+!   TO DO: find a more robust way to implement resolution dependent tuning
+!   -------------------------------------------------------------------------------
     self%emission_scale = Chem_UtilResVal(dims(1), dims(2), self%emission_scale_res(:), __RC__)
 
 !   Get DTs


### PR DESCRIPTION
This is meant as a small patch of v2.2.0 where in dust and sea-salt, dimensions are changed back to globalCellCountPerDim since these are needed to determine emission tuning parameters, not to allocate arrays.
