### PR TITLE
Feature/two freq extinct 2 3 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [v2.3.2] - 2026-03-23
+
+### Changed
+
+- Updated `GOCART2G_GridComp.rc` to output AOD profile at 470 nm and 870 nm
+  for JEDI (in addition to the existing 550 nm vertically integrated AOD),
+  without changing behavior for the PSAS AOD analysis
+
 ## [v2.3.1] - 2026-03-10
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.3.1
+          VERSION 2.3.2
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridComp.rc
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridComp.rc
@@ -38,6 +38,6 @@ PASSIVE_INSTANCES_NI:
 # ---------------------
 aerosol_monochromatic_optics_wavelength_in_nm_from_LUT: 470 550 670 870
 
-wavelengths_for_profile_aop_in_nm: 470 550 870       # must be included in LUT
+wavelengths_for_profile_aop_in_nm: 470 870           # must be included in LUT
 wavelengths_for_vertically_integrated_aop_in_nm: 550 # must be included in LUT
 

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridComp.rc
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridComp.rc
@@ -38,6 +38,6 @@ PASSIVE_INSTANCES_NI:
 # ---------------------
 aerosol_monochromatic_optics_wavelength_in_nm_from_LUT: 470 550 670 870
 
-wavelengths_for_profile_aop_in_nm: 550               # must be included in LUT
+wavelengths_for_profile_aop_in_nm: 470 550 870       # must be included in LUT
 wavelengths_for_vertically_integrated_aop_in_nm: 550 # must be included in LUT
 


### PR DESCRIPTION
This adds frequencies 470 and 870 for extinctions output for JEDI without modifying the behavor felt by PSAS (fields in gaas-bkg-sfc). This has been put on top of v2.3.1 - I hope we can issue a v2.3.2 with ONLY this change.

**SHOLD NOT GO TO MAIN**
