### PR TITLE
Silence error messages in getChannel() and getWavelength(), and add header file in process library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Silenced unwarranted error messages from wavelength/channel retrieval functions occurring when 470nm and/or 870nm channels are not included in GOCART resource file.
+
 ### Added
 
 ### Changed
+
+- Moved process library macros to header file.
 
 ## [v2.2.1] - 2023-05-30
 

--- a/Process_Library/GOCART2G_MieMod.F90
+++ b/Process_Library/GOCART2G_MieMod.F90
@@ -1,3 +1,4 @@
+#include "Process.H"
 !BOP
 !
 ! !MODULE:  GOCART2G_MieMod --- Reader for aerosol mie tables
@@ -540,13 +541,15 @@ CONTAINS
        endif
     enddo
 
-    if (present(rc)) rc = 0
-
-    if (ch < 0) then
-       !$omp critical (GetCha)
-       print*, "wavelength of ",wavelength, " is an invalid value."
-       !$omp end critical (GetCha)
-       if (present(rc)) rc = -1
+    if (present(rc)) then
+       if (ch > 0) then
+          rc = __SUCCESS__
+       else
+          rc = __FAIL__
+          !$omp critical (GetCha)
+          print*, "wavelength of ",wavelength, " is an invalid value."
+          !$omp end critical (GetCha)
+       endif
     endif
 
   end function getChannel
@@ -558,18 +561,22 @@ CONTAINS
      real, parameter :: w_tol = 1.e-9
      integer :: i
 
-     if (present(rc)) rc = 0
-
      if (ith_channel <=0 .or. ith_channel > this%nch ) then
-       !$omp critical (GetWav)
-       print*, "The channel of ",ith_channel, " is an invalid channel number."
-       !$omp end critical (GetWav)
-       if (present(rc)) rc = -1
-       wavelength = -1. ! meanlingless nagative
-       return
+        wavelength = -1. ! meaningless negative
+     else
+        wavelength = this%wavelengths(ith_channel)
      endif
-     
-     wavelength = this%wavelengths(ith_channel)
+
+    if (present(rc)) then
+       if (wavelength > 0) then
+          rc = __SUCCESS__
+       else
+          rc = __FAIL__
+          !$omp critical (GetWav)
+          print*, "The channel of ",ith_channel, " is an invalid channel number."
+          !$omp end critical (GetWav)
+       endif
+    endif
 
   end function getWavelength
 

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -1,13 +1,4 @@
-#define __SUCCESS__ 0
-#define __FAIL__ 1
-#define __VERIFY__(x) if(x/=0) then; if(present(rc)) rc=x; return; endif
-#define __VERIFY_NO_OPT__(x) if(x/=0) then; rc=x; return; endif
-#define __RC__ rc=status); __VERIFY__(status
-#define __RC_NO_OPT__ rc=status); __VERIFY_NO_OPT__(status
-#define __STAT__ stat=status); __VERIFY__(status
-#define __IOSTAT__ iostat=status); __VERIFY__(status
-#define __RETURN__(x) if (present(rc)) rc=x; return
-#define __ASSERT__(expr) if(.not. (expr)) then; if (present(rc)) rc=-1; return; endif
+#include "Process.H"
 !-------------------------------------------------------------------------
 !
 ! !MODULE: GOCART2G_Process -- GOCART2G process library

--- a/Process_Library/Process.H
+++ b/Process_Library/Process.H
@@ -1,0 +1,10 @@
+#define __SUCCESS__ 0
+#define __FAIL__ 1
+#define __VERIFY__(x) if(x/=0) then; if(present(rc)) rc=x; return; endif
+#define __VERIFY_NO_OPT__(x) if(x/=0) then; rc=x; return; endif
+#define __RC__ rc=status); __VERIFY__(status
+#define __RC_NO_OPT__ rc=status); __VERIFY_NO_OPT__(status
+#define __STAT__ stat=status); __VERIFY__(status
+#define __IOSTAT__ iostat=status); __VERIFY__(status
+#define __RETURN__(x) if (present(rc)) rc=x; return
+#define __ASSERT__(expr) if(.not. (expr)) then; if (present(rc)) rc=-1; return; endif


### PR DESCRIPTION
This pull request includes proposed changes to address issue #247.

Error messages from [getChannel()](https://github.com/GEOS-ESM/GOCART/blob/6ea78fd79037b31a1dcdd30d8a315f6558d963e4/Process_Library/GOCART2G_MieMod.F90#L528-L552) and [getWavelenght()](https://github.com/GEOS-ESM/GOCART/blob/6ea78fd79037b31a1dcdd30d8a315f6558d963e4/Process_Library/GOCART2G_MieMod.F90#L554-L574) are silenced unless the optional `rc` argument is provided.

A minor refactoring of the process library is also included to move all preprocessor macros from [GOCART2G_Process.F90](https://github.com/GEOS-ESM/GOCART/blob/main/Process_Library/GOCART2G_Process.F90) to a new header file (`Process.H`), which can be shared with [GOCART2G_MieMod.F90](https://github.com/GEOS-ESM/GOCART/blob/main/Process_Library/GOCART2G_MieMod.F90).