### PR TITLE
Fix/fengsha moist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.2] - 2023-09-19
+## [Unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Correct soil moisture parameterization in FENGSHA
-- Add `soil_moisture_factor` to the DU2G_GridComp.rc and DU2G_GridCompMod.F90 files for FENGSHA
-- Add `soil_drylimit_factor` to the DU2G_GridComp.rc and DU2G_GridCompMod.F90 files for FENGSHA
+- Add `soil_moisture_factor` to the DU2G_instance_DU.rc (same name used in the K14 scheme) and DU2G_GridCompMod.F90 files for FENGSHA
+- Add `soil_drylimit_factor` to the DU2G_instance_DU.rc and DU2G_GridCompMod.F90 files for FENGSHA
 
 ## [v2.2.1] - 2023-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.2] - 2023-09-19
 
 ### Fixed
 
+- Corrected the units of the gravimetric soil moisture to percent instead of fractional in the FENGSHA dust scheme.
+
 ### Added
 
+- Additional tuning parameters for the soil moisture and drylimit calculations for application specific tuning.
+
 ### Changed
+
+- Correct soil moisture parameterization in FENGSHA
+- Add `soil_moisture_factor` to the DU2G_GridComp.rc and DU2G_GridCompMod.F90 files for FENGSHA
+- Add `soil_drylimit_factor` to the DU2G_GridComp.rc and DU2G_GridCompMod.F90 files for FENGSHA
 
 ## [v2.2.1] - 2023-05-30
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -59,6 +59,7 @@ module DU2G_GridCompMod
        real                   :: alpha          ! FENGSHA scaling factor
        real                   :: gamma          ! FENGSHA tuning exponent
        real                   :: kvhmax         ! FENGSHA max. vertical/horizontal mass flux ratio [1]
+       real                   :: f_sdl          ! FENGSHA drylimit tuning factor
        real                   :: Ch_DU_res(NHRES) ! resolutions used for Ch_DU
        real                   :: Ch_DU          ! dust emission tuning coefficient [kg s2 m-5].
        logical                :: maringFlag=.false.  ! maring settling velocity correction
@@ -183,6 +184,8 @@ contains
     case ('fengsha')
        call ESMF_ConfigGetAttribute (cfg, self%alpha,      label='alpha:', __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%gamma,      label='gamma:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:', __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', __RC__)
     case ('k14')
        call ESMF_ConfigGetAttribute (cfg, self%clayFlag,   label='clayFlag:', __RC__)
@@ -794,10 +797,14 @@ contains
        if (associated(DU_EROD)) DU_EROD = f_erod_
 
     case ('fengsha')
+       allocate(R_, mold=U10M,        __STAT__)
+       allocate(H_w_, mold=U10M,      __STAT__)
        call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, du_clay, du_sand, du_silt,       &
                                  du_ssm, du_rdrag, airdens(:,:,self%km), ustar, du_uthres,  &
                                  self%alpha, self%gamma, self%kvhmax, MAPL_GRAV,   &
-                                 self%rhop, self%sdist, emissions_surface, __RC__)
+                                 self%rhop, self%sdist, self%f_sdl, emissions_surface, H_w_,  __RC__)
+       if (associated(DU_DPC)) DU_DPC = du_rdrag
+       if (associated(DU_SMC)) DU_SMC = H_w_
     case ('ginoux')
 
        call DustEmissionGOCART2G(self%radius*1.e-6, frlake, wet1, lwi, u10m, v10m, &

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -797,14 +797,12 @@ contains
        if (associated(DU_EROD)) DU_EROD = f_erod_
 
     case ('fengsha')
-       allocate(R_, mold=U10M,        __STAT__)
-       allocate(H_w_, mold=U10M,      __STAT__)
+
        call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, du_clay, du_sand, du_silt,       &
                                  du_ssm, du_rdrag, airdens(:,:,self%km), ustar, du_uthres,  &
                                  self%alpha, self%gamma, self%kvhmax, MAPL_GRAV,   &
-                                 self%rhop, self%sdist, self%f_sdl, emissions_surface, H_w_,  __RC__)
-       if (associated(DU_DPC)) DU_DPC = du_rdrag
-       if (associated(DU_SMC)) DU_SMC = H_w_
+                                 self%rhop, self%sdist, self%f_sdl, self%f_swc, emissions_surface,  __RC__)
+
     case ('ginoux')
 
        call DustEmissionGOCART2G(self%radius*1.e-6, frlake, wet1, lwi, u10m, v10m, &

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
@@ -63,3 +63,5 @@ pressure_lid_in_hPa: 0.01
 alpha: 0.3
 gamma: 1.3
 vertical_to_horizontal_flux_ratio_limit: 2.e-04
+soil_drylimit_factor: 1.0
+# soil_moisture_factor: 1.0

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -178,7 +178,7 @@ CONTAINS
 ! !IROUTINE: soilMoistureConvertVol2Grav - volumetric to gravimetric soil moisture
 !
 ! !INTERFACE:
-   real function soilMoistureConvertVol2Grav(vsoil, sandfrac, rhop)
+   real function soilMoistureConvertVol2Grav(vsoil, sandfrac)
 
 ! !USES:
    implicit NONE
@@ -186,7 +186,6 @@ CONTAINS
 ! !INPUT PARAMETERS:
    real, intent(in) :: vsoil       ! volumetric soil moisture fraction [1]
    real, intent(in) :: sandfrac    ! fractional sand content [1]
-   real, intent(in) :: rhop        ! dry dust density [kg m-3]
 
 ! !DESCRIPTION: Convert soil moisture fraction from volumetric to gravimetric.
 !
@@ -200,16 +199,16 @@ CONTAINS
 
 !  !CONSTANTS:
    real, parameter :: rhow = 1000.    ! density of water [kg m-3]
-
+   real, parameter :: rhop = 1700. 
 !EOP
 !-------------------------------------------------------------------------
 !  Begin...
 
 !  Saturated volumetric water content (sand-dependent) ! [m3 m-3]
-   vsat = 0.489 - 0.00126 * ( 100. * sandfrac )
+   vsat = 0.489 - 0.126 * sandfrac 
 
 !  Gravimetric soil content
-   soilMoistureConvertVol2Grav = vsoil * rhow / (rhop * (1. - vsat))
+   soilMoistureConvertVol2Grav = 100. * vsoil * rhow / (rhop * (1. - vsat))
 
    end function soilMoistureConvertVol2Grav
 
@@ -219,7 +218,7 @@ CONTAINS
 ! !IROUTINE: moistureCorrectionFecan - Correction factor for Fecan soil moisture
 !
 ! !INTERFACE:
-   real function moistureCorrectionFecan(slc, sand, clay, rhop)
+   real function moistureCorrectionFecan(slc, sand, clay, b)
 
 ! !USES:
    implicit NONE
@@ -228,7 +227,7 @@ CONTAINS
    real, intent(in) :: slc     ! liquid water content of top soil layer, volumetric fraction [1]
    real, intent(in) :: sand    ! fractional sand content [1]
    real, intent(in) :: clay    ! fractional clay content [1]
-   real, intent(in) :: rhop    ! dry dust density [kg m-3]
+   real, intent(in) :: b       ! drylimit factor from zender 2003 
 
 ! !DESCRIPTION: Compute correction factor to account for Fecal soil moisture
 !
@@ -246,10 +245,10 @@ CONTAINS
 !  Begin...
 
 !  Convert soil moisture from volumetric to gravimetric
-   grvsoilm = soilMoistureConvertVol2Grav(slc, sand, rhop)
+   grvsoilm = soilMoistureConvertVol2Grav(slc, sand)
 
 !  Compute fecan dry limit
-   drylimit = clay * (14.0 * clay + 17.0)
+   drylimit = b * clay * (14.0 * clay + 17.0)
 
 !  Compute soil moisture correction
    moistureCorrectionFecan = sqrt(1.0 + 1.21 * max(0., grvsoilm - drylimit)**0.68)
@@ -303,7 +302,7 @@ CONTAINS
 ! !INTERFACE:
    subroutine DustEmissionFENGSHA(fraclake, fracsnow, oro, slc, clay, sand, silt,  &
                                   ssm, rdrag, airdens, ustar, uthrs, alpha, gamma, &
-                                  kvhmax, grav, rhop, distribution, emissions, rc)
+                                  kvhmax, grav, rhop, distribution, drylimit_factor, emissions, h, rc)
 
 ! !USES:
    implicit NONE
@@ -327,9 +326,10 @@ CONTAINS
    real,                 intent(in) :: grav     ! gravity [m/sec^2]
    real, dimension(:),   intent(in) :: rhop            ! soil class density [kg/m^3]
    real, dimension(:),   intent(in) :: distribution    ! normalized dust binned distribution [1]
-
+   real,                 intent(in) :: drylimit_factor ! drylimit tuning factor from zender2003 
 ! !OUTPUT PARAMETERS:
    real,    intent(out) :: emissions(:,:,:)     ! binned surface emissions [kg/(m^2 sec)]
+   real,    intent(out) :: h(:,:)
    integer, intent(out) :: rc                   ! Error return code: __SUCCESS__ or __FAIL__
 
 ! !DESCRIPTION: Compute dust emissions using NOAA/ARL FENGSHA model
@@ -346,7 +346,6 @@ CONTAINS
    integer, dimension(2) :: ilb, iub
    real                  :: alpha_grav
    real                  :: fracland
-   real                  :: h
    real                  :: kvh
    real                  :: q
    real                  :: rustar
@@ -405,24 +404,24 @@ CONTAINS
          !  Compute threshold wind friction velocity using drag partition
          !  -------------------------------------------------------------
          rustar = rdrag(i,j) * ustar(i,j)
+         
+         ! Fecan moisture correction
+         ! -------------------------
+         h(i,j) = moistureCorrectionFecan(slc(i,j), sand(i,j), clay(i,j), drylimit_factor)
 
+         ! Adjust threshold
+         ! ----------------
+         u_thresh = uthrs(i,j) * h(i,j)
+         
+         u_sum = rustar + u_thresh
+         
+         ! Compute Horizontal Saltation Flux according to Eq (9) in Webb et al. (2020)
+         ! ---------------------------------------------------------------------------
+         q = max(0., rustar - u_thresh) * u_sum * u_sum
+         
          !  Now compute size-dependent total emission flux
          !  ----------------------------------------------
          do n = 1, nbins
-           ! Fecan moisture correction
-           ! -------------------------
-           h = moistureCorrectionFecan(slc(i,j), sand(i,j), clay(i,j), rhop(n))
-
-           ! Adjust threshold
-           ! ----------------
-           u_thresh = uthrs(i,j) * h
-
-           u_sum = rustar + u_thresh
-
-           ! Compute Horizontal Saltation Flux according to Eq (9) in Webb et al. (2020)
-           ! ---------------------------------------------------------------------------
-           q = max(0., rustar - u_thresh) * u_sum * u_sum
-
            ! Distribute emissions to bins and convert to mass flux (kg s-1)
            ! --------------------------------------------------------------
            emissions(i,j,n) = distribution(n) * total_emissions * q


### PR DESCRIPTION
Found an issue with the gravimetric soil moisture units used within the FECAN soil moisture correction.  This fixes that as well as adds a few knobs to be able to tune the soil moisture and drylimit within the dust scheme.