### PR TITLE
Continue porting to MAPL3

### DIFF
--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -92,7 +92,7 @@ contains
       !EOP
 
       !Locals
-      character(len=ESMF_MAXSTR) :: comp_name
+      character(len=:), allocatable :: comp_name
       type(SS2G_GridComp), pointer :: self
       character(len=ESMF_MAXSTR) :: field_name
       real :: DEFVAL
@@ -103,8 +103,7 @@ contains
       type(UngriddedDim) :: ungrd_wavelengths_profile, ungrd_wavelengths_vertint
       integer :: i, status
 
-      call ESMF_GridCompGet(gc, name=comp_name, _RC)
-      call MAPL_GridCompGet(gc, logger=logger, _RC)
+      call MAPL_GridCompGet(gc, logger=logger, name=comp_name, _RC)
 
       ! Wrap gridcomp's private state and store it in gridcomp
       _SET_NAMED_PRIVATE_STATE(gc, SS2G_GridComp, PRIVATE_STATE)
@@ -333,13 +332,12 @@ contains
       integer :: i, dims(3), km
       integer :: status
 
-      call MAPL_GridCompGet(gc, name=comp_name, _RC)
+      call MAPL_GridCompGet(gc, name=comp_name, geom=geom, grid=grid, num_levels=km, _RC)
 
       ! Get my internal private state
       _GET_NAMED_PRIVATE_STATE(gc, SS2G_GridComp, PRIVATE_STATE, self)
 
       ! Global dimensions are needed here for choosing tuning parameters
-      call MAPL_GridCompGet(gc, geom=geom, grid=grid, num_levels=km, _RC)
       call MAPL2_GridGet(grid, globalCellCountPerDim=dims, _RC)
       self%km = km
 

--- a/ESMF/Shared/Chem_AeroGeneric.F90
+++ b/ESMF/Shared/Chem_AeroGeneric.F90
@@ -14,7 +14,6 @@ module Chem_AeroGeneric
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    use mapl3g_State_API, only: MAPL_StateGetPointer
    use mapl3g_Field_API, only: MAPL_FieldGet, MAPL_FieldCreate
-   use mapl3g_FieldInfo, only: FieldInfoSetInternal
    use mapl3g_FieldBundle_API, only: MAPL_FieldBundleAdd
    use mapl3g_VerticalStaggerLoc, only: VerticalStaggerLoc, VERTICAL_STAGGER_EDGE, VERTICAL_STAGGER_CENTER
    use mapl3g_UngriddedDims, only: UngriddedDims
@@ -164,21 +163,20 @@ contains
             do iter = 1, size(orig_ptr, 3)
                write (bin_index, "(A, I0.3)") "", iter
                ptr2d => orig_ptr(:,:,iter)
-               field2d = ESMF_FieldCreate( &
-                    geom, &
-                    farray=ptr2d, &
-                    indexflag=ESMF_INDEX_DELOCAL, &
-                    datacopyflag=ESMF_DATACOPY_REFERENCE, &
-                    name=trim(varname)//trim(bin_index), _RC)
-               call ESMF_InfoGetFromHost(field2d, info, _RC)
-               call FieldInfoSetInternal( &
-                    info, &
-                    typekind=typekind, &
-                    vert_staggerloc=vert_stagger, &
+               field2d = MAPL_FieldCreate( &
+                    geom, typekind, &
+                    name=trim(varname)//trim(bin_index), &
                     ungridded_dims=UngriddedDims(), &
+                    vert_staggerloc=vert_stagger, &
                     units=units, &
                     standard_name=stdname//' Bin '//trim(bin_index), &
                     long_name="unknown", _RC)
+               call ESMF_FieldEmptyReset(field2d, status=ESMF_FIELDSTATUS_GEOMSET, _RC)
+               call ESMF_FieldEmptyComplete( &
+                    field2d, &
+                    farray=ptr2d, &
+                    indexflag=ESMF_INDEX_DELOCAL, &
+                    datacopyflag=ESMF_DATACOPY_REFERENCE, _RC)
                call MAPL_FieldBundleAdd(bundle, [field2d], _RC)
             end do
          end if


### PR DESCRIPTION
In `ESMF/Shared/Chem_AeroGeneric.F90`, replaced

`ESMF_FieldCreate` + `ESMF_InfoGetFromHost` + `FieldInfoSetInternal`

with more robust 

`MAPL_FieldCreate` + `ESMF_FieldEmptyReset` + `ESMF_FieldEmptyComplete`