### PR TITLE
Feature/v2.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
-# Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v11.00.0
+# Anchors in case we need to override the defaults from the orb
+#baselibs_version: &baselibs_version v7.27.0
+#bcs_version: &bcs_version v11.6.0
 
 orbs:
-  ci: geos-esm/circleci-tools@1
+  ci: geos-esm/circleci-tools@4
 
 workflows:
   build-and-test:
@@ -18,7 +18,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: *baselibs_version
+          #baselibs_version: *baselibs_version
           repo: GOCART
           buildtarget: GOCART2G_GridComp
           mepodevelop: true
@@ -32,7 +32,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: *baselibs_version
+          #baselibs_version: *baselibs_version
           repo: GOCART
           buildtarget: GOCART2G_GridComp
           mepodevelop: true
@@ -47,7 +47,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: *baselibs_version
+          #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true

--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -15,7 +15,7 @@ jobs:
   validate-YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: yaml-lint
         name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
@@ -24,7 +24,7 @@ jobs:
           format: colored
           config_file: .yamllint.yml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: yamllint-logfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - feature/acollow/#233_aodlongnames
+## [Unreleased]
 
 ### Fixed
 
 ### Added
 
 ### Changed
-<<<<<<< HEAD
--Filepath for CEDS has been updated in the ExtData yaml and rc files. Note the old version had an incorrect seasonal cycle.
-=======
-State Spec RC files for GOCART2G, CA, DU, NI, SU, and SS were updated such that the long names for AOD are more intuitive
->>>>>>> 3bb515b (state spec RC files for GOCART2G, CA, DU, NI, SU, and SS are updated to make AOD long names more intuitive for users, addressing issue #233)
+
+## [v2.3.0] - 2025-MM-DD
+
+### Changed
+
+- Filepath for CEDS has been updated in the ExtData yaml and rc files. Note the old version had an incorrect seasonal cycle.
+- State Spec RC files for GOCART2G, CA, DU, NI, SU, and SS were updated such that the long names for AOD are more intuitive
+- Updated CI to use v4 orb
+- Update components.yaml to match GEOSgcm `main` as of 2025-01-16
 
 ## [v2.2.1] - 2023-05-30
 
 ### Fixed
 
 - In dust and sea-salt, changed dimensions back to `globalCellCountPerDim` since these are needed to determine emission tuning parameters, not to allocate arrays.
-
 
 ## [v2.2.0] - 2023-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+-Filepath for CEDS has been updated in the ExtData yaml and rc files. Note the old version had an incorrect seasonal cycle.
 
 ## [v2.2.1] - 2023-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] - feature/acollow/#233_aodlongnames
 
 ### Fixed
 
 ### Added
 
 ### Changed
+<<<<<<< HEAD
 -Filepath for CEDS has been updated in the ExtData yaml and rc files. Note the old version had an incorrect seasonal cycle.
+=======
+State Spec RC files for GOCART2G, CA, DU, NI, SU, and SS were updated such that the long names for AOD are more intuitive
+>>>>>>> 3bb515b (state spec RC files for GOCART2G, CA, DU, NI, SU, and SS are updated to make AOD long names more intuitive for users, addressing issue #233)
 
 ## [v2.2.1] - 2023-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [v2.3.0] - 2025-MM-DD
+## [v2.3.0] - 2025-01-16
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ foreach (dir IN LISTS ESMA_CMAKE_DIRS)
   endif ()
 endforeach ()
 
+# Set build options
+option (UFS_GOCART "Build GOCART component for UFS" OFF)
+
+# Any UFS build of GOCART is by definition a standalone build
+if(UFS_GOCART)
+  set(GOCART_STANDALONE TRUE)
+endif()
+
 if (GOCART_STANDALONE)
   project (
           GOCART
@@ -38,9 +46,6 @@ if (GOCART_STANDALONE)
               "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
   endif ()
 endif()
-
-# Set build options
-option (UFS_GOCART "Build GOCART component for UFS" OFF)
 
 set (DOING_GEOS5 YES)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,25 +2,6 @@ cmake_minimum_required (VERSION 3.17)
 cmake_policy (SET CMP0053 NEW)
 cmake_policy (SET CMP0054 NEW)
 
-project (
-        GOCART
-        VERSION 2.1.1
-        LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
-
-if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
-    message(SEND_ERROR "In-source builds are disabled. Please
-           issue cmake command in separate build directory.")
-endif ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
-
-# Set the default build type to release
-if (NOT CMAKE_BUILD_TYPE)
-    message (STATUS "Setting build type to 'Release' as none was specified.")
-    set (CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-    # Set the possible values of build type for cmake-gui
-    set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-            "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif ()
-
 # mepo can now clone subrepos in three styles
 set (ESMA_CMAKE_DIRS
   cmake
@@ -36,6 +17,27 @@ foreach (dir IN LISTS ESMA_CMAKE_DIRS)
     set(GOCART_STANDALONE TRUE)
   endif ()
 endforeach ()
+
+if (GOCART_STANDALONE)
+  project (
+          GOCART
+          VERSION 2.1.1
+          LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
+
+  if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+      message(SEND_ERROR "In-source builds are disabled. Please
+            issue cmake command in separate build directory.")
+  endif ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+
+  # Set the default build type to release
+  if (NOT CMAKE_BUILD_TYPE)
+      message (STATUS "Setting build type to 'Release' as none was specified.")
+      set (CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+      # Set the possible values of build type for cmake-gui
+      set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+              "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+  endif ()
+endif()
 
 # Set build options
 option (UFS_GOCART "Build GOCART component for UFS" OFF)
@@ -61,7 +63,9 @@ if (NOT COMMAND esma)
     include (esma)
 endif()
 
-ecbuild_declare_project()
+if(GOCART_STANDALONE)
+  ecbuild_declare_project()
+endif()
 
 if (NOT Baselibs_FOUND)
   # Find dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ endforeach ()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.1.1
+          VERSION 2.3.0
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,22 @@ if (NOT CMAKE_BUILD_TYPE)
             "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif ()
 
+# mepo can now clone subrepos in three styles
+set (ESMA_CMAKE_DIRS
+  cmake
+  @cmake
+  cmake@
+  )
+
+foreach (dir IN LISTS ESMA_CMAKE_DIRS)
+  if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
+    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
+    set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
+    include (esma)
+    set(GOCART_STANDALONE TRUE)
+  endif ()
+endforeach ()
+
 # Set build options
 option (UFS_GOCART "Build GOCART component for UFS" OFF)
 
@@ -81,7 +97,9 @@ include_directories(${MPI_Fortran_INCLUDE_PATH})
 add_subdirectory (ESMF)
 add_subdirectory (Process_Library)
 
-ecbuild_install_project (NAME GOCART)
+if(GOCART_STANDALONE)
+  ecbuild_install_project (NAME GOCART)
+endif()
 
 # https://www.scivision.dev/cmake-auto-gitignore-build-dir/
 # --- auto-ignore build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required (VERSION 3.17)
 cmake_policy (SET CMP0053 NEW)
 cmake_policy (SET CMP0054 NEW)
 
-# mepo can now clone subrepos in three styles
+# Let's look for the ESMA cmake directory in a few places
+# to see if we are building standalone
 set (ESMA_CMAKE_DIRS
   cmake
   @cmake
@@ -13,7 +14,6 @@ foreach (dir IN LISTS ESMA_CMAKE_DIRS)
   if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
     list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
     set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
-    include (esma)
     set(GOCART_STANDALONE TRUE)
   endif ()
 endforeach ()
@@ -59,7 +59,6 @@ if (UFS_GOCART)
 endif()
 
 if (NOT COMMAND esma)
-    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake@")
     include (esma)
 endif()
 
@@ -81,6 +80,12 @@ endif ()
 
 if (UFS_GOCART)
   find_package (GFTL_SHARED REQUIRED)
+  # Dom Heinzeller 2023/08/30 - workaround until https://github.com/GEOS-ESM/MAPL/pull/2320
+  # is merged and finds its way into the ufs-weather-model dependency tree
+  find_package (YAFYAML QUIET)
+  find_package (FARGPARSE QUIET)
+  find_package (PFLOGGER QUIET)
+  #
   find_package (MAPL REQUIRED)
   include(mapl_acg)
 elseif (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/ESMF/Shared/MAPL@")

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP.20C/CA2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP.20C/CA2G_GridComp_ExtData.rc
@@ -54,14 +54,14 @@ OC_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass /dev/null
 OC_BIOFUEL NA  Y Y %y4-%m2-%d2t12:00:00 none none biofuel /dev/null
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-OC_ANTEOC1 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_nonenergy ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-OC_ANTEOC2 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_energy    ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+OC_ANTEOC1 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_nonenergy ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+OC_ANTEOC2 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_energy    ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # EDGAR based ship emissions
-OC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none oc_shipping  ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+OC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none oc_shipping  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-OC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/chemistry/CEDS/v2021-04-21/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+OC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # Aviation emissions during the three phases of flight
 OC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_aviation /dev/null
@@ -81,14 +81,14 @@ BC_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass ExtData/chemistry/HFE
 BC_BIOFUEL NA  Y Y %y4-%m2-%d2t12:00:00 none none biofuel /dev/null
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-BC_ANTEBC1 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_nonenergy ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-BC_ANTEBC2 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_energy    ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+BC_ANTEBC1 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_nonenergy ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+BC_ANTEBC2 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_energy    ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # EDGAR based ship emissions
-BC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none bc_shipping  ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+BC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none bc_shipping  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-BC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/chemistry/CEDS/v2021-04-21/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+BC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # Aviation emissions during the LTO, SDC and CRS phases of flight
 BC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none bc_aviation /dev/null

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.rc
@@ -54,14 +54,14 @@ OC_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass /dev/null
 OC_BIOFUEL NA  Y Y %y4-%m2-%d2t12:00:00 none none biofuel /dev/null
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-OC_ANTEOC1 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_nonenergy ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-OC_ANTEOC2 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_energy    ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+OC_ANTEOC1 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_nonenergy ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+OC_ANTEOC2 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_energy    ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # EDGAR based ship emissions
-OC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none oc_shipping  ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+OC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none oc_shipping  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-OC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/chemistry/CEDS/v2021-04-21/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+OC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # Aviation emissions during the three phases of flight
 OC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_aviation /dev/null
@@ -81,14 +81,14 @@ BC_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass ExtData/chemistry/QFE
 BC_BIOFUEL NA  Y Y %y4-%m2-%d2t12:00:00 none none biofuel /dev/null
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-BC_ANTEBC1 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_nonenergy ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-BC_ANTEBC2 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_energy    ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+BC_ANTEBC1 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_nonenergy ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+BC_ANTEBC2 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_energy    ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # EDGAR based ship emissions
-BC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none bc_shipping  ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+BC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none bc_shipping  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-BC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/chemistry/CEDS/v2021-04-21/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+BC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # Aviation emissions during the LTO, SDC and CRS phases of flight
 BC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none bc_aviation /dev/null

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
@@ -1,20 +1,20 @@
 Collections:
   CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
   CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
   CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
   CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
   CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
   CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
   CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
   CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
   CA2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
     valid_range: "2008-01-01T12:00:00/2008-12-15T12:00:00"

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.rc
@@ -54,14 +54,14 @@ OC_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass /dev/null
 OC_BIOFUEL NA  Y Y %y4-%m2-%d2t12:00:00 none none biofuel /dev/null
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-OC_ANTEOC1 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_nonenergy ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-OC_ANTEOC2 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_energy    ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+OC_ANTEOC1 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_nonenergy ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+OC_ANTEOC2 NA  N Y %y4-%m2-%d2t12:00:00 none none oc_energy    ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # EDGAR based ship emissions
-OC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none oc_shipping  ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+OC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none oc_shipping  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-OC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/chemistry/CEDS/v2021-04-21/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+OC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # Aviation emissions during the three phases of flight
 OC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_aviation /dev/null
@@ -81,14 +81,14 @@ BC_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass ExtData/chemistry/QFE
 BC_BIOFUEL NA  Y Y %y4-%m2-%d2t12:00:00 none none biofuel /dev/null
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-BC_ANTEBC1 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_nonenergy ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-BC_ANTEBC2 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_energy    ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+BC_ANTEBC1 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_nonenergy ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+BC_ANTEBC2 NA  N Y %y4-%m2-%d2t12:00:00 none none bc_energy    ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # EDGAR based ship emissions
-BC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none bc_shipping  ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+BC_SHIP    NA  N Y %y4-%m2-%d2t12:00:00 none none bc_shipping  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-BC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/chemistry/CEDS/v2021-04-21/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+BC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # Aviation emissions during the LTO, SDC and CRS phases of flight
 BC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none bc_aviation /dev/null

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -1,20 +1,20 @@
 Collections:
   CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
   CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
   CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
   CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
   CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
   CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
   CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
   CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
   CA2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
     valid_range: "2008-01-01T12:00:00/2008-12-15T12:00:00"

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -97,10 +97,10 @@ category: EXPORT
  *PSOA        | kg m-2 s-1   | xy    | N     |                                | * Aerosol SOA Production
  *SMASS       | kg m-3       | xy    | N     |                                | * Aerosol Surface Mass Concentration
  *CMASS       | kg m-2       | xy    | N     |                                | * Aerosol Column Mass Density
- *EXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Extinction AOT
- *STEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Extinction AOT Stratosphere
- *SCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Scattering AOT
- *STSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Scattering AOT Stratosphere
+ *EXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Optical Depth
+ *STEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Stratospheric Aerosol Optical Thickness
+ *SCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | * Aerosol Optical Depth Due to Scattering
+ *STSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | * Stratospheric Aerosol Optical Thickness Due to Scattering
  *ANGSTR      | 1            | xy    | N     |                                | * Aerosol Angstrom parameter [470-870 nm]
  *FLUXU       | kg m-1 s-1   | xy    | N     |                                | * Aerosol column u-wind mass flux
  *FLUXV       | kg m-1 s-1   | xy    | N     |                                | * Aerosol column v-wind mass flux

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CMakeLists.txt
@@ -4,9 +4,11 @@ esma_add_library (${this}
   SRCS ${this}Mod.F90
   DEPENDENCIES MAPL GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran)
 
-mapl_acg (${this}   CA2G_StateSpecs.rc 
-          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 
-          GET_POINTERS DECLARE_POINTERS)
+mapl_acg (${this}   CA2G_StateSpecs.rc
+          IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS
+          GET_POINTERS DECLARE_POINTERS
+          LONG_NAME_PREFIX "GCsuffix")
+
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)
 foreach ( file ${rc_files} )

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -71,19 +71,19 @@ category: EXPORT
 #........................................................................................
  DUSMASS       | kg m-3     | xy   | N    |                                | Dust Surface Mass Concentration
  DUCMASS       | kg m-2     | xy   | N    |                                | Dust Column Mass Density
- DUEXTTAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Extinction AOT
- DUSTEXTTAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Extinction AOT Stratosphere
- DUSCATAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Scattering AOT
- DUSTSCATAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Scattering AOT Stratosphere
- DUSMASS25     | kg m-3     | xy   | N    |                                | Dust Surface Mass Concentration - PM 2.5
- DUCMASS25     | kg m-2     | xy   | N    |                                | Dust Column Mass Density - PM 2.5
- DUEXTT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Extinction AOT - PM 2.5
- DUSCAT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Scattering AOT - PM 2.5
+ DUEXTTAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Aerosol Optical Depth
+ DUSTEXTTAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Stratospheric Aerosol Optical Thickness
+ DUSCATAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Aerosol Optical Depth Due to Scattering
+ DUSTSCATAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Stratospheric Aerosol Optical Thickness Due to Scattering
+ DUSMASS25     | kg m-3     | xy   | N    |                                | Dust Surface Mass Concentration of Particulate Matter < 2.5 microns (PM 2.5)
+ DUCMASS25     | kg m-2     | xy   | N    |                                | Dust Column Mass Density of Particulate Matter < 2.5 microns (PM 2.5)
+ DUEXTT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Aerosol Optical Depth from Particulate Matter < 2.5 microns (PM2.5)
+ DUSCAT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Aerosol Optical Depth Due to Scattering from Particulate Matter < 2.5 microns (PM2.5)
  DUAERIDX      | 1          | xy   | N    |                                | Dust TOMS UV Aerosol Index
  DUFLUXU       | kg m-1 s-1 | xy   | N    |                                | Dust column u-wind mass flux
  DUFLUXV       | kg m-1 s-1 | xy   | N    |                                | Dust column v-wind mass flux
- DUEXTTFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Extinction AOT - PM 1.0 um
- DUSCATFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Scattering AOT - PM 1.0 um
+ DUEXTTFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Aerosol Optical Depth from Particulate Matter < 1 micron (PM1.0)
+ DUSCATFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Dust Aerosol Optical Depth Due to Scattering from Particulate Matter < 1 micron (PM1.0)
  DUANGSTR      | 1          | xy   | N    |                                | Dust Angstrom parameter [470-870 nm]
  DUEM          | kg m-2 s-1 | xy   | N    | self%nbins                     | Dust Emission (Bin %d)
  DUSD          | kg m-2 s-1 | xy   | N    | self%nbins                     | Dust Sedimentation (Bin %d)

--- a/ESMF/GOCART2G_GridComp/GOCART2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_StateSpecs.rc
@@ -21,14 +21,14 @@ category: EXPORT
 #----------------------------------------------------------------------------------------
  PSO4TOT        | kg m-2 s-1 | xyz  | C    |                                | Total Sulfate Produced in GOCART
 #........................................................................................
- TOTEXTTAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Extinction AOT [550 nm]
- TOTSTEXTTAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Extinction AOT [550 nm] Stratosphere
- TOTSCATAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Scattering AOT [550 nm]
- TOTSTSCATAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Scattering AOT [550 nm] Stratosphere
- TOTEXTT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Extinction AOT [550 nm] - PM2.5
- TOTSCAT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Extinction AOT [550 nm] - PM2.5
- TOTEXTTFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Extinction AOT [550 nm] - PM1.0
- TOTSCATFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Extinction AOT [550 nm] - PM1.0
+ TOTEXTTAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Optical Depth at 550 nm
+ TOTSTEXTTAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Stratospheric Aerosol Optical Thickness at 550 nm
+ TOTSCATAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Optical Depth at 550 nm Due to Scattering
+ TOTSTSCATAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Stratospheric Aerosol Optical Thickness at 550 nm Due to Scattering
+ TOTEXTT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Optical Depth at 550 nm from Particluate Matter < 2.5 microns  (PM2.5)
+ TOTSCAT25      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Optical Depth at 550 nm Due to Scattering from Particulate Matter < 2.5 microns (PM2.5)
+ TOTEXTTFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Optical Depth at 550 nm from Particluate Matter < 1 micron  (PM1.0)
+ TOTSCATFM      | 1          | xy   | N    | size(self%wavelengths_vertint) | Total Aerosol Optical Depth at 550 nm Due to Scattering from Particulate Matter < 1 micron (PM1.0)
  TOTANGSTR      | 1          | xy   | N    |            | Total Aerosol Angstrom parameter [470-870 nm]
  TOTEXTCOEF     | m-1        | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Extinction coefficient
  TOTEXTCOEFRH20 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Extinction coefficient - Fixed RH=20%
@@ -39,12 +39,12 @@ category: EXPORT
  TOTBCKCOEF     | m-1 sr-1   | xyz  | C    | size(self%wavelengths_profile) | Total Aerosol Single Scattering Backscatter coefficient
  TOTABCKTOA     | m-1 sr-1   | xyz  | C    |                                | Total Attenuated Backscatter Coefficient from TOA [532nm]
  TOTABCKSFC     | m-1 sr-1   | xyz  | C    |                                | Total Attenuated Backscatter Coefficient from surface [532nm]
- PM             | kg m-3     | xy   | N    |            | Total reconstructed PM
- PM_RH35        | kg m-3     | xy   | N    |            | Total reconstructed PM(RH=35%)
- PM_RH50        | kg m-3     | xy   | N    |            | Total reconstructed PM(RH=50%)
- PM25           | kg m-3     | xy   | N    |            | Total reconstructed PM2.5
- PM25_RH35      | kg m-3     | xy   | N    |            | Total reconstructed PM2.5(RH=35%)
- PM25_RH50      | kg m-3     | xy   | N    |            | Total reconstructed PM2.5(RH=50%)
+ PM             | kg m-3     | xy   | N    |            | Total Reconstructed Dry Particulate Matter
+ PM_RH35        | kg m-3     | xy   | N    |            | Total Reconstructed Particulate Matter at 35% Relative Humidity
+ PM_RH50        | kg m-3     | xy   | N    |            | Total Reconstructed Particulate Matter at 50% Relative Humidity
+ PM25           | kg m-3     | xy   | N    |            | Total Reconstructed Dry Particulate Matter < 2.5 microns (PM2.5)
+ PM25_RH35      | kg m-3     | xy   | N    |            | Total Reconstructed Particulate Matter < 2.5 microns (PM2.5) at 35% Relative Humidity
+ PM25_RH50      | kg m-3     | xy   | N    |            | Total Reconstructed Particulate Matter < 2.5 microns (PM2.5) at 50% Relative Humidity
 
 category: INTERNAL
 #----------------------------------------------------------------------------------------

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP.20C/NI2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP.20C/NI2G_GridComp_ExtData.rc
@@ -12,7 +12,7 @@ climNO3an3  'kg kg-1'  N    Y  F0   none      none     NO3AN3    /dev/null
 # ======= Nitrate Sources ========
 EMI_NH3_BB   'kg m-2 s-1'  N      Y      %y4-%m2-%d2T12:00:00    none     0.778     biomass     ExtData/chemistry/HFED/v1.0/Y%y4/hfed.emis_nh3.x576_y361_t14.%y4.nc4 
 EMI_NH3_AG   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
-EMI_NH3_EN   'kg m-2 s-1'  N      Y      %y4-%m2-%d2t12:00:00    none     none      nh3         ExtData/chemistry/CEDS/v2021-04-21/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+EMI_NH3_EN   'kg m-2 s-1'  N      Y      %y4-%m2-%d2t12:00:00    none     none      nh3         ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
 EMI_NH3_IN   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
 EMI_NH3_RE   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
 EMI_NH3_TR   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.rc
@@ -12,7 +12,7 @@ climNO3an3  'kg kg-1'  N    Y  F0   none      none     NO3AN3    /dev/null
 # ======= Nitrate Sources ========
 EMI_NH3_BB   'kg m-2 s-1'  N      Y      %y4-%m2-%d2T12:00:00    none     0.778     biomass     ExtData/chemistry/QFED/v2.6r1/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
 EMI_NH3_AG   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
-EMI_NH3_EN   'kg m-2 s-1'  N      Y      %y4-%m2-%d2t12:00:00    none     none      nh3         ExtData/chemistry/CEDS/v2021-04-21/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+EMI_NH3_EN   'kg m-2 s-1'  N      Y      %y4-%m2-%d2t12:00:00    none     none      nh3         ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
 EMI_NH3_IN   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
 EMI_NH3_RE   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
 EMI_NH3_TR   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
@@ -6,7 +6,7 @@ Collections:
   NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
     template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
   NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
   NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.6r1/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
     valid_range: "2000-02-29T12:00/2025-01-01"

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.rc
@@ -12,7 +12,7 @@ climNO3an3  'kg kg-1'  N    Y  F0   none      none     NO3AN3    /dev/null
 # ======= Nitrate Sources ========
 EMI_NH3_BB   'kg m-2 s-1'  N      Y      %y4-%m2-%d2T12:00:00    none     0.778     biomass     ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.006.%y4%m2%d2.nc4
 EMI_NH3_AG   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
-EMI_NH3_EN   'kg m-2 s-1'  N      Y      %y4-%m2-%d2t12:00:00    none     none      nh3         ExtData/chemistry/CEDS/v2021-04-21/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+EMI_NH3_EN   'kg m-2 s-1'  N      Y      %y4-%m2-%d2t12:00:00    none     none      nh3         ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
 EMI_NH3_IN   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
 EMI_NH3_RE   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null
 EMI_NH3_TR   'kg m-2 s-1'  Y      Y      %y4-%m2-%d2T12:00:00    none     none      nh3_emis    /dev/null

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -6,7 +6,7 @@ Collections:
   NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
     template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
   NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
   NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.006.%y4%m2%d2.nc4
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
@@ -49,12 +49,12 @@ category: EXPORT
   NH3MASS       | kg/kg        | xyz   | C     |                                | Ammonia Mass Mixing Ratio
   NH4MASS       | kg/kg        | xyz   | C     |                                | Ammonium Aerosol Mass Mixing Ratio
   NIMASS        | kg/kg        | xyz   | C     |                                | Nitrate Mass Mixing Ratio
-  NIMASS25      | kg/kg        | xyz   | C     |                                | Nitrate Mass Mixing Ratio [PM2.5]
+  NIMASS25      | kg/kg        | xyz   | C     |                                | Nitrate Mass Mixing Ratio of Particulate Matter < 2.5 microns (PM2.5)
   HNO3CONC      | kg m-3       | xyz   | C     |                                | Nitric Acid Mass Concentration
   NH3CONC       | kg m-3       | xyz   | C     |                                | Ammonia Mass Concentration
   NH4CONC       | kg m-3       | xyz   | C     |                                | Ammonium Mass Concentration
   NICONC        | kg m-3       | xyz   | C     |                                | Nitrate Mass Concentration
-  NICONC25      | kg m-3       | xyz   | C     |                                | Nitrate Mass Concentration [PM2.5]
+  NICONC25      | kg m-3       | xyz   | C     |                                | Nitrate Mass Concentration of Particulate Matter < 2.5 microns (PM2.5)
   NIEXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Extinction Coefficient
   NIEXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Extinction Coefficient - fixed RH=20%
   NIEXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Extinction Coefficient - fixed RH=80%
@@ -83,20 +83,20 @@ category: EXPORT
   NH3SMASS      | kg m-3       | xy    | N     |                                | Ammonia Surface Mass Concentration
   NH4SMASS      | kg m-3       | xy    | N     |                                | Ammonium Surface Mass Concentration
   NISMASS       | kg m-3       | xy    | N     |                                | Nitrate Surface Mass Concentration
-  NISMASS25     | kg m-3       | xy    | N     |                                | Nitrate Surface Mass Concentration [PM2.5]
+  NISMASS25     | kg m-3       | xy    | N     |                                | Nitrate Surface Mass Concentration of Particulate Matter < 2.5 microns (PM2.5)
   HNO3CMASS     | kg m-3       | xy    | N     |                                | Nitric Acid Column Mass Density
   NH3CMASS      | kg m-3       | xy    | N     |                                | Ammonia Column Mass Density
   NH4CMASS      | kg m-3       | xy    | N     |                                | Ammonium Column Mass Density
   NICMASS       | kg m-2       | xy    | N     |                                | Nitrate Column Mass Density
-  NICMASS25     | kg m-2       | xy    | N     |                                | Nitrate Column Mass Density [PM2.5]
-  NIEXTTFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Extinction AOT - PM 1.0 um
-  NISCATFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Scattering AOT - PM 1.0 um
-  NIEXTT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Extinction AOT - PM 2.5 um
-  NISCAT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Scattering AOT - PM 2.5 um
-  NIEXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Extinction AOT
-  NISTEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Extinction AOT Stratosphere
-  NISCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Scattering AOT
-  NISTSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Scattering AOT Stratosphere
+  NICMASS25     | kg m-2       | xy    | N     |                                | Nitrate Column Mass Density of Particulate Matter < 2.5 microns (PM2.5)
+  NIEXTTFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Aerosol Optical Depth from Particulate Matter < 1 micron (PM1.0)
+  NISCATFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Aerosol Optical Depth Due to Scattering from Particulate Matter < 1 micron (PM1.0)
+  NIEXTT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Aerosol Optical Depth from Particulate Matter < 2.5 microns (PM2.5)
+  NISCAT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Aerosol Optical Depth Due to Scattering from Particulate Matter < 2.5 microns (PM2.5)
+  NIEXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Aerosol Optical Depth
+  NISTEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Stratospheric Aerosol Optical Thickness
+  NISCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Aerosol Optical Depth Due to Scattering
+  NISTSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Nitrate Stratospheric Aerosol Optical Thickness Due to Scattering
   NIANGSTR      | 1            | xy    | N     |                                | Nitrate Angstrom parameter [470-870 nm]
   NIFLUXU       | kg m-1 s-1   | xy    | N     |                                | Nitrate column u-wind mass flux
   NIFLUXV       | kg m-1 s-1   | xy    | N     |                                | Nitrate column v-wind mass flux

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_StateSpecs.rc
@@ -42,7 +42,7 @@ category: EXPORT
  NAME          | UNITS        | DIMS  | VLOC  | UNGRIDDED                      | LONG NAME
 #----------------------------------------------------------------------------------------
  SSMASS        | kg kg-1      | xyz   | C     |                                | Sea Salt Mass Mixing Ratio
- SSMASS25      | kg kg-1      | xyz   | C     |                                | Sea Salt Mass Mixing Ratio - PM 2.5
+ SSMASS25      | kg kg-1      | xyz   | C     |                                | Sea Salt Mass Mixing Ratio of Particulate Matter < 2.5 microns (PM2.5)
  SSCONC        | kg m-3       | xyz   | C     |                                | Sea Salt Mass Concentration
  SSEXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Extinction Coefficient
  SSEXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Extinction Coefficient - Fixed RH=20%
@@ -59,17 +59,17 @@ category: EXPORT
  SSSV          | kg m-2 s-1   | xy    | N     | self%nbins                     | Sea Salt Convective Scavenging (Bin %d)
  SSSMASS       | kg m-3       | xy    | N     |                                | Sea Salt Surface Mass Concentration
  SSCMASS       | kg m-2       | xy    | N     |                                | Sea Salt Column Mass Density
- SSEXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Extinction AOT
- SSSTEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Extinction AOT Stratosphere
- SSSCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Scattering AOT
- SSSTSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Scattering AOT Stratosphere
- SSSMASS25     | kg m-3       | xy    | N     |                                | Sea Salt Surface Mass Concentration - PM 2.5
- SSCMASS25     | kg m-2       | xy    | N     |                                | Sea Salt Column Mass Density - PM 2.5
- SSEXTT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Extinction AOT - PM 2.5
- SSSCAT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Scattering AOT - PM 2.5
+ SSEXTTAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Aerosol Optical Depth
+ SSSTEXTTAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Stratospheric Aerosol Optical Thickness
+ SSSCATAU      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Aerosol Optical Depth Due to Scattering
+ SSSTSCATAU    | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Stratospheric Aerosol Optical Thickness Due to Scattering
+ SSSMASS25     | kg m-3       | xy    | N     |                                | Sea Salt Surface Mass Concentration of Particulate Matter < 2.5 microns (PM2.5)
+ SSCMASS25     | kg m-2       | xy    | N     |                                | Sea Salt Column Mass Density of Particulate Matter < 2.5 microns (PM2.5)
+ SSEXTT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Aerosol Optical Depth from Particulate Matter < 2.5 microns (PM2.5)
+ SSSCAT25      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Aerosol Optical Depth Due to Scattering from Particulate Matter < 2.5 microns (PM2.5)
  SSAERIDX      | 1            | xy    | N     |                                | Sea Salt TOMS UV Aerosol Index
- SSEXTTFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Extinction AOT [550 nm] - PM 1.0 um
- SSSCATFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Scattering AOT [550 nm] - PM 1.0 um
+ SSEXTTFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Aerosol Optical Depth from Particulate Matter < 1 micron (PM1.0)
+ SSSCATFM      | 1            | xy    | N     | size(self%wavelengths_vertint) | Sea Salt Aerosol Optical Depth Due to Scattering from Particulate Matter < 1 micron (PM1.0)
  SSANGSTR      | 1            | xy    | N     |                                | Sea Salt Angstrom parameter [470-870 nm]
  SSFLUXU       | kg m-1 s-1   | xy    | N     |                                | Sea Salt column u-wind mass flux
  SSFLUXV       | kg m-1 s-1   | xy    | N     |                                | Sea Salt column v-wind mass flux

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_GridComp_ExtData.rc
@@ -36,15 +36,15 @@ climSUSV004    'kg m-2 s-1'   Y   N               0              0.0      1.0   
 SU_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass ExtData/chemistry/HFED/v1.0/Y%y4/hfed.emis_so2.x576_y361_t14.%y4.nc4
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-SU_ANTHROL1 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_nonenergy  ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-SU_ANTHROL2 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_energy     ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+SU_ANTHROL1 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_nonenergy  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+SU_ANTHROL2 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_energy     ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # Ship emissions
-SU_SHIPSO2    NA  N Y %y4-%m2-%d2t12:00:00 none none so2_shipping ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-SU_SHIPSO4    NA  N Y %y4-%m2-%d2t12:00:00 none none so4_shipping ExtData/chemistry/CEDS/v2021-04-21/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+SU_SHIPSO2    NA  N Y %y4-%m2-%d2t12:00:00 none none so2_shipping ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+SU_SHIPSO4    NA  N Y %y4-%m2-%d2t12:00:00 none none so4_shipping ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-SU_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none so2_aviation   ExtData/chemistry/CEDS/v2021-04-21/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+SU_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none so2_aviation   ExtData/chemistry/CEDS/v2021-04-21-revised/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # DMS concentration
 SU_DMSO NA  Y Y %y4-%m2-%d2t12:00:00 none none conc ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.rc
@@ -36,15 +36,15 @@ climSUSV004    'kg m-2 s-1'   Y   N               0              0.0      1.0   
 SU_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass ExtData/chemistry/QFED/v2.6r1/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.061.%y4%m2%d2.nc4
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-SU_ANTHROL1 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_nonenergy  ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-SU_ANTHROL2 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_energy     ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+SU_ANTHROL1 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_nonenergy  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+SU_ANTHROL2 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_energy     ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # Ship emissions
-SU_SHIPSO2    NA  N Y %y4-%m2-%d2t12:00:00 none none so2_shipping ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-SU_SHIPSO4    NA  N Y %y4-%m2-%d2t12:00:00 none none so4_shipping ExtData/chemistry/CEDS/v2021-04-21/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+SU_SHIPSO2    NA  N Y %y4-%m2-%d2t12:00:00 none none so2_shipping ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+SU_SHIPSO4    NA  N Y %y4-%m2-%d2t12:00:00 none none so4_shipping ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-SU_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none so2_aviation   ExtData/chemistry/CEDS/v2021-04-21/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+SU_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none so2_aviation   ExtData/chemistry/CEDS/v2021-04-21-revised/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # DMS concentration
 SU_DMSO NA  Y Y %y4-%m2-%d2t12:00:00 none none conc ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.rc
@@ -36,15 +36,15 @@ climSUSV004    'kg m-2 s-1'   Y   N               0              0.0      1.0   
 SU_BIOMASS NA  N Y %y4-%m2-%d2t12:00:00 none 0.778 biomass ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.006.%y4%m2%d2.nc4
 
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers
-SU_ANTHROL1 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_nonenergy  ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-SU_ANTHROL2 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_energy     ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+SU_ANTHROL1 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_nonenergy  ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+SU_ANTHROL2 NA  N Y %y4-%m2-%d2t12:00:00 none none so2_energy     ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
 
 # Ship emissions
-SU_SHIPSO2    NA  N Y %y4-%m2-%d2t12:00:00 none none so2_shipping ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-SU_SHIPSO4    NA  N Y %y4-%m2-%d2t12:00:00 none none so4_shipping ExtData/chemistry/CEDS/v2021-04-21/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+SU_SHIPSO2    NA  N Y %y4-%m2-%d2t12:00:00 none none so2_shipping ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+SU_SHIPSO4    NA  N Y %y4-%m2-%d2t12:00:00 none none so4_shipping ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
 
 # Aircraft fuel consumption
-SU_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none so2_aviation   ExtData/chemistry/CEDS/v2021-04-21/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+SU_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none so2_aviation   ExtData/chemistry/CEDS/v2021-04-21-revised/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
 
 # DMS concentration
 SU_DMSO NA  Y Y %y4-%m2-%d2t12:00:00 none none conc ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -4,15 +4,15 @@ Collections:
   SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
     template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
   SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
   SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
   SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
   SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
   SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
   SU2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
     valid_range: "2008-01-01T12:00:00/2008-12-15T12:00:00"

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
@@ -95,10 +95,10 @@ category: EXPORT
  SUFLUXU       | kg m-1 s-1 | xy   | N    |                                | SO4 column u-wind mass flux
  SUFLUXV       | kg m-1 s-1 | xy   | N    |                                | SO4 column v-wind mass flux
  SO4MASS       | kg kg-1    | xyz  | C    |                                | SO4 Aerosol Mass Mixing Ratio
- SUEXTTAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Extinction AOT
- SUSTEXTTAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Extinction AOT Stratosphere
- SUSCATAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Scattering AOT
- SUSTSCATAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Scattering AOT Stratosphere
+ SUEXTTAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Aerosol Optical Depth
+ SUSTEXTTAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Stratospheric Aerosol Optical Thickness
+ SUSCATAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Aerosol Optical Depth Due to Scattering
+ SUSTSCATAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Stratospheric Aerosol Optical Depth Due to Scattering
  SO4SAREA      | m2 m-3     | xyz  | C    |                                | SO4 Surface Area Density
  SO4SNUM       | m-3        | xyz  | C    |                                | SO4 Number Density
 

--- a/ESMF/GOCART_GridComp/O3_GridComp/O3_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/O3_GridComp/O3_GridCompMod.F90
@@ -636,6 +636,7 @@ CONTAINS
    REAL, ALLOCATABLE :: dryDepFreq(:,:)
    REAL, ALLOCATABLE :: dO3(:,:)
    INTEGER, ALLOCATABLE :: oro(:,:)
+   REAL, ALLOCATABLE :: tropPa(:,:)
 
    REAL, ALLOCATABLE :: lai2D(:,:)
    CHARACTER(LEN= 3) :: laiID
@@ -889,7 +890,8 @@ CONTAINS
 
 ! Repair bad tropopause pressures, if any exist
 ! ---------------------------------------------
-   CALL Chem_UtilTroppFixer(i2, j2, tropp, VERBOSE=.TRUE., RC=status)
+   ALLOCATE(tropPa(i1:i2,j1:j2), _STAT)
+   CALL Chem_UtilTroppFixer(i2, j2, tropp, VERBOSE=.TRUE., NEWTROPP=tropPa, RC=status)
    VERIFY_(status)
 
 ! Perform parameterized production and loss chemistry
@@ -1288,13 +1290,14 @@ CONTAINS
    mask = 0
 
    DO k=1,km
-    WHERE(plPa(:,:,k) <= tropp(:,:)) mask(:,:,k) = 1
-    WHERE(tropp(:,:) == MAPL_UNDEF)  mask(:,:,k) = 0
+    WHERE(plPa(:,:,k) <= tropPa(:,:)) mask(:,:,k) = 1
+    WHERE(tropPa(:,:) == MAPL_UNDEF)  mask(:,:,k) = 0
    END DO
   
    n = w_c%reg%i_O3
    WHERE(mask == 1) w_c%qa(n)%data3d = (w_c%qa(n)%data3d + cdt*Pi)/(1.00 + cdt*Li)
    
+   DEALLOCATE(tropPa, _STAT)
    DEALLOCATE(mask, STAT=status)
    VERIFY_(status)
    DEALLOCATE(Pclim, STAT=status)

--- a/components.yaml
+++ b/components.yaml
@@ -35,5 +35,5 @@ GMAO_Shared:
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.38.1
+  tag: v2.47.1.2
   develop: develop

--- a/components.yaml
+++ b/components.yaml
@@ -5,19 +5,19 @@ GOCART:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v4.9.1
+  tag: v4.29.2
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.28.0
+  tag: v3.56.0
   develop: develop
 
 ecbuild:
   local: ./cmake@/ecbuild@
   remote: ../ecbuild.git
-  tag: geos/v1.3.0
+  tag: geos/v1.4.0
 
 HEMCO:
   local: ./ESMF/HEMCO_GridComp@
@@ -28,12 +28,12 @@ HEMCO:
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v1.9.0
+  tag: v1.9.9
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.47.1.2
+  tag: v2.51.2
   develop: develop


### PR DESCRIPTION
This is an update to the main branch of GOCART to bring it in line and up to date with the GCM releases for MERRA-21C and v11, and to be tagged as GOCART v2.3.0. The changes include a fix for ozone replay, updating cmake to all for GOCART to be stand alone, revised extdata.yaml files to account for the seasonal cycle revision to the 2021 CEDS release, and an update to variable long names in the StateSpecs.rc file. Note that the changes for CEDS emissions requires this to be taken along with an update to GEOSchem_GridComp as achem also uses these emissions (https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/279).