### PR TITLE
Reverted to intended 'rhod' reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use 'CA' component name to identify carbonaceous contributions to PM in UFS diagnostic calculations. These contributions were missing due to changes in field names.
 - Add replay import patch for ozone.
-- corrected reading variable 'rhod' from files ( it was mispelled as 'rhop')
+- corrected reading variable 'rhod' from files ( it was mispelled as 'rhop') - it is reverted now
 - Silenced unwarranted error messages from wavelength/channel retrieval functions occurring when 470nm and/or 870nm channels are not included in GOCART resource file.
 - Add explicit `find_package()` calls for missing dependencies for MAPL for builds with spack-stack. Will eventually be fixed in MAPL in later versions
 - Corrected the units of the gravimetric soil moisture to percent instead of fractional in the FENGSHA dust scheme.

--- a/Process_Library/GOCART2G_MieMod.F90
+++ b/Process_Library/GOCART2G_MieMod.F90
@@ -65,7 +65,7 @@ module GOCART2G_MieMod
       real, pointer  :: pmom(:,:,:,:,:) => Null() ! (r,c,b,m,p) moments of phase function
       real, pointer  :: gf(:,:) => Null()         ! (r,b) hygroscopic growth factor
       real, pointer  :: rhop(:,:) => Null()       ! (r,b) wet particle density [kg m-3]
-      real, pointer  :: rhod(:,:) => Null()       ! (r,b) wet particle density [kg m-3]
+      real, pointer  :: rhod(:,:) => Null()       ! (r,b) dry particle density [kg m-3]
       real, pointer  :: vol(:,:) => Null()        ! (r,b) wet particle volume [m3 kg-1]
       real, pointer  :: area(:,:) => Null()       ! (r,b) wet particle cross section [m2 kg-1]
       real, pointer  :: refr(:,:,:) => Null()     ! (r,c,b) real part of refractive index
@@ -291,7 +291,7 @@ CONTAINS
       endif
 
 !     Dry particle density (will be pulled from wet particle radius)
-      rc = nf90_inq_varid(ncid,'rhod',ivarid)
+      rc = nf90_inq_varid(ncid,'rhop',ivarid)
       if(rc .ne. NF90_NOERR) then   ! not in table, fill in dummy variable
         rhod_table = -999.
       else


### PR DESCRIPTION
This PR reverts the change made in PR #257.    
Because 'rhod' is being pulled from 'rhop' (for relative humidity = 0), there should not be 'rhod' instead of 'rhop.' 
'rhod' looks nonexistent in file as well. 