### PR TITLE
Update ESMF CMake target to ESMF::ESMF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update ESMF CMake target to `ESMF::ESMF`
 - Modified the file paths in carbon, sulfate, and nitrate ExtData.yaml files to used the revised version of the CEDS anthropogenic emissions. Note the previous version has an incorrect seasonal cycle.
 - State Spec RC files for GOCART2G, CA, DU, NI, SU, and SS were updated such that the long names for AOD are more intuitive
 - Modified ExtData.yaml files to persist as climatological anthropogenic emissions after the end of the CEDS dataset in 2019. Analogous rc files removed as this capability is only available with ExtData2G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ### Removed
 
 - Removed all ExtData.rc files
 
-### Changed
-- Modified the file paths in carbon, sulfate, and nitrate ExtData.yaml files to used the revised version of the CEDS anthropogenic emissions. Note the previous version has an incorrect seasonal cycle.
-
-
-## [Unreleased] - 2024-05-14
-
-### Added
-
-- Required attributes for the 2D GOCART export fields in AERO_DP bundle have been set in subroutine append_to_bundle in Chem_AeroGeneric.F90. These export fields are imported by OBIO via Surface GC, and the missing of the attributes was causing the writing of surface import checkpoint to fail. The issue has been explained in detail on https://github.com/GEOS-ESM/GOCART/issues/258  
-
-
-## [Unreleased] - 2023-07-24
-
-
 ### Fixed
 
-
 - corrected reading variable 'rhod' from files ( it was mispelled as 'rhop')
-
 - Silenced unwarranted error messages from wavelength/channel retrieval functions occurring when 470nm and/or 870nm channels are not included in GOCART resource file.
-
 - Add explicit `find_package()` calls for missing dependencies for MAPL for builds with spack-stack. Will eventually be fixed in MAPL in later versions
 - Corrected the units of the gravimetric soil moisture to percent instead of fractional in the FENGSHA dust scheme.
 - Fix issue of GOCART/GEOSgcm circular CMake dependencies when used as external project
@@ -37,13 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Additional tuning parameters for the soil moisture and drylimit calculations for application specific tuning.
+- Required attributes for the 2D GOCART export fields in AERO_DP bundle have been set in subroutine append_to_bundle in Chem_AeroGeneric.F90. These export fields are imported by OBIO via Surface GC, and the missing of the attributes was causing the writing of surface import checkpoint to fail. The issue has been explained in detail on https://github.com/GEOS-ESM/GOCART/issues/258
 
 ### Changed
 
+- Modified the file paths in carbon, sulfate, and nitrate ExtData.yaml files to used the revised version of the CEDS anthropogenic emissions. Note the previous version has an incorrect seasonal cycle.
 - State Spec RC files for GOCART2G, CA, DU, NI, SU, and SS were updated such that the long names for AOD are more intuitive
-
 - Modified ExtData.yaml files to persist as climatological anthropogenic emissions after the end of the CEDS dataset in 2019. Analogous rc files removed as this capability is only available with ExtData2G
-
 - Update `components.yaml` to match that of GEOSgcm v11.6.1
   - ESMA_env v4.29.0 (Baselibs 7.24.0, Updates for SLES15 at NCCS, various fixes)
   - ESMA_cmake v3.48.0 (Fixes for NAS, debug flags, Updates for SLES15 at NCCS, MPI detection, ESMF and MPI CMake fixes for Spack)
@@ -53,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct soil moisture parameterization in FENGSHA
 - Add `soil_moisture_factor` to the DU2G_instance_DU.rc (same name used in the K14 scheme) and DU2G_GridCompMod.F90 files for FENGSHA
 - Add `soil_drylimit_factor` to the DU2G_instance_DU.rc and DU2G_GridCompMod.F90 files for FENGSHA
-
 - Moved process library macros to header file.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Required attributes for the 2D GOCART export fields in AERO_DP bundle have been set in subroutine append_to_bundle in Chem_AeroGeneric.F90. These export fields are imported by OBIO via Surface GC, and the missing of the attributes was causing the writing of surface import checkpoint to fail. The issue has been explained in detail on https://github.com/GEOS-ESM/GOCART/issues/258  
-
 - Additional tuning parameters for the soil moisture and drylimit calculations for application specific tuning.
 - Required attributes for the 2D GOCART export fields in AERO_DP bundle have been set in subroutine append_to_bundle in Chem_AeroGeneric.F90. These export fields are imported by OBIO via Surface GC, and the missing of the attributes was causing the writing of surface import checkpoint to fail. The issue has been explained in detail on https://github.com/GEOS-ESM/GOCART/issues/258
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CARMA
 
 - Update ESMF CMake target to `ESMF::ESMF`
-- Modified the file paths in carbon, sulfate, and nitrate ExtData.yaml files to used the revised version of the CEDS anthropogenic emissions. Note the previous version has an incorrect seasonal cycle.
 
 - Changed SU2G_instance_SU.rc to now have separate filename inputs for explosive and degassing volcanoes
 - Moved present volcanic emission inventories to one or the other line for these new entries; set other

--- a/ESMF/Aerosol_GridComp/CMakeLists.txt
+++ b/ESMF/Aerosol_GridComp/CMakeLists.txt
@@ -4,7 +4,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Aerosol_GridComp.F90)
 
     esma_add_library (${this}
             SRCS Aerosol_GridComp.F90
-            DEPENDENCIES GOCART2G_GridComp MAPL esmf)
+            DEPENDENCIES GOCART2G_GridComp MAPL ESMF::ESMF)
 
     mapl_acg (${this} Aerosol_StateSpecs.rc
             IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS

--- a/ESMF/Apps/CMakeLists.txt
+++ b/ESMF/Apps/CMakeLists.txt
@@ -1,7 +1,7 @@
 esma_set_this ()
 
 set (srcs
-  GOCART2G_SimpleBundleMod.F90 
+  GOCART2G_SimpleBundleMod.F90
   aop_calculator.F90
   GOCART2G_AopMod.F90
   )
@@ -18,10 +18,10 @@ endforeach ()
 set (resource_files
    aop_calculator.rc
    )
-install( FILES ${resource_files} 
+install( FILES ${resource_files}
    DESTINATION etc
    )
-esma_add_library(${this} 
-  SRCS ${srcs} 
-  DEPENDENCIES MAPL Process_Library esmf NetCDF::NetCDF_Fortran
+esma_add_library(${this}
+  SRCS ${srcs}
+  DEPENDENCIES MAPL Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
   )

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CMakeLists.txt
@@ -2,10 +2,10 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPL GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES MAPL GA_Environment Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran)
 
-mapl_acg (${this}   CA2G_StateSpecs.rc 
-          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 
+mapl_acg (${this}   CA2G_StateSpecs.rc
+          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
           GET_POINTERS DECLARE_POINTERS)
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)

--- a/ESMF/GOCART2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/CMakeLists.txt
@@ -15,13 +15,13 @@ set (srcs
 
 set (resource_files
    GOCART2G_GridComp.rc
-   ) 
+   )
 
-install( FILES ${resource_files} 
+install( FILES ${resource_files}
    DESTINATION etc
    )
 
-set (dependencies MAPL Chem_Shared2G Process_Library esmf)
+set (dependencies MAPL Chem_Shared2G Process_Library ESMF::ESMF)
 esma_add_library (${this}
   SRCS ${srcs}
   SUBCOMPONENTS ${alldirs}

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
@@ -2,10 +2,10 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran)
 
-mapl_acg (${this}   DU2G_StateSpecs.rc 
-          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 
+mapl_acg (${this}   DU2G_StateSpecs.rc
+          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
           GET_POINTERS DECLARE_POINTERS)
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)

--- a/ESMF/GOCART2G_GridComp/GA_Environment/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPL Chem_Shared2G Process_Library esmf
+  DEPENDENCIES MAPL Chem_Shared2G Process_Library ESMF::ESMF
   )
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/CMakeLists.txt
@@ -2,10 +2,10 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran)
 
-mapl_acg (${this}   NI2G_StateSpecs.rc 
-          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 
+mapl_acg (${this}   NI2G_StateSpecs.rc
+          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
           GET_POINTERS DECLARE_POINTERS)
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
@@ -2,10 +2,10 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPL GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES MAPL GA_Environment Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran)
 
-mapl_acg (${this}   SS2G_StateSpecs.rc 
-          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 
+mapl_acg (${this}   SS2G_StateSpecs.rc
+          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
           GET_POINTERS DECLARE_POINTERS)
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library esmf)
+  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library ESMF::ESMF)
 
 mapl_acg (${this}   SU2G_StateSpecs.rc
           IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS

--- a/ESMF/GOCART_GridComp/CFC_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART_GridComp/CFC_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 esma_generate_gocart_code (${this} "-B\;-C\;-N\;GOCART")
 

--- a/ESMF/GOCART_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART_GridComp/CMakeLists.txt
@@ -22,7 +22,7 @@ install( FILES ${resource_files}
    DESTINATION etc
    )
 
-set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu esmf)
+set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu ESMF::ESMF)
 esma_add_library (${this}
   SRCS ${srcs}
   SUBCOMPONENTS ${alldirs}

--- a/ESMF/GOCART_GridComp/CO2_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART_GridComp/CO2_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 esma_generate_gocart_code (${this} "-B\;-C\;-N\;GOCART")
 

--- a/ESMF/GOCART_GridComp/CO_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART_GridComp/CO_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 esma_generate_gocart_code (${this} "-B\;-E\;-F\;-N\;GOCART")
 

--- a/ESMF/GOCART_GridComp/Rn_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART_GridComp/Rn_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES Chem_Shared Chem_Base GMAO_mpeu MAPL_cfio_r4 ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 esma_generate_gocart_code (${this} "-B\;-E\;-F\;-N\;GOCART")
 

--- a/ESMF/Shared/CMakeLists.txt
+++ b/ESMF/Shared/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL esmf)
+  DEPENDENCIES MAPL ESMF::ESMF)
 
 if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/@GSW )
     set (gsw_ECBUILD_SYSTEM_INCLUDED TRUE)

--- a/ESMF/UFS/CMakeLists.txt
+++ b/ESMF/UFS/CMakeLists.txt
@@ -10,7 +10,7 @@ set (srcs
   Aerosol_Tracer_Mod.F90
   )
 
-set (dependencies Aerosol_GridComp MAPL esmf)
+set (dependencies Aerosol_GridComp MAPL ESMF::ESMF)
 esma_add_library (${this}
   SRCS ${srcs}
   DEPENDENCIES ${dependencies})

--- a/Process_Library/CMakeLists.txt
+++ b/Process_Library/CMakeLists.txt
@@ -5,9 +5,9 @@ set (srcs
   GOCART2G_Process.F90
   )
 
-esma_add_library(${this} 
-  SRCS ${srcs} 
-  DEPENDENCIES esmf NetCDF::NetCDF_Fortran
+esma_add_library(${this}
+  SRCS ${srcs}
+  DEPENDENCIES ESMF::ESMF NetCDF::NetCDF_Fortran
   )
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280


### PR DESCRIPTION
This PR updates the ESMF CMake target to `ESMF::ESMF` which is the correct canonical target name for ESMF. NOTE: This requires ESMF 8.6.1 or later.

This reflects the target name requested by our Spack-using colleagues and is the "right" thing to do CMake-wise. This should pass all CMake tests...