### PR TITLE
Features/pcolarco/su sad and data driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Units error in sulfate surface area density calculation in Process Library corrected
-- Removed erroneous/extraneous friendly attributes to internal state for DU and NI
-  when in data_driven mode
-
-
 ### Removed
 
 ### Changed
@@ -27,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified filepaths for the optics files to no longer link to a personal nobackup directory
 
 ### Fixed
+
+- Units error in sulfate surface area density calculation in Process Library corrected
+- Removed erroneous/extraneous friendly attributes to internal state for DU and NI
+  when in data_driven mode
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Units error in sulfate surface area density calculation in Process Library corrected
+- Removed erroneous/extraneous friendly attributes to internal state for DU and NI
+  when in data_driven mode
+
+
 ### Removed
 
 - Removed all ExtData.rc files

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -226,7 +226,7 @@ contains
           vlocation=MAPL_VlocationCenter, &
           restart=MAPL_RestartOptional, &
           ungridded_dims=[self%nbins], &
-          friendlyto='DYNAMICS:TURBULENCE:MOIST', &
+!          friendlyto='DYNAMICS:TURBULENCE:MOIST', &
           add2export=.true., __RC__)
 
 !      Pressure at layer edges

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -181,7 +181,7 @@ contains
           & dims=MAPL_DimsHorzVert, &
           & vlocation=MAPL_VlocationCenter, &
           & restart=MAPL_RestartOptional, &
-          & friendlyto='DYNAMICS:TURBULENCE:MOIST', &
+!          & friendlyto='DYNAMICS:TURBULENCE:MOIST', &
           & add2export=.true., __RC__)
 
        call MAPL_AddInternalSpec(gc,&
@@ -191,7 +191,7 @@ contains
           & dims=MAPL_DimsHorzVert, &
           & vlocation=MAPL_VlocationCenter, &
           & restart=MAPL_RestartOptional, &
-          & friendlyto='DYNAMICS:TURBULENCE:MOIST', &
+!          & friendlyto='DYNAMICS:TURBULENCE:MOIST', &
           & add2export=.true., __RC__)
 
        call MAPL_AddInternalSpec(gc,&
@@ -201,7 +201,7 @@ contains
           & dims=MAPL_DimsHorzVert, &
           & vlocation=MAPL_VlocationCenter, &
           & restart=MAPL_RestartOptional, &
-          & friendlyto='DYNAMICS:TURBULENCE:MOIST', &
+!          & friendlyto='DYNAMICS:TURBULENCE:MOIST', &
           & add2export=.true., __RC__)
 
        call MAPL_AddImportSpec(gc,&

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -96,7 +96,7 @@ real, parameter :: OCEAN=0.0, LAND = 1.0, SEA_ICE = 2.0
       real    :: aviation_layers(4)  ! heights of the LTO, CDS and CRS layers
       real    :: fSO4anth  ! Fraction of anthropogenic emissions that are SO4
       !logical :: firstRun = .true.
-      real, allocatable  :: rmed(:)  ! Median radius of lognormal number distribution
+      real, allocatable  :: rmed(:)  ! Median radius [um] of lognormal number distribution
       real, allocatable  :: sigma(:) ! Sigma of lognormal number distribution
       !real, pointer :: h2o2_init(:,:,:)
 

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -266,7 +266,7 @@ CONTAINS
    real, parameter :: clay_thresh = 0.2    ! clay fraction above which the maximum flux ratio is returned
 
 ! !DESCRIPTION: Computes the vertical-to-horizontal dust flux ratio according to
-!               B.Marticorena, G.Bergametti, J.Geophys.Res., 100(D8), 16415–16430, 1995
+!               B.Marticorena, G.Bergametti, J.Geophys.Res., 100(D8), 16415?16430, 1995
 !               doi:10.1029/95JD00690
 !
 ! !REVISION HISTORY:
@@ -7084,10 +7084,10 @@ K_LOOP: do k = km, 1, -1
           do i = i1, i2
            rh_ = min(0.95,rh(i,j,k))
            gf = (1. + 1.19*rh_/(1.-rh_) )                   ! ratio of wet/dry volume, eq. 5
-           rwet = rmed * gf**(1./3.)                      ! wet effective radius, m
+           rwet = rmed * gf**(1./3.)*1.e-6                  ! wet effective radius, m (note unit change)
 !          Wet particle volume m3 m-3
            svol = SO4(i,j,k) * rhoa(i,j,k) / rhop * gf
-!          Integral of lognormal surface area m2 m-3
+!          Integral of lognormal surface area m2 m-3 (From Zender Table 1)
            if(present(sarea)) sarea(i,j,k) = 3./rwet*svol*exp(-5./2.*alog(sigma)**2.)
 !          Integral of lognormal number density # m-3
            if(present(snum)) snum(i,j,k) = svol / (rwet**3) * exp(-9/2.*alog(sigma)**2.) * 3./4./pi
@@ -8051,7 +8051,7 @@ K_LOOP: do k = km, 1, -1
 !     of Potential Importance in
 !     Environmental Chemistry (Version 3)
 !     http://www.henrys-law.org
-!     * indica artigos nao encontrados nesse endereço eletronico
+!     * indica artigos nao encontrados nesse endere�o eletronico
   REAL,PARAMETER,DIMENSION(nspecies_HL) :: hstar=(/&
     1.10E-2              ,   & ! O3 - 001
     8.30E+4              ,   & ! H2O2 - 002


### PR DESCRIPTION
Corrected a units error in calculation of sulfate surface area density in SU_compute_diags in process library

Removed extraneous (erroneous?) friendly attribute in declaring data_driven internal states for DU and NI; this is needed for GEOS CTM usage at least.