### PR TITLE
Workaround for MAPL dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ endif ()
 
 if (UFS_GOCART)
   find_package (GFTL_SHARED REQUIRED)
+  # Dom Heinzeller 2023/08/30 - workaround until https://github.com/GEOS-ESM/MAPL/pull/2320
+  # is merged and finds its way into the ufs-weather-model dependency tree
+  find_package (FARGPARSE QUIET)
+  find_package (PFLOGGER QUIET)
+  #
   find_package (MAPL REQUIRED)
   include(mapl_acg)
 elseif (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/ESMF/Shared/MAPL@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if (UFS_GOCART)
   find_package (GFTL_SHARED REQUIRED)
   # Dom Heinzeller 2023/08/30 - workaround until https://github.com/GEOS-ESM/MAPL/pull/2320
   # is merged and finds its way into the ufs-weather-model dependency tree
+  find_package (YAFYAML QUIET)
   find_package (FARGPARSE QUIET)
   find_package (PFLOGGER QUIET)
   #


### PR DESCRIPTION
There is a long discussion in the ufs-weather-model (https://github.com/ufs-community/ufs-weather-model/issues/1854) and in MAPL (https://github.com/GEOS-ESM/MAPL/pull/2320) on missing (implicit) dependencies for MAPL. It's been fixed in MAPL develop, but this version won't be used in the software stack for a while.

Meanwhile, we need to find the dependencies for GOCART in spack-stack-1.5.0 explicitly. Because of the `QUIET` attribute, this won't break other software environments where one or more of `fargparse`, `yafyaml`, `pflogger` are not installed.