### PR TITLE
Fix ifx errors in legacy GOCART GridComps (Ops emissions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed ifx compilation errors in legacy GOCART GridComps (Ops emissions path):
+  - Changed `intent(in)` to `intent(inout)` on `w_c` (`Chem_Bundle`) arguments in `Aero`, `CFC`, `CH4`, `CO`, `CO2`, and `Rn` GridComps, as sub-components temporarily modify registry indices
+- Additional fixes in `CO_GridCompMod.F90`:
+  - Initialize `eCO_bioburn_` to `0.0` to prevent use of uninitialized data when `diurnal_bb` is false
+  - Guard `DEALLOCATE` of `ier` with an `ALLOCATED` check
+  - Add local `ios` variable in `CO_Emission` to prevent host-association aliasing under optimization
+
 ### Added
 
 ## [v2.6.2] - 2026-03-09

--- a/ESMF/GOCART_GridComp/Aero_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/Aero_GridCompMod.F90
@@ -507,7 +507,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   type(Chem_Bundle), intent(in)  :: w_c      ! Chemical tracer fields   
+   type(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: sub-components temporarily modify reg indices)
    integer, intent(in) :: nymd, nhms          ! time
    real, intent(in) :: cdt                    ! chemistry timestep (secs)
 

--- a/ESMF/GOCART_GridComp/CFC_GridComp/CFC_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CFC_GridComp/CFC_GridCompMod.F90
@@ -130,7 +130,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 

--- a/ESMF/GOCART_GridComp/CH4_GridComp/CH4_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CH4_GridComp/CH4_GridCompMod.F90
@@ -174,7 +174,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -310,7 +310,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -366,7 +366,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -459,7 +459,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 

--- a/ESMF/GOCART_GridComp/CO2_GridComp/CO2_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CO2_GridComp/CO2_GridCompMod.F90
@@ -265,7 +265,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   type(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   type(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    integer, intent(in) :: nymd, nhms           ! time
    real,    intent(in) :: cdt                  ! chemical timestep (secs)
 
@@ -989,7 +989,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   type(Chem_Bundle), intent(in)  :: w_c      ! Chemical tracer fields   
+   type(Chem_Bundle), intent(inout) :: w_c   ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)
    integer, intent(in) :: nymd, nhms          ! time
    real,    intent(in) :: cdt                 ! chemical timestep (secs)
 

--- a/ESMF/GOCART_GridComp/CO_GridComp/CO_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CO_GridComp/CO_GridCompMod.F90
@@ -197,7 +197,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c          ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c       ! Chemical tracer fields (inout: CO_SingleInstance_ temporarily modifies reg indices)
    INTEGER, INTENT(IN) :: nymd, nhms             ! time
    REAL,    INTENT(IN) :: cdt                    ! chemical timestep (secs)
 
@@ -345,7 +345,7 @@ CONTAINS
 !
 
    subroutine CO_GridCompRun ( gcCO, w_c, impChem, expChem, &
-                                      nymd, nhms, cdt, rc )
+                                       nymd, nhms, cdt, rc )
 
 ! !USES:
 
@@ -353,7 +353,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c          ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c       ! Chemical tracer fields (inout: CO_SingleInstance_ temporarily modifies reg indices)
    INTEGER, INTENT(IN) :: nymd, nhms             ! time
    REAL,    INTENT(IN) :: cdt                    ! chemical timestep (secs)
 
@@ -403,7 +403,7 @@ CONTAINS
 !
 
    subroutine CO_GridCompFinalize ( gcCO, w_c, impChem, expChem, &
-                                      nymd, nhms, cdt, rc )
+                                       nymd, nhms, cdt, rc )
 
 ! !USES:
 
@@ -411,7 +411,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c          ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c       ! Chemical tracer fields (inout: CO_SingleInstance_ temporarily modifies reg indices)
    INTEGER, INTENT(IN) :: nymd, nhms             ! time
    REAL,    INTENT(IN) :: cdt                    ! chemical timestep (secs)
 
@@ -702,6 +702,7 @@ CONTAINS
               ier(nerr),STAT=ios )
    ier = 0
    IF ( ios /= 0 ) rc = 100
+   gcCO%eCO_bioburn_ = 0.0   ! initialize to prevent use of uninitialized data if diurnal_bb is false
    END SUBROUTINE init_
 
    SUBROUTINE final_(ierr)
@@ -711,7 +712,8 @@ CONTAINS
                 gcCO%eCO_bioburn_, &
                 gcCO%COsfcFlux, gcCO%eCO_iso, gcCO%eCO_mon, &
                 gcCO%eCO_mtn, gcCO%CH4, gcCO%OHnd, &
-                ier, STAT=ios )
+                STAT=ios )
+   IF ( ALLOCATED(ier) ) DEALLOCATE( ier, STAT=ios )
    CALL I90_release()
    rc = ierr
    END SUBROUTINE final_
@@ -1149,6 +1151,7 @@ CONTAINS
    CHARACTER(LEN=*), PARAMETER :: myname = 'CO_Emission'
 
    INTEGER :: i, j, k, kt, minkPBL
+   INTEGER :: ios                        ! local ios - prevent host association aliasing under optimization
    INTEGER, ALLOCATABLE :: index(:)
 
    REAL, PARAMETER :: mwtAir=28.97

--- a/ESMF/GOCART_GridComp/Rn_GridComp/Rn_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/Rn_GridComp/Rn_GridCompMod.F90
@@ -183,7 +183,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -316,7 +316,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -373,7 +373,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -461,7 +461,7 @@ subroutine RN_GridCompSetServices1_(  gc, chemReg, iname, rc)
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 


### PR DESCRIPTION
## Summary

Fixes #398

When running GEOSgcm v12 with ifx 2025.3 and OPS emissions in Release mode, the `CO_GridComp` (and other legacy GOCART GridComps) would fail during initialization due to ifx's stricter enforcement of `intent(in)` on arguments that are temporarily modified internally.

## Changes

- Changed `intent(in)` to `intent(inout)` on `w_c` (`Chem_Bundle`) arguments in `Aero`, `CFC`, `CH4`, `CO`, `CO2`, and `Rn` GridComps, as sub-components temporarily modify registry indices during execution
- Initialize `eCO_bioburn_` to `0.0` in `CO_GridCompMod.F90` to prevent use of uninitialized data when `diurnal_bb` is false
- Guard `DEALLOCATE` of `ier` in `CO_GridCompMod.F90` with an `ALLOCATED` check
- Add local `ios` variable in `CO_Emission` to prevent host-association aliasing under optimization

## Testing

All tests with v12 show this is zero-diff for Ops runs.

---

## More info from Claude:

### Root Cause

The real bug was `intent(in)` declared on `w_c` (type `Chem_Bundle`) in the outer public-facing routines (`Initialize`, `Run`, `Finalize`) across multiple species GridComps, while the `*_SingleInstance_` wrapper routines declared it `intent(inout)` and actually modified `w_c%reg%{n,i,j}_CO` (and equivalent fields for other species).

This is a Fortran aliasing violation: passing an `intent(in)` actual argument to an `intent(inout)` dummy argument. `ifx` at optimization level is legally allowed to assume `intent(in)` variables cannot change across a call, so it cached `w_c%reg%i_CO`, `w_c%reg%j_CO` etc. in registers. The `SingleInstance_` wrapper modifies these fields temporarily (saves, sets to single-instance values, calls method, restores), but the inner routine `CO_GridCompInitialize1_` (etc.) read the stale cached values — causing `nbeg /= nend` → `rc=1` → propagated up as `rc=3001`.

### Failure trace decoded

- GOCART_GridCompMod.F90:1006 → Aero_GridCompInitialize → status=3001
- 3001 = 2000 (CO offset in Aero) + 1000 (instance wrapper offset) + 1 (nbeg /= nend check in CO_GridCompInitialize1_)

### Why prints made it work

I/O flushes force register spills to memory, incidentally making the stale-cache issue disappear.