### PR TITLE
Update components to match GEOSgcm v11.1.0, update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.7.0
+baselibs_version: &baselibs_version v7.13.0
 bcs_version: &bcs_version v11.00.0
 
 orbs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `components.yaml` to match that of GEOSgcm v11.1.0
+  - ESMA_env v4.17.0 (Baselibs 7.13.0)
+  - ESMA_cmake v3.29.0 (Fixes for NAS)
+  - GMAO_Shared v1.9.1 (Bug fix for MITgcm)
+  - MAPL 2.39.1 (Various minor fixes and features)
+- Update CI to use Baselibs 7.13.0
+
 ## [v2.2.1] - 2023-05-30
 
 ### Fixed

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GOCART:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v4.9.1
+  tag: v4.17.0
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.28.0
+  tag: v3.29.0
   develop: develop
 
 ecbuild:
@@ -28,12 +28,12 @@ HEMCO:
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.9.0
+  tag: v1.9.1
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.38.1
+  tag: v2.39.1
   develop: develop


### PR DESCRIPTION
This PR updates the "in-repo" components to match GEOSgcm v11.1.0. This is mainly used for build testing of GOCART without the full model.

This PR also updates the CI to point to Baselibs 7.13.0 which is the version used by GEOSgcm v11.1.0. 

Note that for GEOSgcm, Baselibs 7.13.0 updates to ESMF v8.5.0b22 which has a non-zero-diff bugfix to grid generation (precision fix).