### PR TITLE
Add support for settling velocity diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified filepaths for the optics files to no longer link to a personal nobackup directory
 - Added logic to ensure the alarm accounts for skipping heartbeat in `NI` and `SU` components
 - Added new SettlingSolver scheme `SettlingSolverUFS` and rolled back the previous `SettlingSolver`
+- Updated settling routine and calls to allow settling velocity diagnostics in output field
 
 ### Fixed
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -988,6 +988,7 @@ contains
 
     integer                           :: n
     real, allocatable, dimension(:,:) :: drydepositionfrequency, dqa
+    real, pointer, dimension(:,:,:)   :: casd_vel
     real                              :: fwet
     real, dimension(3)                :: rainout_eff
     logical                           :: KIN
@@ -1101,9 +1102,11 @@ contains
         call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)
         nullify(flux_ptr)
         flux_ptr => SD(:,:,n)
+        nullify(casd_vel)
+        if (associated(SD_V)) casd_vel => SD_V(:,:,:,n)
         call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, n, self%cdt, MAPL_GRAV, &
                         int_ptr, t, airdens, &
-                        rh2, zle, delp, flux_ptr, settling_scheme=settling_opt, __RC__)
+                        rh2, zle, delp, flux_ptr, casd_vel, settling_scheme=settling_opt, __RC__)
     end do
 
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_StateSpecs.rc
@@ -76,6 +76,7 @@ category: EXPORT
 #----------------------------------------------------------------------------------------
  *MASS        | kg kg-1      | xyz   | C     |                                | * Aerosol Mass Mixing Ratio
  *CONC        | kg m-3       | xyz   | C     |                                | * Aerosol Mass Concentration
+ *SD_V        | m s-1        | xyz   | C     | self%nbins                     | * Aerosol Settling Velocity (Bin %d)
  *EXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient
  *EXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=20%
  *EXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | * Aerosol Extinction Coefficient - Fixed RH=80%

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -175,7 +175,6 @@ contains
     if (MAPL_AM_I_ROOT()) then
        write (*,*) trim(Iam)//": Dust emission scheme is "//trim(self%emission_scheme)
     end if
-
     ! Point Sources
     call ESMF_ConfigGetAttribute (cfg, self%point_emissions_srcfilen, &
                                   label='point_emissions_srcfilen:', default='/dev/null', __RC__)
@@ -978,6 +977,7 @@ contains
 
     integer                           :: n
     real, allocatable, dimension(:,:) :: drydepositionfrequency, dqa
+    real, pointer, dimension(:,:,:)   :: dusd_vel
     real                              :: fwet
     logical                           :: KIN
 
@@ -1039,9 +1039,11 @@ contains
     do n = 1, self%nbins
        nullify(flux_ptr)
        if (associated(DUSD)) flux_ptr => DUSD(:,:,n)
+       nullify(dusd_vel)
+       if (associated(DUSD_V)) dusd_vel => DUSD_V(:,:,:,n)
        call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, n, self%cdt, MAPL_GRAV, &
                            DU(:,:,:,n), t, airdens, &
-                           rh2, zle, delp, flux_ptr, correctionMaring=self%maringFlag, &
+                           rh2, zle, delp, flux_ptr, dusd_vel, correctionMaring=self%maringFlag, &
                            settling_scheme=settling_opt, __RC__)
     end do
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -62,6 +62,7 @@ category: EXPORT
  DUMASS        | kg kg-1    | xyz  | C    |                                | Dust Mass Mixing Ratio
  DUMASS25      | kg kg-1    | xyz  | C    |                                | Dust Mass Mixing Ratio
  DUCONC        | kg m-3     | xyz  | C    |                                | Dust Mass Concentration
+ DUSD_V        | m s-1      | xyz  | C    | self%nbins                     | Dust Settling Velocity (Bin %d)
  DUEXTCOEF     | m-1        | xyz  | C    | size(self%wavelengths_profile) | Dust Extinction Coefficient
  DUEXTCOEFRH20 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Dust Extinction Coefficient - Fixed RH=20%
  DUEXTCOEFRH80 | m-1        | xyz  | C    | size(self%wavelengths_profile) | Dust Extinction Coefficient - Fixed RH=80%

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -754,6 +754,7 @@ contains
     type (NI2G_GridComp), pointer     :: self
 
     real, allocatable, dimension(:,:) :: drydepositionfrequency, dqa
+    real, pointer, dimension(:,:,:)   :: nisd_vel
     real                              :: fwet
     logical                           :: KIN
     real, allocatable, target, dimension(:,:,:) :: fluxoutWT
@@ -858,26 +859,35 @@ contains
     end select
 
 !   Ammonium - settles like bin 1 of nitrate
+    nullify(nisd_vel)
+    if (associated(NH4SD_V)) nisd_vel => NH4SD_V
     call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, 1, self%cdt, MAPL_GRAV, &
-                              NH4a, t, airdens, rh2, zle, delp, NH4SD, settling_scheme=settling_opt, __RC__)
+                              NH4a, t, airdens, rh2, zle, delp, NH4SD, nisd_vel, &
+                              settling_scheme=settling_opt, __RC__)
 !   Nitrate Bin 1
     nullify(flux_ptr)
     if (associated(NISD)) flux_ptr => NISD(:,:,1)
+    nullify(nisd_vel)
+    if (associated(NISD_V)) nisd_vel => NISD_V(:,:,:,1)
     call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, 1, self%cdt, MAPL_GRAV, &
                         NO3an1, t, airdens, &
-                        rh2, zle, delp, flux_ptr,  settling_scheme=settling_opt, __RC__)
+                        rh2, zle, delp, flux_ptr, nisd_vel, settling_scheme=settling_opt, __RC__)
 !   Nitrate Bin 2
     nullify(flux_ptr)
     if (associated(NISD)) flux_ptr => NISD(:,:,2)
+    nullify(nisd_vel)
+    if (associated(NISD_V)) nisd_vel => NISD_V(:,:,:,2)
     call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, 2, self%cdt, MAPL_GRAV, &
                         NO3an2, t, airdens, &
-                        rh2, zle, delp, flux_ptr,  settling_scheme=settling_opt, __RC__)
+                        rh2, zle, delp, flux_ptr, nisd_vel, settling_scheme=settling_opt, __RC__)
 !   Nitrate Bin 3
     nullify(flux_ptr)
     if (associated(NISD)) flux_ptr => NISD(:,:,3)
+    nullify(nisd_vel)
+    if (associated(NISD_V)) nisd_vel => NISD_V(:,:,:,3)
     call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, 3, self%cdt, MAPL_GRAV, &
                         NO3an3, t, airdens, &
-                        rh2, zle, delp, flux_ptr,  settling_scheme=settling_opt, __RC__)
+                        rh2, zle, delp, flux_ptr, nisd_vel, settling_scheme=settling_opt, __RC__)
 
 
 

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_StateSpecs.rc
@@ -48,6 +48,7 @@ category: EXPORT
 #----------------------------------------------------------------------------------------
   NH3MASS       | kg/kg        | xyz   | C     |                                | Ammonia Mass Mixing Ratio
   NH4MASS       | kg/kg        | xyz   | C     |                                | Ammonium Aerosol Mass Mixing Ratio
+  NH4SD_V       | m s-1        | xyz   | C     |                                | Ammonium Settling Velocity
   NIMASS        | kg/kg        | xyz   | C     |                                | Nitrate Mass Mixing Ratio
   NIMASS25      | kg/kg        | xyz   | C     |                                | Nitrate Mass Mixing Ratio of Particulate Matter < 2.5 microns (PM2.5)
   HNO3CONC      | kg m-3       | xyz   | C     |                                | Nitric Acid Mass Concentration
@@ -55,6 +56,7 @@ category: EXPORT
   NH4CONC       | kg m-3       | xyz   | C     |                                | Ammonium Mass Concentration
   NICONC        | kg m-3       | xyz   | C     |                                | Nitrate Mass Concentration
   NICONC25      | kg m-3       | xyz   | C     |                                | Nitrate Mass Concentration of Particulate Matter < 2.5 microns (PM2.5)
+  NISD_V        | m s-1        | xyz   | C     | 3                              | Nitrate Settling Velocity (Bin %d)
   NIEXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Extinction Coefficient
   NIEXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Extinction Coefficient - fixed RH=20%
   NIEXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Nitrate Extinction Coefficient - fixed RH=80%

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -802,6 +802,7 @@ contains
 
     integer                           :: n
     real, allocatable, dimension(:,:) :: drydepositionfrequency, dqa
+    real, pointer, dimension(:,:,:)   :: sssd_vel
     real                              :: fwet
     logical                           :: KIN
 
@@ -860,9 +861,11 @@ contains
     do n = 1, self%nbins
        nullify(flux_ptr)
        if (associated(SSSD)) flux_ptr => SSSD(:,:,n)
+       nullify(sssd_vel)
+       if (associated(SSSD_V)) sssd_vel => SSSD_V(:,:,:,n)
        call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, n, self%cdt, MAPL_GRAV, &
                            SS(:,:,:,n), t, airdens, &
-                           rh2, zle, delp, flux_ptr, settling_scheme=settling_opt, __RC__)
+                           rh2, zle, delp, flux_ptr, sssd_vel, settling_scheme=settling_opt, __RC__)
     end do
 
 !   Deposition

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_StateSpecs.rc
@@ -44,6 +44,7 @@ category: EXPORT
  SSMASS        | kg kg-1      | xyz   | C     |                                | Sea Salt Mass Mixing Ratio
  SSMASS25      | kg kg-1      | xyz   | C     |                                | Sea Salt Mass Mixing Ratio of Particulate Matter < 2.5 microns (PM2.5)
  SSCONC        | kg m-3       | xyz   | C     |                                | Sea Salt Mass Concentration
+ SSSD_V        | m s-1        | xyz   | C     | self%nbins                     | Sea Salt Settling Velocity (Bin %d)
  SSEXTCOEF     | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Extinction Coefficient
  SSEXTCOEFRH20 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Extinction Coefficient - Fixed RH=20%
  SSEXTCOEFRH80 | m-1          | xyz   | C     | size(self%wavelengths_profile) | Sea Salt Extinction Coefficient - Fixed RH=80%

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1097,6 +1097,7 @@ contains
     real, dimension(:,:,:), allocatable :: xoh, xno3, xh2o2
 
     real, dimension(:,:), allocatable   :: drydepositionf
+    real, pointer, dimension(:,:,:)     :: susd_vel
 
     real, pointer, dimension(:,:,:)     :: dummyMSA !=> null() ! this is so the model can run without MSA enabled
     logical :: alarm_is_ringing
@@ -1199,6 +1200,7 @@ contains
        ! if radius == 0 then we're dealing with a gas which has no settling losses
        if (self%radius(n) == 0.0) then
           if (associated(SUSD)) SUSD(:,:,n) = 0.0
+          if (associated(SUSD_V)) SUSD_V(:,:,:,n) = 0.0
           cycle
        end if
 
@@ -1206,11 +1208,12 @@ contains
        call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)
        nullify(flux_ptr)
        if (associated(SUSD)) flux_ptr => SUSD(:,:,n)
-
+       nullify(susd_vel)
+       if (associated(SUSD_V)) susd_vel => SUSD_V(:,:,:,n)
 
        call Chem_SettlingSimple (self%km, self%klid, self%diag_Mie, 1, self%cdt, MAPL_GRAV, &
                            int_ptr, t, airdens, &
-                           rh2, zle, delp, flux_ptr, settling_scheme=settling_opt, __RC__)
+                           rh2, zle, delp, flux_ptr, susd_vel, settling_scheme=settling_opt, __RC__)
 
     end do
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_StateSpecs.rc
@@ -84,6 +84,7 @@ category: EXPORT
  MSASMASS      | kg m-3     | xy   | N    |                                | MSA Surface Mass Concentration
  MSACMASS      | kg m-2     | xy   | N    |                                | MSA Column Mass Density
  SUCONC        | kg m-3     | xyz  | C    |                                | SO4 Aerosol Mass Concentration
+ SUSD_V        | m s-1      | xyz  | C    | self%nbins                     | SO4 Settling Velocity (Bin %d)
  SUEXTCOEF     | m-1        | xyz  | C    | size(self%wavelengths_profile) | SO4 Extinction Coefficient
  SUEXTCOEFRH20 | m-1        | xyz  | C    | size(self%wavelengths_profile) | SO4 Extinction Coefficient - Fixed RH=20%
  SUEXTCOEFRH80 | m-1        | xyz  | C    | size(self%wavelengths_profile) | SO4 Extinction Coefficient - Fixed RH=80%

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -1465,7 +1465,7 @@ end function DarmenovaDragPartition
                                                   !  0 - all is well
                                                   !  1 -
 !  Optionally output the settling velocity calculated
-   real, pointer, optional, dimension(:,:,:)  :: vsettleOut
+   real, pointer, optional, intent (inout)  :: vsettleOut (:,:,:)
 
 !  Optionally correct the settling velocity following Maring et al, 2003
    logical, optional, intent(in)    :: correctionMaring
@@ -1576,9 +1576,9 @@ end function DarmenovaDragPartition
        endif
     endif
 
-    if(present(vsettleOut)) then
+    if (present(vsettleOut)) then
        vsettleOut = vsettle
-    endif
+    end if
 
 !   Time integration
     select case (settling_scheme)


### PR DESCRIPTION
This PR allows the model to output aerosol settling velocity as a diagnostic field.

- It modifies the settling routine and its calling functions to enable this output. 

This PR was motivated by discussion with @acollow about earlier settling tests.

