### PR TITLE
v12: Set default optics to RRTMGP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update aerosol optics bands files to default to RRTMGP bands, rather than RRTMG (as GEOSgcm v12 has switched to RRTMGP)
+  - NOTE: This means users needing RRTMG bands will need to update at run time
+
 ### Fixed
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed pointer in XX2G_instance rc files to v2.x.x aerosol optical property
   LUTs now based on GEOSmie and with dimensions renamed and reordered as above
 - Updated version of volcanic sulfur emissions for AMIP configuration to v202601
-
 - Update aerosol optics bands files to default to RRTMGP bands, rather than RRTMG (as GEOSgcm v12 has switched to RRTMGP)
-  - NOTE: This means users needing RRTMG bands will need to update at run time
+  - NOTE: This means users needing RRTMG bands will need to update at run time. See https://github.com/GEOS-ESM/GEOSgcm_App/pull/878 for changes needed at run-time for GEOSgcm
 
 ### Fixed
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
@@ -2,7 +2,7 @@
 # Resource file for Black Carbon parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_BC.v1_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_BC.v1_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_BC.v1_6.nc
 
 # Aircraft emission factor: convert input unit to kg C

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
@@ -2,7 +2,7 @@
 # Resource file for Brown Carbon parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_BRC.v1_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_BRC.v1_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_BRC.v1_6.nc
 
 # Aircraft emission factor: convert input unit to kg C

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
@@ -2,7 +2,7 @@
 # Resource file for Organic Carbon parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_OC.v1_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_OC.v1_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_OC.v1_6.nc
 
 # Aircraft emission factor: convert input unit to kg C

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
@@ -2,7 +2,7 @@
 # Resource file Dust parameters.
 #
 
-aerosol_radBands_optics_file:      ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_DU.v15_6.RRTMG.nc
+aerosol_radBands_optics_file:      ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_DU.v15_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_DU.v15_6.nc
 
 particle_radius_microns: 0.73 1.4 2.4 4.5 8.0

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
@@ -4,7 +4,7 @@
 
 nbins: 5
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_NI.v2_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_NI.v2_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_NI.v2_6.nc
 
 # Scavenging efficiency per bin [km-1]

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
@@ -2,7 +2,7 @@
 # Resource file Sea Salt parameters
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SS.v3_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SS.v3_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SS.v3_6.nc
 
 particle_radius_microns: 0.079 0.316 1.119 2.818 7.772

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP.20C/SU2G_instance_SU.rc
@@ -2,7 +2,7 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_6.nc
 
 nbins: 4

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -2,7 +2,7 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_6.nc
 
 nbins: 4

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -2,7 +2,7 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMG.nc
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMGP.nc
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_6.nc
 
 nbins: 4


### PR DESCRIPTION
In GEOSgcm v12, we have moved from RRTMG to RRTMGP by default. However, GOCART has continued with RRTMG optics by default.

So, this PR updates it to be RRTMGP by default. This is zero-diff because, at the moment, we do sed shenanigans in `gcm_run.j` to change these lines at run time to RRTMGP.

NOTE: This will require changes in GEOSgcm_App for running with RRTMG. See https://github.com/GEOS-ESM/GEOSgcm_App/pull/878

cc: @sdrabenh