### PR TITLE
Bring over latest Atanas alarm fix to develop

### DIFF
--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -187,6 +187,8 @@ contains
 !   -----------------------------------------------------------------
     call createInstances_(self, GC, __RC__)
 
+    call alarmResourcesToChildren(self, GC, _RC)
+
 !   Define EXPORT states
 
 !   This state is needed by radiation and moist. It contains
@@ -1368,6 +1370,80 @@ contains
      end subroutine addChildren__
 
   end subroutine createInstances_
+
+!==============================================================================
+  subroutine alarmResourcesToChildren(self, GC, rc)
+
+!   Description:
+    implicit none
+
+    type (GOCART_State), pointer,            intent(in   )     :: self
+    type (ESMF_GridComp),                    intent(inout)     :: GC
+    integer,                                 intent(  out)     :: rc
+
+    ! locals
+    integer :: i
+    integer :: status
+    logical :: lvalue
+    type (MAPL_MetaComp), pointer :: MAPL
+!    character(len=ESMF_MAXSTR) :: lbl
+    character(len=:), allocatable :: lbl, label
+
+!-----------------------------------------------------------------------------
+!   Begin...
+!   Get my internal MAPL_Generic state
+!   -----------------------------------
+    call MAPL_GetObjectFromGC (GC, MAPL, _RC)
+    label = "RUN_AT_INTERVAL_START:"
+    call MAPL_GetResource(MAPL, lvalue, Label=label, default=.false., _RC)
+
+    lbl = 'p:'//label
+
+    call setChildResource (MAPL, self%DU, Label=lbl, value = lvalue, _RC)
+    call setChildResource (MAPL, self%SS, Label=lbl, value = lvalue, _RC)
+    call setChildResource (MAPL, self%CA, Label=lbl, value = lvalue, _RC)
+    call setChildResource (MAPL, self%SU, Label=lbl, value = lvalue, _RC)
+    call setChildResource (MAPL, self%NI, Label=lbl, value = lvalue, _RC)
+
+    deallocate(lbl, label)
+
+    _RETURN(ESMF_SUCCESS)
+
+  contains
+
+    subroutine setChildResource (MAPL, species, label, value, rc)
+
+      type (MAPL_MetaComp), intent(in) :: mapl
+      type(Constituent), intent(inout)     :: species
+      logical, intent(in) :: value
+      character(len=*), intent(in) :: label
+      integer, intent(  out)     :: rc
+      integer :: ivalue
+
+      ! local
+      integer  :: i, n, id
+      type (ESMF_GridComp), pointer :: cgc
+      type (MAPL_MetaComp), pointer :: cmapl
+      type (ESMF_Config) :: cf
+
+      ivalue = 0
+      if (lvalue) ivalue=1
+
+      n=size(species%instances)
+
+      do i = 1, n
+         id=species%instances(i)%id
+         cgc => MAPL%Get_Child_Gridcomp(id)
+         call MAPL_GetObjectFromGC (cgc, cmapl, _RC)
+         call ESMF_GridCompGet(cgc, config=cf, _RC)
+         call MAPL_ConfigSetAttribute(cf, value=ivalue, Label=label, _RC)
+      end do
+
+      _RETURN(ESMF_SUCCESS)
+
+    end subroutine setChildResource
+
+  end subroutine alarmResourcesToChildren
 
 !===================================================================================
   subroutine serialize_bundle (state, rc)

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -13,6 +13,7 @@ module NI2G_GridCompMod
    use MAPL
    use GOCART2G_MieMod
    use Chem_AeroGeneric
+   use ReplenishAlarm
    use iso_c_binding, only: c_loc, c_f_pointer, c_ptr
 
    use GOCART2G_Process       ! GOCART2G process library
@@ -59,7 +60,7 @@ integer, parameter     :: DP = kind(1.0d0)
        real, allocatable :: rmedDU(:), rmedSS(:) ! DU and SS radius
        real, allocatable :: fnumDU(:), fnumSS(:) ! DU and SS particles per kg mass
        type(ThreadWorkspace), allocatable :: workspaces(:)
-       type(ESMF_Time) :: last_time_replenished
+       type(ESMF_Alarm) :: alarm
    end type NI2G_GridComp
 
    type wrap_
@@ -501,14 +502,10 @@ contains
     call ESMF_MethodAdd (aero, label='monochromatic_aerosol_optics', userRoutine=monochromatic_aerosol_optics, __RC__)
     call ESMF_MethodAdd (aero, label='get_mixR', userRoutine=get_mixR, __RC__)
 
-    block
-      type(ESMF_TimeInterval) :: oneDay
-      call ESMF_TimeIntervalSet(oneDay,d=1,_RC)
-      call ESMF_ClockGet(clock,currTime=currentTime,_RC)
-      self%last_time_replenished = currentTime - oneDay
-    end block
-      
-    RETURN_(ESMF_SUCCESS)
+! Deal with replenishment alarm (formerly the daily_alarm subroutine)
+! ===================================================================
+    self%alarm = createReplenishAlarm(gc, clock, 30000, _RC)
+    _RETURN(ESMF_SUCCESS)
 
   end subroutine Initialize
 
@@ -807,11 +804,14 @@ contains
     allocate(dqa, mold=lwi, __STAT__)
     allocate(drydepositionfrequency, mold=lwi, __STAT__)
 
-    !ALT: Caution: with the current implementation of the routine
-    ! daily_alarm, the next call might not function correctly if it is called
-    ! more than once for the entire Run method (including Run1 and Run2)
-    ! If needed, this could be fixed by adding extra bookkeeping logic
-    alarm_is_ringing = daily_alarm(clock,30000,self%last_time_replenished, _RC)
+    alarm_is_ringing = ESMF_AlarmIsRinging(self%alarm, _RC)
+#ifdef DEBUG
+    if (alarm_is_ringing) then
+          if (MAPL_Am_I_Root()) then
+             print *,'DEBUG:: NI replenish alarm is ringing'
+          end if
+    end if
+#endif
 
 !   Save local copy of HNO3 for first pass through run method regardless
     thread = MAPL_get_current_thread()
@@ -1386,33 +1386,5 @@ contains
     RETURN_(ESMF_SUCCESS)
 
   end subroutine monochromatic_aerosol_optics
-
-  function daily_alarm(clock,freq,last_time_replenished,rc) result(is_ringing)
-     logical :: is_ringing
-     type(ESMF_Clock), intent(in) :: clock
-     integer, intent(in) :: freq
-     type(ESMF_Time), intent(inout) :: last_time_replenished
-     integer, optional, intent(out) :: rc
-
-     type(ESMF_Time) :: current_time
-     integer :: status
-     integer :: nhh,nmm,nss
-
-     type(ESMF_TimeInterval) :: esmf_freq
-
-     call ESMF_ClockGet(clock,currTime=current_time,_RC)
-!     call ESMF_TimeGet(current_time,yy=year,mm=month,dd=day,h=hour,m=minute,s=second,_RC)
-
-     call MAPL_UnpackTIme(freq,nhh,nmm,nss) 
-     call ESMF_TimeIntervalSet(esmf_freq,h=nhh,m=nmm,s=nss ,_RC)
-
-     is_ringing = .false.
-
-     if (current_time >= last_time_replenished + esmf_freq) then
-           is_ringing = .true.
-        last_time_replenished = current_time
-        end if
-     _RETURN(_SUCCESS)
-  end function
 
 end module NI2G_GridCompMod

--- a/ESMF/Shared/CMakeLists.txt
+++ b/ESMF/Shared/CMakeLists.txt
@@ -2,6 +2,7 @@ esma_set_this (OVERRIDE Chem_Shared2G)
 
 set (srcs
   Chem_AeroGeneric.F90
+  ReplenishAlarm.F90
   )
 
 esma_add_library(${this}

--- a/ESMF/Shared/ReplenishAlarm.F90
+++ b/ESMF/Shared/ReplenishAlarm.F90
@@ -1,0 +1,106 @@
+#include "MAPL_Generic.h"
+
+module ReplenishAlarm
+   use ESMF
+   use MAPL
+
+   implicit none
+   private
+
+   public :: createReplenishAlarm
+
+   contains
+
+   function createReplenishAlarm(gc,clock,freq,rc) result(alarm)
+      type(ESMF_GridComp), intent(inout) :: gc
+      type(ESMF_Clock), intent(in) :: clock
+      integer, intent(in) :: freq
+      integer, optional, intent(out) :: rc
+
+      type(ESMF_Alarm) :: alarm
+
+      integer :: status, ival
+      logical :: run_at_interval_start
+      integer :: nhh, nmm, nss
+      integer :: year, month, day
+      integer :: hh, mm, ss, yyyymmdd, hhmmss
+      integer :: reference_date, reference_time
+      character(len=ESMF_MAXSTR) :: comp_name
+      type(ESMF_Config) :: cf
+      type(ESMF_Time) :: RingTime, currTime
+      type(ESMF_TimeInterval) :: timeint, tstep
+      type(MAPL_MetaComp), pointer :: MAPL
+
+      ! this section mimics MAPL2 way to create the run alarm
+      ! the goal is to have a consistent way of setting the proper
+      ! offset, so that the alarm would run when the parent calls the children
+
+      ! Get my internal MAPL_Generic state
+      ! -----------------------------------
+      call MAPL_GetObjectFromGC (gc, MAPL, _RC)
+
+      call MAPL_GetResource(MAPL, run_at_interval_start, &
+           Label="RUN_AT_INTERVAL_START:", default=.false., _RC)
+      call ESMF_GridCompGet(gc, name=comp_name, Config=cf, _RC)
+      call ESMF_ConfigGetAttribute(cf, ival, &
+           label="p:RUN_AT_INTERVAL_START:", _RC)
+      _ASSERT(run_at_interval_start .neqv. ival==0, "Inconsistent run alarm")
+
+      call ESMF_ClockGet(clock, currTime=currTime, timestep=tstep, _RC)
+      call MAPL_UnpackTIme(freq,nhh,nmm,nss)
+
+      !?call ESMF_TimeSet(reff_time,yy=year,mm=month,dd=day,h=0,m=0,s=0,_RC)
+      call ESMF_TimeIntervalSet(timeint,h=nhh,m=nmm,s=nss,_RC)
+
+      ! get current time from clock and create a referenace time with optonal override
+      call ESMF_TimeGet(currTime, YY=YEAR, MM=MONTH, DD=DAY, &
+           H=HH, M=MM, S=SS, _RC)
+
+      yyyymmdd = year*10000 + month*100 + day
+      hhmmss   = HH*10000 + MM*100 + SS
+
+      !  Get Alarm reference date and time from resouce, it defaults to midnight of the current day
+      call MAPL_GetResource (MAPL, reference_date, label='REFERENCE_DATE:', &
+           default=yyyymmdd, _RC )
+
+      call MAPL_GetResource (MAPL, reference_time, label='REFERENCE_TIME:', &
+           default=0, _RC )
+
+      YEAR = reference_date/10000
+      MONTH = mod(reference_date,10000)/100
+      DAY = mod(reference_date,100)
+
+      HH = reference_time/10000
+      MM = mod(reference_time,10000)/100
+      SS = mod(reference_time,100)
+
+      call ESMF_TimeSet( ringTime, YY=YEAR, MM=MONTH, DD=DAY, &
+           H=HH, M=MM, S=SS, _RC)
+
+      if (ringTime > currTime) then
+         ringTime = ringTime - (INT((ringTime - currTime)/TIMEINT)+1)*TIMEINT
+      end if
+
+      ! we back off current time with clock's dt since
+      ! we advance the clock AFTER run method
+      if (.not.run_at_interval_start) ringTime = ringTime-TSTEP
+
+      ! make sure that ringTime is not in the past
+      do while (ringTime < currTime)
+         ringTime = ringTime + timeint
+      end do
+
+      alarm = ESMF_AlarmCreate(Clock = clock, &
+           name = trim(comp_name) // "_ReplenishAlarm" , &
+           RingInterval = timeint  ,  &
+           RingTime     = ringTime,  &
+           sticky       = .false.  ,  &
+           _RC )
+      if(ringTime == currTime) then
+         call ESMF_AlarmRingerOn(alarm, _RC)
+      end if
+
+      _RETURN(ESMF_SUCCESS)
+    end function createReplenishAlarm
+
+end module ReplenishAlarm


### PR DESCRIPTION
This is the equivalent of #343 but to `develop`. 

This has fixes by @atrayano for the alarms in GOCART in NI and SU when running replay. 

It is non-zero-diff in my testing.