### PR TITLE
v2.5: Fix start-stop and missing GMI_HNO3 in NI AMIP ExtData yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-## [v2.5.1] - 2026-02-13
+## [v2.5.1] - 2026-02-17
 
 ### Fixed
 
 - Fix missing `GMI_HNO3` entry in `AMIP/NI2G_GridComp_ExtData.yaml` file
+- Fix start-stop regression failure in SU GridComp
 
 ## [v2.5.0] - 2026-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [v2.5.1] - 2026-02-13
+
+### Fixed
+
+- Fix missing `GMI_HNO3` entry in `AMIP/NI2G_GridComp_ExtData.yaml` file
+
 ## [v2.5.0] - 2026-02-05
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.5.0
+          VERSION 2.5.1
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
@@ -85,5 +85,8 @@ Exports:
     collection: /dev/null
   climNO3an3:
     collection: /dev/null
-
-
+  GMI_HNO3:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: NI2G_sample_2
+    variable: GMI_HNO3

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -860,11 +860,6 @@ contains
       thread = MAPL_get_current_thread()
       workspace => self%workspaces(thread)
 
-      !if (workspace%first) then
-         !xhno3 = MAPL_UNDEF
-         !workspace%first = .false.
-      !end if
-
       ! Recycle HNO3 every 3 hours
       if (alarm_is_ringing) then
          xhno3 = NITRATE_HNO3

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -97,7 +97,6 @@ real, parameter :: OCEAN=0.0, LAND = 1.0, SEA_ICE = 2.0
       real    :: aviation_layers(4)  ! heights of the LTO, CDS and CRS layers
       real    :: fSO4anth  ! Fraction of anthropogenic emissions that are SO4
       !logical :: firstRun = .true.
-      !real, pointer :: h2o2_init(:,:,:)
 
 !     PRC: logic for GMI coupling
       logical :: using_GMI
@@ -532,8 +531,6 @@ contains
     call MAPL_Get ( mapl, INTERNAL_ESMF_STATE = internal, &
                          LONS = LONS, &
                          LATS = LATS, __RC__ )
-
-    !allocate(self%h2o2_init(size(lats,1),size(lats,2),self%km), __STAT__)
 
 !   Is SU data driven?
 !   ------------------
@@ -1256,13 +1253,6 @@ contains
 
      xoh = 0.0
      xno3 = 0.0
-
-     if (workspace%firstRun) then
-        xh2o2          = MAPL_UNDEF
-        h2o2_init = MAPL_UNDEF
-        workspace%firstRun  = .false.
-     end if
-
      xh2o2 = h2o2_init
 
      call SulfateUpdateOxidants (nymd, nhms, LONS, LATS, airdens, self%km, self%cdt, &
@@ -1332,7 +1322,7 @@ contains
           call MAPL_VarSpecGet(InternalSpec(n), SHORT_NAME=short_name, __RC__)
           call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)
           call WetRemovalUFS  (self%km, self%klid, n, self%cdt, 'sulfate', &
-                      KIN, MAPL_GRAV, self%radius(n), rainout_eff, self%washout_tuning, & 
+                      KIN, MAPL_GRAV, self%radius(n), rainout_eff, self%washout_tuning, &
                       self%wet_radius_thr, int_ptr, ple, t, airdens, pfl_lsan, pfi_lsan, SUWT, __RC__)
     enddo
 


### PR DESCRIPTION
Testing with GOCART v2.5.0 found that it fails to run with AMIP emissions. The culprit was `GMI_HNO3` which was added to `NI2G_GridComp_ExtData.yaml` in https://github.com/GEOS-ESM/GOCART/pull/373 but it wasn't added to `AMIP/NI2G_GridComp_ExtData.yaml`

This PR adds it.