### PR TITLE
Feature/acollow/#277-useGCsuffixforCAlongnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
-Long names for carbon diagnostics to use BC, OC, and BR instead of CA.*
+- Long names for carbon diagnostics to use BC, OC, and BR instead of CA.* 
+  - Note this requires MAPL v2.35.3+R21C_v1.2.0 or later
 
 ## v2.1.2+R21C_v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
-- Long names for carbon diagnostics to use BC, OC, and BR instead of CA.* 
+
+- Long names for carbon diagnostics to use BC, OC, and BR instead of CA.*
   - Note this requires MAPL v2.35.3+R21C_v1.2.0 or later
+- Update `components.yaml` to match the `R21C` branch of GEOSgcm
 
 ## v2.1.2+R21C_v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
-Long names in State Spec files
+Long names for carbon diagnostics to use BC, OC, and BR instead of CA.*
 
 ## v2.1.2+R21C_v1.0.1
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CMakeLists.txt
@@ -4,9 +4,11 @@ esma_add_library (${this}
   SRCS ${this}Mod.F90
   DEPENDENCIES MAPL GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran)
 
-mapl_acg (${this}   CA2G_StateSpecs.rc 
-          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 
-          GET_POINTERS DECLARE_POINTERS)
+mapl_acg (${this}   CA2G_StateSpecs.rc
+          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
+          GET_POINTERS DECLARE_POINTERS
+          LONG_NAME_PREFIX "GCsuffix")
+
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)
 foreach ( file ${rc_files} )

--- a/components.yaml
+++ b/components.yaml
@@ -5,19 +5,19 @@ GOCART:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v4.2.0
+  tag: v4.9.1
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.17.0
+  tag: v3.26.0
   develop: develop
 
 ecbuild:
   local: ./cmake@/ecbuild@
   remote: ../ecbuild.git
-  tag: geos/v1.2.0
+  tag: geos/v1.3.0
 
 HEMCO:
   local: ./ESMF/HEMCO_GridComp@
@@ -27,12 +27,12 @@ HEMCO:
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.5.6
+  tag: v1.7.2+R21C_v1.0.0
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.23.1
-  develop: develop
+  tag: v2.35.3+R21C_v1.2.0
+  develop: R21C


### PR DESCRIPTION
CMakeLists.txt was edit by adding:
mapl_acg (${this}   CA2G_StateSpecs.rc
          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
          GET_POINTERS DECLARE_POINTERS
          LONG_NAME_PREFIX "GCsuffix")

This, alongside a MAPL update that has been merged into R21C, will allow for the GCsuffix (BC, OC, and BR) to be used instead of CA.* in the long names for carbon diagnostics.