### PR TITLE
Feature/acollow/qfed3yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+- OPS ExtData yaml files fo CA, NI, SU, and CO to look for science quality QFED3 files beginning 11/27/25 specifically for xrun testing
 ## [v2.3.0] - 2025-01-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- OPS ExtData yaml files fo CA, NI, SU, and CO to look for science quality QFED3 files beginning 11/27/25 specifically for xrun testing
+- ExtData yaml files fo CA, NI, SU, and CO to use QFED3 files beginning 1/15/2026 for OPS emissions and 3/1/2023 for AMIP emissions
 ## [v2.3.0] - 2025-01-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
+## [v2.3.1] - 2026-03-10
+
+### Changed
+
 - ExtData yaml files fo CA, NI, SU, and CO to use QFED3 files beginning 1/15/2026 for OPS emissions and 3/1/2023 for AMIP emissions
+
 ## [v2.3.0] - 2025-01-16
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.3.0
+          VERSION 2.3.1
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
@@ -30,6 +30,12 @@ Collections:
   CA2G_hfed.emis_oc.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_oc.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-12-16T12:00"
+  CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
+  CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   CA2G_sample_0:
@@ -83,6 +89,7 @@ Exports:
   BC_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CA2G_hfed.emis_bc.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}    
   BC_SHIP:
     collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE
@@ -126,6 +133,7 @@ Exports:
   BRC_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CA2G_hfed.emis_oc.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}    
   BRC_SHIP:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
@@ -89,7 +89,7 @@ Exports:
   BC_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CA2G_hfed.emis_bc.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}    
+    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BC_SHIP:
     collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE
@@ -133,7 +133,7 @@ Exports:
   BRC_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CA2G_hfed.emis_oc.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}    
+    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BRC_SHIP:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -26,16 +26,16 @@ Collections:
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
   CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_bc.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
   CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_oc.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
-  CA2G_qfed_emis_x3600y1800_oc.v3_2_0.%y4%m2%d2.nc4:
-    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_oc.v3_2_0.%y4%m2%d2.nc4
-    valid_range: "2025-11-27T12:00/2028-01-01"
-  CA2G_qfed_emis_x3600y1800_bc.v3_2_0.%y4%m2%d2.nc4:
-    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_bc.v3_2_0.%y4%m2%d2.nc4
-    valid_range: "2025-11-27T12:00/2028-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
+  CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-02-01T12:00/2028-01-01"
+  CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-02-01T12:00/2028-01-01"
 
 Samplings:
   CA2G_sample_0:
@@ -89,7 +89,7 @@ Exports:
   BC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_bc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-    - {starting: "2025-11-27T12:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BC_SHIP:
     collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE
@@ -133,7 +133,7 @@ Exports:
   BRC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_oc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-    - {starting: "2025-11-27T12:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BRC_SHIP:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -30,6 +30,12 @@ Collections:
   CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_oc.061.%y4%m2%d2.nc4
     valid_range: "2021-11-01T12:00/2025-01-01"
+  CA2G_qfed_emis_x3600y1800_oc.v3_2_0.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_oc.v3_2_0.%y4%m2%d2.nc4
+    valid_range: "2025-11-27T12:00/2028-01-01"
+  CA2G_qfed_emis_x3600y1800_bc.v3_2_0.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_bc.v3_2_0.%y4%m2%d2.nc4
+    valid_range: "2025-11-27T12:00/2028-01-01"
 
 Samplings:
   CA2G_sample_0:
@@ -82,7 +88,8 @@ Exports:
     variable: biofuel
   BC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_bc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-    - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2021-11-01T12:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2025-11-27T12:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BC_SHIP:
     collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE
@@ -126,6 +133,7 @@ Exports:
   BRC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_oc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2025-11-27T12:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BRC_SHIP:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -88,7 +88,7 @@ Exports:
     variable: biofuel
   BC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_bc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
-    - {starting: "2021-11-01T12:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2026-02-01T12:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BC_SHIP:
     collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -32,10 +32,10 @@ Collections:
     valid_range: "2021-11-01T12:00/2026-02-01"
   CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4
-    valid_range: "2026-02-01T12:00/2028-01-01"
+    valid_range: "2026-01-15T12:00/2028-01-01"
   CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4
-    valid_range: "2026-02-01T12:00/2028-01-01"
+    valid_range: "2026-01-15T12:00/2028-01-01"
 
 Samplings:
   CA2G_sample_0:

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
@@ -41,7 +41,7 @@ Exports:
   EMI_NH3_BB:
     - {starting: "1960-01-16T12:00", collection: NI2G_hfed.emis_nh3.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
-    - {starting: "2023-03-01T00:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
   EMI_NH3_EN:
     collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
@@ -9,10 +9,13 @@ Collections:
     template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
   NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.6r1/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
-    valid_range: "2000-02-29T12:00/2025-01-01"
+    valid_range: "2000-02-29T12:00/2026-02-01"
   NI2G_hfed.emis_nh3.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_nh3.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-12-16T12:00"
+  NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   NI2G_sample_0:
@@ -38,6 +41,7 @@ Exports:
   EMI_NH3_BB:
     - {starting: "1960-01-16T12:00", collection: NI2G_hfed.emis_nh3.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
   EMI_NH3_EN:
     collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -12,10 +12,10 @@ Collections:
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
   NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-11-26"
-  NI2G_qfed_emis_x3600y1800_nh3.v3_2_0.%y4%m2%d2.nc4:
-    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_nh3.v3_2_0.%y4%m2%d2.nc4
-    valid_range: "2025-11-27T12:00/2028-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
+  NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-02-01T12:00/2028-01-01"
 
 Samplings:
   NI2G_sample_0:
@@ -41,7 +41,7 @@ Exports:
   EMI_NH3_BB:
     - {starting: "2014-12-01T12:00", collection: NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
-    - {starting: "2025-11-27T12:00", collection: NI2G_qfed_emis_x3600y1800_nh3.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
   EMI_NH3_EN:
     collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -12,7 +12,10 @@ Collections:
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
   NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
+    valid_range: "2021-11-01T12:00/2025-11-26"
+  NI2G_qfed_emis_x3600y1800_nh3.v3_2_0.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_nh3.v3_2_0.%y4%m2%d2.nc4
+    valid_range: "2025-11-27T12:00/2028-01-01"
 
 Samplings:
   NI2G_sample_0:
@@ -38,6 +41,7 @@ Exports:
   EMI_NH3_BB:
     - {starting: "2014-12-01T12:00", collection: NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+    - {starting: "2025-11-27T12:00", collection: NI2G_qfed_emis_x3600y1800_nh3.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
   EMI_NH3_EN:
     collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -15,7 +15,7 @@ Collections:
     valid_range: "2021-11-01T12:00/2026-02-01"
   NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4
-    valid_range: "2026-02-01T12:00/2028-01-01"
+    valid_range: "2026-01-15T12:00/2028-01-01"
 
 Samplings:
   NI2G_sample_0:

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
@@ -22,6 +22,9 @@ Collections:
   SU2G_hfed.emis_so2.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_so2.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-012-16T12:00"
+  SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   SU2G_sample_0:
@@ -70,6 +73,7 @@ Exports:
   SU_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: SU2G_hfed.emis_so2.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
   SU_DMSO:
     collection: SU2G_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -22,7 +22,10 @@ Collections:
   SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.061.%y4%m2%d2.nc4
     valid_range: "2021-11-01T12:00/2025-01-01"
-
+  SU2G_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4
+    valid_range: "2025-11-27T12:00/2028-01-01"
+    
 Samplings:
   SU2G_sample_0:
     extrapolation: clim
@@ -70,6 +73,7 @@ Exports:
   SU_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: SU2G_qfed2.emis_so2.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
+    - {starting: "2025-11-27T12:00", collection: SU2G_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
   SU_DMSO:
     collection: SU2G_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -21,10 +21,10 @@ Collections:
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
   SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
-  SU2G_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4:
-    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4
-    valid_range: "2025-11-27T12:00/2028-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
+  SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-02-01T12:00/2028-01-01"
     
 Samplings:
   SU2G_sample_0:
@@ -73,7 +73,7 @@ Exports:
   SU_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: SU2G_qfed2.emis_so2.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
-    - {starting: "2025-11-27T12:00", collection: SU2G_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
   SU_DMSO:
     collection: SU2G_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -24,7 +24,7 @@ Collections:
     valid_range: "2021-11-01T12:00/2026-02-01"
   SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4
-    valid_range: "2026-02-01T12:00/2028-01-01"
+    valid_range: "2026-01-15T12:00/2028-01-01"
     
 Samplings:
   SU2G_sample_0:

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -25,7 +25,7 @@ Collections:
   SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4
     valid_range: "2026-01-15T12:00/2028-01-01"
-    
+
 Samplings:
   SU2G_sample_0:
     extrapolation: clim

--- a/ESMF/GOCART_GridComp/CO_GridComp/AMIP/CO_GridComp_ExtData.yaml
+++ b/ESMF/GOCART_GridComp/CO_GridComp/AMIP/CO_GridComp_ExtData.yaml
@@ -15,6 +15,9 @@ Collections:
   CO_hfed.emis_co.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_co.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-12-16T12:00"
+  CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   CO_sample_0:
@@ -68,6 +71,7 @@ Exports:
   CO_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CO_hfed.emis_co.x576_y361.%y4%m2.nc4, linear_transformation: [0.0,1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CO_qfed2.emis_co.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
   CO_BIOMASSnbas:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
+++ b/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
@@ -15,6 +15,9 @@ Collections:
   CO_qfed2.emis_co.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_co.061.%y4%m2%d2.nc4
     valid_range: "2021-11-01T12:00/2025-01-01"
+  CO_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_co.v3_2_0.%y4%m2%d2.nc4
+    valid_range: "2025-11-27T12:00/2028-01-01"
 
 Samplings:
   CO_sample_0:
@@ -68,6 +71,7 @@ Exports:
   CO_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CO_qfed2.emis_co.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CO_qfed2.emis_co.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
+    - {starting: "2025-11-27T12:00", collection: CO_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
   CO_BIOMASSnbas:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
+++ b/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
@@ -15,9 +15,9 @@ Collections:
   CO_qfed2.emis_co.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_co.061.%y4%m2%d2.nc4
     valid_range: "2021-11-01T12:00/2025-01-01"
-  CO_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4:
-    template: ExtData/chemistry/QFED/v3.2-sci/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_co.v3_2_0.%y4%m2%d2.nc4
-    valid_range: "2025-11-27T12:00/2028-01-01"
+  CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-02-01T12:00/2028-01-01"
 
 Samplings:
   CO_sample_0:
@@ -71,7 +71,7 @@ Exports:
   CO_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CO_qfed2.emis_co.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CO_qfed2.emis_co.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
-    - {starting: "2025-11-27T12:00", collection: CO_qfed_emis_x3600y1800_so2.v3_2_0.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
   CO_BIOMASSnbas:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
+++ b/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
@@ -17,7 +17,7 @@ Collections:
     valid_range: "2021-11-01T12:00/2025-01-01"
   CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4
-    valid_range: "2026-02-01T12:00/2028-01-01"
+    valid_range: "2026-01-15T12:00/2028-01-01"
 
 Samplings:
   CO_sample_0:


### PR DESCRIPTION
This updates the ExtData.yaml files for carbon, sulfate, nitrate, and CO in the OPS and AMIP directories to use QFED3.2 once the data is available. Note that a corresponding change is also required in ACHEM to be used for SOA production.