### PR TITLE
fix nsubsteps = 0 again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix the bug nSubsteps =0 again with abs()
 - fixed a bug that avoids dividing nSubsteps = 0
 
 ### Added

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -1916,11 +1916,9 @@ end function DarmenovaDragPartition
           dp_  = delp(i,j,:)
           tau_ = tau(i,j,:)
 
-          dt_cfl  = 1 / maxval(tau_)
+          dt_cfl  = abs(1.0 / maxval(tau_))
 
-          if (dt_cfl <= 0.) then
-             nSubSteps = 0
-          else if (dt_cfl > cdt) then
+          if (dt_cfl > cdt) then
               ! no need for time sub-splitting
               nSubSteps = 1
               dt = cdt


### PR DESCRIPTION
It is reported #313 that it can be fixed by taking the abs of dt_cfl. So it is fixed again.