### PR TITLE
Feature/acollow/hemcoemissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
-
+- removed energy, non-energy, and shipping emissions of carbon, sulfate, and nitrate as these will enter through HEMCO
 ### Changed
 
 ### Fixed

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
@@ -2,26 +2,8 @@ Collections:
   CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
     valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
     valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   CA2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
@@ -62,12 +44,6 @@ Exports:
   BC_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_aviation}
     - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_aviation}
-  BC_ANTEBC1:
-    - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_nonenergy}
-  BC_ANTEBC2:
-    - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_energy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_energy}
   BC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -91,9 +67,6 @@ Exports:
   BC_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CA2G_hfed.emis_bc.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-  BC_SHIP:
-    - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_shipping}
-    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_shipping}
   BRC_AIRCRAFT:
     collection: /dev/null
     regrid: CONSERVE
@@ -145,12 +118,6 @@ Exports:
   OC_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_aviation}
     - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_aviation}
-  OC_ANTEOC1:
-    - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_nonenergy}
-  OC_ANTEOC2:
-    - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_energy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_energy}
   OC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -179,9 +146,6 @@ Exports:
     regrid: CONSERVE
     sample: CA2G_sample_1
     variable: biomass
-  OC_SHIP:
-    - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_shipping}
-    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_shipping}
   climBCDP001:
     collection: /dev/null
   climBCDP002:

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -2,26 +2,8 @@ Collections:
   CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
     valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
     valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   CA2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
@@ -63,12 +45,6 @@ Exports:
   BC_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_aviation}
     - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_aviation}
-  BC_ANTEBC1:
-    - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_nonenergy}
-  BC_ANTEBC2:
-    - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_energy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_energy}
   BC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -92,9 +68,6 @@ Exports:
   BC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_bc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-  BC_SHIP:
-    - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_shipping}
-    - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_shipping}
   BRC_AIRCRAFT:
     collection: /dev/null
     regrid: CONSERVE
@@ -146,12 +119,6 @@ Exports:
   OC_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_aviation}
     - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_aviation}
-  OC_ANTEOC1:
-    - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_nonenergy}
-  OC_ANTEOC2:
-    - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_energy}
-    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_energy}
   OC_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -180,9 +147,6 @@ Exports:
     regrid: CONSERVE
     sample: CA2G_sample_1
     variable: biomass
-  OC_SHIP:
-    - {starting: "1979-01-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: oc_shipping}
-    - {starting: "2019-12-15T12:00", collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: oc_shipping}
   climBCDP001:
     collection: CA2G_merra2.aer_Nx.2003-2015.2008%m2clm.nc4
     sample: CA2G_sample_0

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
@@ -5,9 +5,6 @@ Collections:
     template: ExtData/chemistry/GEIA/v0.0.0/sfc/GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4
   NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
     template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
-  NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.6r1/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
     valid_range: "2000-02-29T12:00/2025-01-01"
@@ -44,9 +41,6 @@ Exports:
   EMI_NH3_BB:
     - {starting: "1960-01-16T12:00", collection: NI2G_hfed.emis_nh3.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
-  EMI_NH3_EN:
-    - {starting: "1979-01-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, sample: NI2G_sample_1, regrid: CONSERVE, variable: nh3}
-    - {starting: "2019-12-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: NI2G_sample_4, variable: nh3}
   EMI_NH3_IN:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -7,9 +7,6 @@ Collections:
     template: /discover/nobackup/projects/gmao/gmao_ops/pub/fp/das/Y%y4/M%m2/D%d2/GEOS.fp.asm.inst3_3d_aer_Nv.%y4%m2%d2_%h2%n2.V01.nc4
   NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
     template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
-  NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.006.%y4%m2%d2.nc4
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
@@ -46,9 +43,6 @@ Exports:
   EMI_NH3_BB:
     - {starting: "2014-12-01T12:00", collection: NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
-  EMI_NH3_EN:
-    - {starting: "1979-01-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, sample: NI2G_sample_1, regrid: CONSERVE, variable: nh3}
-    - {starting: "2019-12-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: NI2G_sample_4, variable: nh3}
   EMI_NH3_IN:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
@@ -6,18 +6,6 @@ Collections:
   SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
     valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   SU2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
     valid_range: "2008-01-01T12:00:00/2008-12-15T12:00:00"
@@ -51,12 +39,6 @@ Exports:
   SU_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_aviation}
     - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_aviation}
-  SU_ANTHROL1:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_nonenergy}
-  SU_ANTHROL2:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_energy}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_energy}
   SU_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -95,12 +77,6 @@ Exports:
     regrid: CONSERVE
     sample: SU2G_sample_1
     variable: oh
-  SU_SHIPSO2:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_shipping}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_shipping}
-  SU_SHIPSO4:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so4_shipping}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so4_shipping}
   climSO4:
     collection: SU2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4
     sample: SU2G_sample_0

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -6,18 +6,6 @@ Collections:
   SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
     valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
-  SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   SU2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4:
     template: ExtData/chemistry/MERRA2/v0.0.0/L72/merra2.aer_Nv.2003-2015.2008%m2clm.nc4
   SU2G_merra2.aer_Nx.2003-2015.2008%m2clm.nc4:
@@ -52,12 +40,6 @@ Exports:
   SU_AIRCRAFT:
     - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_aviation}
     - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_aviation}
-  SU_ANTHROL1:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_nonenergy}
-  SU_ANTHROL2:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_energy}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_energy}
   SU_AVIATION_CDS:
     collection: /dev/null
     regrid: CONSERVE
@@ -96,12 +78,6 @@ Exports:
     regrid: CONSERVE
     sample: SU2G_sample_1
     variable: oh
-  SU_SHIPSO2:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so2_shipping}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so2_shipping}
-  SU_SHIPSO4:
-    - {starting: "1979-01-15T12:00", collection: SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: SU2G_sample_1, regrid: CONSERVE, variable: so4_shipping}
-    - {starting: "2019-12-15T12:00", collection: SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: SU2G_sample_3, variable: so4_shipping}
   climSO4:
     collection: SU2G_merra2.aer_Nv.2003-2015.2008%m2clm.nc4
     sample: SU2G_sample_0


### PR DESCRIPTION
Entries for energy, non-energy, and shipping emissions have been removed from the ExtData.yaml files for carbon, sulfate, and nitrate as these enter through HEMCO. This change must be pulled in at the same time as a PR in GEOSChem_GridComp. The changes are not fully 0 diff however the difference in the emissions when piped through HEMCO instead of entering through GOCART is within the range of uncertainty and below the non-conservative nature of the daily temporal interpolation.