### PR TITLE
Feature/pcolarco/chem coupling

### DIFF
--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1171,12 +1171,8 @@ contains
                              fluxu=FLUXU, fluxv=FLUXV, &
                              conc=CONC, extcoef=EXTCOEF, scacoef=SCACOEF, bckcoef=BCKCOEF, angstrom=ANGSTR,&
                              aerindx=AERIDX, NO3nFlag=.false., SAREA=SAREA, REFF=REFF, __RC__)
-!++PRC
-!  Calculate the surface area density [m2 m-3], possibly for use in
-!  StratChem or other component.  Optics tables provide cross-sectional area
-!  for hydrated particle per kg dry mass but we want total surface area,
-!  which is 4 x cross section.
-   if(associated(SAREA)) then
+
+    if(associated(SAREA)) then
      call MAPL_MaxMin(trim(COMP_NAME)//': CA2GSAREA:', SAREA)
      nullify(int_ptr)
      call ESMF_AttributeGet(aero, name='surface_area_density', value=fld_name, __RC__)
@@ -1184,9 +1180,9 @@ contains
          call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
          int_ptr = SAREA
      endif
-   endif
+    endif
 
-    if(associated(REFF)) then ! Note unit conversion below
+    if(associated(REFF)) then ! Note unit conversion below to microns
      call MAPL_MaxMin(trim(COMP_NAME)//': CA2GREFF:', REFF)
      nullify(int_ptr)
      call ESMF_AttributeGet(aero, name='effective_radius_in_microns', value=fld_name, __RC__)
@@ -1194,8 +1190,11 @@ contains
          call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
          int_ptr = REFF*1.e6
      endif
-   endif
-!--PRC
+    endif
+
+    i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)
+    j1 = lbound(RH2, 2); j2 = ubound(RH2, 2)
+    km = ubound(RH2, 3)
 
     allocate(RH20(i1:i2,j1:j2,km), __STAT__)
     allocate(RH80(i1:i2,j1:j2,km), __STAT__)

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1173,7 +1173,6 @@ contains
                              aerindx=AERIDX, NO3nFlag=.false., SAREA=SAREA, REFF=REFF, __RC__)
 
     if(associated(SAREA)) then
-     call MAPL_MaxMin(trim(COMP_NAME)//': CA2GSAREA:', SAREA)
      nullify(int_ptr)
      call ESMF_AttributeGet(aero, name='surface_area_density', value=fld_name, __RC__)
      if (fld_name /= '') then
@@ -1183,7 +1182,6 @@ contains
     endif
 
     if(associated(REFF)) then ! Note unit conversion below to microns
-     call MAPL_MaxMin(trim(COMP_NAME)//': CA2GREFF:', REFF)
      nullify(int_ptr)
      call ESMF_AttributeGet(aero, name='effective_radius_in_microns', value=fld_name, __RC__)
      if (fld_name /= '') then

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -60,7 +60,7 @@ module CA2G_GridCompMod
        logical            :: diurnal_bb   ! diurnal biomass burning
        real               :: eAircraftfuel       ! Aircraft emission factor: go from kg fuel to kg C
        real               :: aviation_layers(4)  ! heights of the LTO, CDS and CRS layers
-!      !Workspae for point emissions
+!      !Workspace for point emissions
        logical                :: doing_point_emissions = .false.
        character(len=255)     :: point_emissions_srcfilen   ! filename for pointwise emissions
        type(ThreadWorkspace), allocatable :: workspaces(:)
@@ -565,6 +565,12 @@ contains
 !   call ESMF_StateGet (import, 'RH2', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
 
+!+++PRC
+    ! Add variables to CA instance aero state for chemistry
+    call ESMF_AttributeSet(aero, NAME='effective_radius_in_microns', VALUE=self%radius(1), __RC__)
+    call add_aero (aero, label='surface_area_density', label2='SAREA', grid=grid, typekind=MAPL_R4,__RC__)
+!---PRC
+    
     call add_aero (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
     call add_aero (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
     call add_aero (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
@@ -979,6 +985,7 @@ contains
     character (len=ESMF_MAXSTR)       :: COMP_NAME
     type (MAPL_MetaComp), pointer     :: MAPL
     type (ESMF_State)                 :: internal
+    type (ESMF_State)                 :: aero
     type (wrap_)                      :: wrap
     type (CA2G_GridComp), pointer     :: self
     type(MAPL_VarSpec), pointer       :: InternalSpec(:)
@@ -992,13 +999,13 @@ contains
     real, pointer, dimension(:,:,:)       :: int_ptr
     real, allocatable, dimension(:,:,:,:) :: int_arr
     character(len=2)  :: GCsuffix
-    character(len=ESMF_MAXSTR)      :: short_name
+    character(len=ESMF_MAXSTR)      :: short_name, fld_name
     real, pointer, dimension(:,:,:)  :: intPtr_phobic, intPtr_philic
     real, pointer, dimension(:,:)     :: flux_ptr
 
     real, parameter ::  cpd    = 1004.16
     integer                      :: i1, j1, i2, j2, km
-    real, target, allocatable, dimension(:,:,:)   :: RH20,RH80
+    real, target, allocatable, dimension(:,:,:)   :: RH20,RH80, int_AREA
 #include "CA2G_DeclarePointer___.h"
 
     __Iam__('Run2')
@@ -1022,6 +1029,9 @@ contains
 
     call MAPL_GetPointer (internal, intPtr_phobic, trim(comp_name)//'phobic', __RC__)
     call MAPL_GetPointer (internal, intPtr_philic, trim(comp_name)//'philic', __RC__)
+
+!   Get the aero state
+    call ESMF_StateGet (export, trim(COMP_NAME)//'_AERO'    , aero    , __RC__)
 
 #include "CA2G_GetPointer___.h"
 
@@ -1160,12 +1170,22 @@ contains
                              exttau=EXTTAU,stexttau=STEXTTAU, scatau=SCATAU, stscatau=STSCATAU,&
                              fluxu=FLUXU, fluxv=FLUXV, &
                              conc=CONC, extcoef=EXTCOEF, scacoef=SCACOEF, bckcoef=BCKCOEF, angstrom=ANGSTR,&
-                             aerindx=AERIDX, NO3nFlag=.false., __RC__)
-
-
-    i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)
-    j1 = lbound(RH2, 2); j2 = ubound(RH2, 2)
-    km = ubound(RH2, 3)
+                             aerindx=AERIDX, NO3nFlag=.false., SAREA=SAREA, __RC__)
+!++PRC
+!  Calculate the surface area density [m2 m-3], possibly for use in
+!  StratChem or other component.  Optics tables provide cross-sectional area
+!  for hydrated particle per kg dry mass but we want total surface area,
+!  which is 4 x cross section.
+   if(associated(SAREA)) then
+     call MAPL_MaxMin(trim(COMP_NAME)//': CA2GSAREA:', SAREA)
+     nullify(int_ptr)
+     call ESMF_AttributeGet(aero, name='surface_area_density', value=fld_name, __RC__)
+     if (fld_name /= '') then
+         call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
+         int_ptr = SAREA
+     endif
+   endif
+!--PRC
 
     allocate(RH20(i1:i2,j1:j2,km), __STAT__)
     allocate(RH80(i1:i2,j1:j2,km), __STAT__)

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -567,7 +567,7 @@ contains
 
 !+++PRC
     ! Add variables to CA instance aero state for chemistry
-    call ESMF_AttributeSet(aero, NAME='effective_radius_in_microns', VALUE=self%radius(1), __RC__)
+    call add_aero (aero, label='effective_radius_in_microns', label2='REFF', grid=grid, typekind=MAPL_R4,__RC__)
     call add_aero (aero, label='surface_area_density', label2='SAREA', grid=grid, typekind=MAPL_R4,__RC__)
 !---PRC
     
@@ -1170,7 +1170,7 @@ contains
                              exttau=EXTTAU,stexttau=STEXTTAU, scatau=SCATAU, stscatau=STSCATAU,&
                              fluxu=FLUXU, fluxv=FLUXV, &
                              conc=CONC, extcoef=EXTCOEF, scacoef=SCACOEF, bckcoef=BCKCOEF, angstrom=ANGSTR,&
-                             aerindx=AERIDX, NO3nFlag=.false., SAREA=SAREA, __RC__)
+                             aerindx=AERIDX, NO3nFlag=.false., SAREA=SAREA, REFF=REFF, __RC__)
 !++PRC
 !  Calculate the surface area density [m2 m-3], possibly for use in
 !  StratChem or other component.  Optics tables provide cross-sectional area
@@ -1183,6 +1183,16 @@ contains
      if (fld_name /= '') then
          call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
          int_ptr = SAREA
+     endif
+   endif
+
+    if(associated(REFF)) then ! Note unit conversion below
+     call MAPL_MaxMin(trim(COMP_NAME)//': CA2GREFF:', REFF)
+     nullify(int_ptr)
+     call ESMF_AttributeGet(aero, name='effective_radius_in_microns', value=fld_name, __RC__)
+     if (fld_name /= '') then
+         call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
+         int_ptr = REFF*1.e6
      endif
    endif
 !--PRC

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -77,6 +77,7 @@ category: EXPORT
  *MASS        | kg kg-1      | xyz   | C     |                                | * Aerosol Mass Mixing Ratio
  *CONC        | kg m-3       | xyz   | C     |                                | * Aerosol Mass Concentration
  *SAREA       | m2 m-3       | xyz   | C     |                                | * Aerosol Surface Area Density
+ *REFF        | m            | xyz   | C     |                                | * Aerosol Effective Radius
  *EXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient
  *EXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=20%
  *EXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=80%

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -76,6 +76,7 @@ category: EXPORT
 #----------------------------------------------------------------------------------------
  *MASS        | kg kg-1      | xyz   | C     |                                | * Aerosol Mass Mixing Ratio
  *CONC        | kg m-3       | xyz   | C     |                                | * Aerosol Mass Concentration
+ *SAREA       | m2 m-3       | xyz   | C     |                                | * Aerosol Surface Area Density
  *EXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient
  *EXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=20%
  *EXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=80%

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
@@ -3,7 +3,7 @@
 #
 
 aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_BRC.v1_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/optics_BRC.v1_6.nc
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_BRC.v1_6.nc
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_instance_SU.rc
@@ -48,11 +48,5 @@ sigma: -1  -1  2.03  -1
 
 # OH H2O2 NO3 from GMI Combined Stratosphere Troposphere (Lower case yes to enable)
 # -------------------------------------------------------------------------------------
-#using_GMI_OH: no
-#using_GMI_NO3: no
-#using_GMI_H2O2: no
-export_H2O2: no
-using_GMI_OH: .false.
-using_GMI_NO3: .false.
-using_GMI_H2O2: .false.
-
+using_GMI: .false.
+disable_emissions: .false.

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_instance_SU.rc
@@ -2,8 +2,8 @@
 # Resource file for Sulfer parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_3.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_3.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMG.nc
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_6.nc
 
 nbins: 4
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
@@ -142,4 +142,19 @@ Exports:
     regrid: CONSERVE
     sample: SU2G_sample_2
     variable: biofuel
+  GMI_H2O2:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: GMI_H2O2
+  GMI_OH:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: GMI_OH
+  GMI_NO3:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: GMI_NO3
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -48,11 +48,5 @@ sigma: -1  -1  2.03  -1
 
 # OH H2O2 NO3 from GMI Combined Stratosphere Troposphere (Lower case yes to enable)
 # -------------------------------------------------------------------------------------
-#using_GMI_OH: no
-#using_GMI_NO3: no
-#using_GMI_H2O2: no
-export_H2O2: no
-using_GMI_OH: .false.
-using_GMI_NO3: .false.
-using_GMI_H2O2: .false.
-
+using_GMI: .false.
+disable_emissions: .false.

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -2,8 +2,8 @@
 # Resource file for Sulfer parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_3.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_3.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMG.nc
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_6.nc
 
 nbins: 4
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1289,7 +1289,7 @@ contains
       endif
     endif
     
-    if(associated(SO4REFF)) then ! Note unit conversion below
+    if(associated(SO4REFF)) then ! Note unit conversion below to microns
       nullify(int_ptr)
       call ESMF_AttributeGet(aero, name='effective_radius_in_microns', value=fld_name, __RC__)
       if (fld_name /= '') then

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -175,4 +175,19 @@ Exports:
     regrid: CONSERVE
     sample: SU2G_sample_2
     variable: biofuel
+  GMI_H2O2:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: GMI_H2O2
+  GMI_OH:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: GMI_OH
+  GMI_NO3:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: GMI_NO3
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
@@ -36,6 +36,9 @@ category: IMPORT
  SU_NO3          | 1        | xyz  | C    | SKIP    | climatological NO3 source
  SU_OH           | 1        | xyz  | C    | SKIP    | climatological OH source
  SU_H2O2         | 1        | xyz  | C    | SKIP    | climatological H2O2 source
+ GMI_NO3         | 1        | xyz  | C    | SKIP    | GMI NO3 source
+ GMI_OH          | 1        | xyz  | C    | SKIP    | GMI OH source
+ GMI_H2O2        | 1        | xyz  | C    | SKIP    | GMI H2O2 source
 #........................................................................................
  SU_BIOMASS      | 1        | xy   | N    | SKIP    | biomass burning emissions
  SU_ANTHROL1     | 1        | xy   | N    | SKIP    | anthropogenic BF emissions
@@ -100,6 +103,7 @@ category: EXPORT
  SUSCATAU      | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Aerosol Optical Depth Due to Scattering
  SUSTSCATAU    | 1          | xy   | N    | size(self%wavelengths_vertint) | SO4 Stratospheric Aerosol Optical Depth Due to Scattering
  SO4SAREA      | m2 m-3     | xyz  | C    |                                | SO4 Surface Area Density
+ SO4REFF       | m          | xyz  | C    |                                | SO4 Effective Radius
  SO4SNUM       | m-3        | xyz  | C    |                                | SO4 Number Density
 
 category: INTERNAL

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -45,11 +45,5 @@ sigma: -1  -1  2.03  -1
 
 # OH H2O2 NO3 from GMI Combined Stratosphere Troposphere (Lower case yes to enable)
 # -------------------------------------------------------------------------------------
-#using_GMI_OH: no
-#using_GMI_NO3: no
-#using_GMI_H2O2: no
-export_H2O2: no
-using_GMI_OH: .false.
-using_GMI_NO3: .false.
-using_GMI_H2O2: .false.
-
+using_GMI: .false.
+disable_emissions: .false.

--- a/Process_Library/GOCART2G_MieMod.F90
+++ b/Process_Library/GOCART2G_MieMod.F90
@@ -319,13 +319,21 @@ CONTAINS
         refi_table = abs(refi_table)
       endif
 
-!     Wet particle volume [m3 kg-1]
-!     Ratio of wet to dry volume is gf^3, hence the following
-      vol_table = gf_table**3 / rhod_table
+!     Wet particle volume [m3 kg-1 dry mass]
+      rc = nf90_inq_varid(ncid,'volume',ivarid)
+      if(rc .ne. NF90_NOERR) then   ! not in table, fill in dummy variable
+        vol_table = gf_table**3 / rhod_table
+      else
+        NF_VERIFY_(nf90_get_var(ncid,ivarid,vol_table))
+      endif
 
-!     Wet particle cross sectional area [m2 kg-1]
-!     Assume area is volume divided by (4./3.*reff)
-      area_table = vol_table / (4./3.*reff_table)
+!     Wet particle cross sectional area [m2 kg-1 dry mass]
+      rc = nf90_inq_varid(ncid,'area',ivarid)
+      if(rc .ne. NF90_NOERR) then   ! not in table, fill in dummy variable
+         area_table = vol_table / (4./3.*reff_table)
+      else
+        NF_VERIFY_(nf90_get_var(ncid,ivarid,area_table))
+      endif
 
 !     Close the table file
 !     -------------------------------------

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -1560,7 +1560,7 @@ end function DarmenovaDragPartition
     do k = klid, km
        do j = j1, j2
           do i = i1, i2
-            call Chem_CalcVsettle(radius(i,j,k)*1.e-6, rhop(i,j,k), rhoa(i,j,k), &
+            call Chem_CalcVsettle(radius(i,j,k), rhop(i,j,k), rhoa(i,j,k), &
                                    tmpu(i,j,k), vsettle(i,j,k), grav)
           end do
        end do

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -4187,7 +4187,8 @@ end function DarmenovaDragPartition
                                   sfcmass, colmass, mass, exttau, stexttau, scatau, stscatau,&
                                   sfcmass25, colmass25, mass25, exttau25, scatau25, &
                                   fluxu, fluxv, conc, extcoef, scacoef, bckcoef,&
-                                  exttaufm, scataufm, angstrom, aerindx, NO3nFlag, rc )
+                                  exttaufm, scataufm, angstrom, aerindx, NO3nFlag, &
+                                  sarea, rc )
 
 ! !USES:
 
@@ -4238,6 +4239,7 @@ end function DarmenovaDragPartition
    real, optional, dimension(:,:,:), intent(inout)   :: exttaufm  ! fine mode (sub-micron) ext. AOT at 550 nm
    real, optional, dimension(:,:,:), intent(inout)   :: scataufm  ! fine mode (sub-micron) sct. AOT at 550 nm
    real, optional, dimension(:,:), intent(inout)   :: angstrom  ! 470-870 nm Angstrom parameter
+   real, optional, dimension(:,:,:), intent(inout)  :: sarea      ! Sulfate surface area density [m2 m-3]
    integer, optional, intent(out)   :: rc        ! Error return code:
                                                  !  0 - all is well
                                                  !  1 -
@@ -4255,7 +4257,7 @@ end function DarmenovaDragPartition
    integer :: i, j, k, n, w, ios, status
    integer :: i1 =1, i2, j1=1, j2
    integer :: ilam470, ilam870
-   real, allocatable, dimension(:,:,:) :: tau, ssa, bck
+   real, allocatable, dimension(:,:,:) :: tau, ssa, bck, area
 !   real :: fPMfm(nbins)  ! fraction of bin with particles diameter < 1.0 um
 !   real :: fPM25(nbins)  ! fraction of bin with particles diameter < 2.5 um
    real, dimension(:), allocatable :: fPMfm  ! fraction of bin with particles diameter < 1.0 um
@@ -4554,6 +4556,22 @@ end function DarmenovaDragPartition
          log(470./870.)
    endif
    deallocate(tau,ssa)
+
+!  Calculate the sulfate area density [m2 m-3], possibly for use in
+!  StratChem or other component.  Optics tables provide cross-sectional area
+!  for hydrated particle per kg dry mass but we want total surface area,
+!  which is 4 x cross section.
+   if(present(sarea)) then
+    sarea = 0.0
+    allocate(area(i1:i2,j1:j2,km), __STAT__)
+    do n = nbegin, nbins
+     call mie%Query(550e-9,n,   &
+                    aerosol(:,:,:,n)*delp/grav, rh, &
+                    area=area, __RC__)
+     sarea = sarea + 4.*area*aerosol(:,:,:,n)*rhoa
+    enddo
+    deallocate(area)
+   endif
    __RETURN__(__SUCCESS__)
    end subroutine Aero_Compute_Diags
 !====================================================================
@@ -7706,7 +7724,7 @@ K_LOOP: do k = km, 1, -1
 !BOP
 ! !IROUTINE: SU_Compute_Diags
 
-   subroutine SU_Compute_Diags ( km, klid, rmed, sigma, rhop, grav, pi, nSO4, mie, &
+   subroutine SU_Compute_Diags ( km, klid, rhop, grav, pi, nSO4, mie, &
                                  wavelengths_profile, wavelengths_vertint, &
                                  tmpu, rhoa, delp, ple, tropp,rh, u, v, &
                                  DMS, SO2, SO4, MSA, &
@@ -7715,7 +7733,7 @@ K_LOOP: do k = km, 1, -1
                                  so2sfcmass, so2colmass, &
                                  so4sfcmass, so4colmass, &
                                  exttau, stexttau,scatau, stscatau,so4mass, so4conc, extcoef, &
-                                 scacoef, bckcoef, angstrom, fluxu, fluxv, sarea, snum, rc )
+                                 scacoef, bckcoef, angstrom, fluxu, fluxv, sarea, snum, reff, rc )
 
 ! !USES:
    implicit NONE
@@ -7723,8 +7741,6 @@ K_LOOP: do k = km, 1, -1
 ! !INPUT PARAMETERS:
    integer, intent(in) :: km    ! number of model levels
    integer,    intent(in)    :: klid   ! index for pressure lid
-   real, intent(in)    :: rmed  ! mean radius [um]
-   real, intent(in)    :: sigma ! Sigma of lognormal number distribution
    real, intent(in)    :: rhop  ! dry particle density [kg m-3]
    real, intent(in)    :: grav  ! gravity [m/sec]
    real, intent(in)    :: pi    ! pi constant
@@ -7768,6 +7784,7 @@ K_LOOP: do k = km, 1, -1
    real, optional, dimension(:,:),   intent(inout)  :: fluxv      ! Column mass flux in y direction
    real, optional, dimension(:,:,:), intent(inout)  :: sarea      ! Sulfate surface area density [m2 m-3]
    real, optional, dimension(:,:,:), intent(inout)  :: snum       ! Sulfate number density [# m-2]
+   real, optional, dimension(:,:,:), intent(inout)  :: reff       ! Sulfate effective radius [m]
    integer, optional, intent(out)   :: rc         ! Error return code:
                                                   !  0 - all is well
                                                   !  1 -
@@ -8015,30 +8032,26 @@ K_LOOP: do k = km, 1, -1
    endif
 
 !  Calculate the sulfate surface area density [m2 m-3], possibly for use in
-!  StratChem or other component.  Assumption here is a specified effective
-!  radius (gcSU%radius for sulfate) and standard deviation of lognormal
-!  distribution.  Hydration is by grid box provided RH and is follows Petters
-!  and Kreeidenweis (ACP2007)
-   if(present(sarea) .or. present(snum)) then
-!        rmed   = w_c%reg%rmed(n1+nSO4-1)                    ! median radius, m
-        if(rmed > 0.) then
-!         sigma  = w_c%reg%sigma(n1+nSO4-1)                  ! width of lognormal distribution
-         do k = klid, km
-         do j = j1, j2
-          do i = i1, i2
-           rh_ = min(0.95,rh(i,j,k))
-           gf = (1. + 1.19*rh_/(1.-rh_) )                   ! ratio of wet/dry volume, eq. 5
-           rwet = rmed * gf**(1./3.)*1.e-6                  ! wet effective radius, m (note unit change)
-!          Wet particle volume m3 m-3
-           svol = SO4(i,j,k) * rhoa(i,j,k) / rhop * gf
-!          Integral of lognormal surface area m2 m-3 (From Zender Table 1)
-           if(present(sarea)) sarea(i,j,k) = 3./rwet*svol*exp(-5./2.*alog(sigma)**2.)
-!          Integral of lognormal number density # m-3
-           if(present(snum)) snum(i,j,k) = svol / (rwet**3) * exp(-9/2.*alog(sigma)**2.) * 3./4./pi
-          enddo
-         enddo
-        enddo
-       endif
+!  StratChem or other component.  Optics tables provide cross-sectional area
+!  for hydrated particle per kg dry mass but we want total surface area,
+!  which is 4 x cross section.
+   if(present(sarea)) then
+     call mie%Query(550e-9,1,   &
+                         SO4*delp/grav, rh, &
+                         area=sarea, __RC__)
+     sarea = 4.*sarea*SO4*rhoa
+   endif
+
+!  Get the sulfate particle effective radius [m] possibly for use in chemistry
+   if(present(reff)) then
+     call mie%Query(550e-9,1,   &
+                         SO4*delp/grav, rh, &
+                         reff=reff, __RC__)
+   endif
+   
+   
+!  To implement if desired:
+   if(present(snum)) then   
    endif
    deallocate(tau,ssa)
    __RETURN__(__SUCCESS__)

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -4564,7 +4564,6 @@ end function DarmenovaDragPartition
 !  which is 4 x cross section.
    if(present(sarea)) then
     sarea = 0.0
-    if(present(reff))  reff  = 0.0
     allocate(area(i1:i2,j1:j2,km), __STAT__)
     do n = nbegin, nbins
      call mie%Query(550e-9,n,   &
@@ -7820,7 +7819,7 @@ K_LOOP: do k = km, 1, -1
 
 ! !Local Variables
    integer :: i, j, k, w, i1=1, j1=1, i2, j2, status
-   real, dimension(:,:,:), allocatable :: tau, ssa, bck
+   real, dimension(:,:,:), allocatable :: tau, ssa, bck, area
    real, dimension(:,:), allocatable :: tau470, tau870
    integer    :: ilam470, ilam870
    logical :: do_angstrom
@@ -8057,14 +8056,18 @@ K_LOOP: do k = km, 1, -1
 !  for hydrated particle per kg dry mass but we want total surface area,
 !  which is 4 x cross section.
    if(present(sarea)) then
+     sarea = 0.
+     allocate(area(i1:i2,j1:j2,km), __STAT__)
      call mie%Query(550e-9,1,   &
                          SO4*delp/grav, rh, &
-                         area=sarea, __RC__)
-     sarea = 4.*sarea*SO4*rhoa
+                         area=area, __RC__)
+     sarea = 4.*area*SO4*rhoa
+     deallocate(area)
    endif
 
 !  Get the sulfate particle effective radius [m] possibly for use in chemistry
    if(present(reff)) then
+     reff = 0.
      call mie%Query(550e-9,1,   &
                          SO4*delp/grav, rh, &
                          reff=reff, __RC__)

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -4188,7 +4188,7 @@ end function DarmenovaDragPartition
                                   sfcmass25, colmass25, mass25, exttau25, scatau25, &
                                   fluxu, fluxv, conc, extcoef, scacoef, bckcoef,&
                                   exttaufm, scataufm, angstrom, aerindx, NO3nFlag, &
-                                  sarea, rc )
+                                  sarea, reff, rc )
 
 ! !USES:
 
@@ -4258,7 +4258,7 @@ end function DarmenovaDragPartition
    integer :: i, j, k, n, w, ios, status
    integer :: i1 =1, i2, j1=1, j2
    integer :: ilam470, ilam870
-   real, allocatable, dimension(:,:,:) :: tau, ssa, bck, area
+   real, allocatable, dimension(:,:,:) :: tau, ssa, bck, area, tarea, pref
 !   real :: fPMfm(nbins)  ! fraction of bin with particles diameter < 1.0 um
 !   real :: fPM25(nbins)  ! fraction of bin with particles diameter < 2.5 um
    real, dimension(:), allocatable :: fPMfm  ! fraction of bin with particles diameter < 1.0 um

--- a/Process_Library/MieQuery.H
+++ b/Process_Library/MieQuery.H
@@ -48,7 +48,7 @@
      real,    optional,      intent(out) :: bext   (__DIMS__)      ! mass extinction efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bsca   (__DIMS__)      ! mass scattering efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bbck   (__DIMS__)      ! mass backscatter efficiency [m2 (kg dry mass)-1]
-     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (micron)
+     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (m)
      real,    optional,      intent(out) :: pmom   (__DIMS__,:,:)  ! moments of phase function 
      real,    optional,      intent(out) :: p11    (__DIMS__)      ! P11 phase function at backscatter
      real,    optional,      intent(out) :: p22    (__DIMS__)      ! P22 phase function at backscatter
@@ -115,7 +115,7 @@
      endif
 
      if(present(rEff)) then
-       rEff = 1.E6* __RHINTERP2__(this%rEff, irh, arh, bin, rEff)
+       rEff = __RHINTERP2__(this%rEff, irh, arh, bin, rEff)
      endif
 
      if(present(rhop)) then
@@ -204,7 +204,7 @@
      real,    optional,      intent(out) :: bext   (__DIMS__)      ! mass extinction efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bsca   (__DIMS__)      ! mass scattering efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bbck   (__DIMS__)      ! mass backscatter efficiency [m2 (kg dry mass)-1]
-     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (micron)
+     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (m)
      real,    optional,      intent(out) :: pmom   (__DIMS__,:,:)  ! moments of phase function
      real,    optional,      intent(out) :: p11    (__DIMS__)      ! P11 phase function at backscatter
      real,    optional,      intent(out) :: p22    (__DIMS__)      ! P22 phase function at backscatter


### PR DESCRIPTION
This adds hooks in SU2G_GridComp to on-way couple GMI oxidants (OH, NO3, H2O2) to GOCART sulfur chemistry. Control is through instance RC file; off by default
Add "disable_emissions" feature to SU2G_instance file to turn off sulfur emissions except what is specified in instance RC; useful for volcanic only instance
Add calculations of surface area density and effective radius to GOCART sulfate and carbonaceous species, and add to respective aerosol states for use in chemistry
Made a change in MieQuery.H to *not* convert units of effective radius in place to [um]. Units are now read in native units on optics file [m] and made corresponding change in Chem_Settling call
Made updates to latest version of IDL legacy optics tables for surface area and effective radius calculations
All changes are zero diff except the optics tables