### PR TITLE
Feature/pcolarco/optics reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- Changed the Process_Library GOCART_MieMod and MieQuery files to handle dimension
+  reordered aerosol optical property LUTs.
+- Changed pointer in XX2G_instance rc files to v2.x.x aerosol optical property
+  LUTs now based on GEOSmie and with dimensions renamed and reordered as above
 
 ### Fixed
 

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
@@ -23,13 +23,13 @@ time_days_chemical_destruction: -1.  -1.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficency per bin [km-1]
+# Scavenging efficiency per bin [km-1]
 fscav: 0.0  0.4
 
-# Large scale rainout efficency per bin for wet_removal_scheme == gocart
+# Large scale rainout efficiency per bin for wet_removal_scheme == gocart
 fwet: 0.0  1.0
 
-# Rainout efficency per bin for wet_removal_scheme == ufs
+# Rainout efficiency per bin for wet_removal_scheme == ufs
 fwet_ice: 0.0 1.0
 fwet_snow: 0.0 1.0
 fwet_rain: 0.0 1.0

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
@@ -2,8 +2,8 @@
 # Resource file for Black Carbon parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BC.v1_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_BC.v1_6.nc4
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_BC.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_BC.v2.1.0.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
@@ -2,8 +2,8 @@
 # Resource file for Black Carbon parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_BC.v1_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_BC.v1_6.nc
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BC.v1_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_BC.v1_6.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000
@@ -23,13 +23,13 @@ time_days_chemical_destruction: -1.  -1.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficiency per bin [km-1]
+# Scavenging effici.nc4y per bin [km-1]
 fscav: 0.0  0.4
 
-# Large scale rainout efficiency per bin for wet_removal_scheme == gocart
+# Large scale rainout effici.nc4y per bin for wet_removal_scheme == gocart
 fwet: 0.0  1.0
 
-# Rainout efficiency per bin for wet_removal_scheme == ufs
+# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
 fwet_ice: 0.0 1.0
 fwet_snow: 0.0 1.0
 fwet_rain: 0.0 1.0

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.bc.rc
@@ -2,8 +2,8 @@
 # Resource file for Black Carbon parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_BC.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_BC.v2.1.0.nc4
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_BC.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_BC.v2.1.0.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000
@@ -23,13 +23,13 @@ time_days_chemical_destruction: -1.  -1.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging effici.nc4y per bin [km-1]
+# Scavenging efficency per bin [km-1]
 fscav: 0.0  0.4
 
-# Large scale rainout effici.nc4y per bin for wet_removal_scheme == gocart
+# Large scale rainout efficency per bin for wet_removal_scheme == gocart
 fwet: 0.0  1.0
 
-# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
+# Rainout efficency per bin for wet_removal_scheme == ufs
 fwet_ice: 0.0 1.0
 fwet_snow: 0.0 1.0
 fwet_rain: 0.0 1.0

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
@@ -2,8 +2,8 @@
 # Resource file for Brown Carbon parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_6.nc4
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_BR.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_BR.v2.1.0.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
@@ -2,8 +2,8 @@
 # Resource file for Brown Carbon parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_BR.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_BR.v2.1.0.nc4
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_BR.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_BR.v2.1.0.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.br.rc
@@ -2,8 +2,8 @@
 # Resource file for Brown Carbon parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_BRC.v1_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_BRC.v1_6.nc
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_6.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
@@ -2,8 +2,8 @@
 # Resource file for Organic Carbon parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_OC.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_OC.v2.1.0.nc4
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_OC.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_OC.v2.1.0.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000
@@ -33,13 +33,13 @@ time_days_chemical_destruction: -1.  -1.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging effici.nc4y per bin [km-1]
+# Scavenging efficency per bin [km-1]
 fscav: 0.0  0.4
 
-# Large scale rainout effici.nc4y per bin for wet_removal_scheme == gocart
+# Large scale rainout efficency per bin for wet_removal_scheme == gocart
 fwet: 0.0  1.0
 
-# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
+# Rainout efficency per bin for wet_removal_scheme == ufs
 fwet_ice: 0.0 1.0
 fwet_snow: 0.0 1.0
 fwet_rain: 0.0 1.0

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
@@ -2,8 +2,8 @@
 # Resource file for Organic Carbon parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_OC.v1_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_OC.v1_6.nc4
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_OC.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_OC.v2.1.0.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
@@ -33,13 +33,13 @@ time_days_chemical_destruction: -1.  -1.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficency per bin [km-1]
+# Scavenging efficiency per bin [km-1]
 fscav: 0.0  0.4
 
-# Large scale rainout efficency per bin for wet_removal_scheme == gocart
+# Large scale rainout efficiency per bin for wet_removal_scheme == gocart
 fwet: 0.0  1.0
 
-# Rainout efficency per bin for wet_removal_scheme == ufs
+# Rainout efficiency per bin for wet_removal_scheme == ufs
 fwet_ice: 0.0 1.0
 fwet_snow: 0.0 1.0
 fwet_rain: 0.0 1.0

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_instance_CA.oc.rc
@@ -2,8 +2,8 @@
 # Resource file for Organic Carbon parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_OC.v1_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_OC.v1_6.nc
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_OC.v1_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_OC.v1_6.nc4
 
 # Aircraft emission factor: convert input unit to kg C
 aircraft_fuel_emission_factor: 1.0000
@@ -33,13 +33,13 @@ time_days_chemical_destruction: -1.  -1.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficiency per bin [km-1]
+# Scavenging effici.nc4y per bin [km-1]
 fscav: 0.0  0.4
 
-# Large scale rainout efficiency per bin for wet_removal_scheme == gocart
+# Large scale rainout effici.nc4y per bin for wet_removal_scheme == gocart
 fwet: 0.0  1.0
 
-# Rainout efficiency per bin for wet_removal_scheme == ufs
+# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
 fwet_ice: 0.0 1.0
 fwet_snow: 0.0 1.0
 fwet_rain: 0.0 1.0

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
@@ -2,8 +2,8 @@
 # Resource file Dust parameters.
 #
 
-aerosol_radBands_optics_file:      /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_DU.v15_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_6.nc4
+aerosol_radBands_optics_file:      /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_DU.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_DU.v2.1.0.nc4
 
 particle_radius_microns: 0.73 1.4 2.4 4.5 8.0
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
@@ -2,8 +2,8 @@
 # Resource file Dust parameters.
 #
 
-aerosol_radBands_optics_file:      ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_DU.v15_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_DU.v15_6.nc
+aerosol_radBands_optics_file:      /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_DU.v15_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_6.nc4
 
 particle_radius_microns: 0.73 1.4 2.4 4.5 8.0
 
@@ -44,13 +44,13 @@ soil_clay_factor: 1.0
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficiency per bin [km-1]
+# Scavenging effici.nc4y per bin [km-1]
 fscav: 0.2  0.2  0.2  0.2  0.2
 
-# Large scale rainout efficiency per bin for wet_removal_scheme == gocart
+# Large scale rainout effici.nc4y per bin for wet_removal_scheme == gocart
 fwet: 1.0 1.0 1.0 1.0 1.0
 
-# Rainout efficiency per bin for wet_removal_scheme == ufs
+# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
 fwet_ice: 0.8 0.8 0.8 1.0 1.0
 fwet_snow: 0.8 0.8 0.8 1.0 1.0
 fwet_rain: 0.8 0.8 0.8 1.0 1.0

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
@@ -44,13 +44,13 @@ soil_clay_factor: 1.0
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficency per bin [km-1]
+# Scavenging efficiency per bin [km-1]
 fscav: 0.2  0.2  0.2  0.2  0.2
 
-# Large scale rainout efficency per bin for wet_removal_scheme == gocart
+# Large scale rainout efficiency per bin for wet_removal_scheme == gocart
 fwet: 1.0 1.0 1.0 1.0 1.0
 
-# Rainout efficency per bin for wet_removal_scheme == ufs
+# Rainout efficiency per bin for wet_removal_scheme == ufs
 fwet_ice: 0.8 0.8 0.8 1.0 1.0
 fwet_snow: 0.8 0.8 0.8 1.0 1.0
 fwet_rain: 0.8 0.8 0.8 1.0 1.0

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
@@ -2,8 +2,8 @@
 # Resource file Dust parameters.
 #
 
-aerosol_radBands_optics_file:      /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_DU.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_DU.v2.1.0.nc4
+aerosol_radBands_optics_file:      ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_DU.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_DU.v2.1.0.nc4
 
 particle_radius_microns: 0.73 1.4 2.4 4.5 8.0
 
@@ -44,13 +44,13 @@ soil_clay_factor: 1.0
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging effici.nc4y per bin [km-1]
+# Scavenging efficency per bin [km-1]
 fscav: 0.2  0.2  0.2  0.2  0.2
 
-# Large scale rainout effici.nc4y per bin for wet_removal_scheme == gocart
+# Large scale rainout efficency per bin for wet_removal_scheme == gocart
 fwet: 1.0 1.0 1.0 1.0 1.0
 
-# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
+# Rainout efficency per bin for wet_removal_scheme == ufs
 fwet_ice: 0.8 0.8 0.8 1.0 1.0
 fwet_snow: 0.8 0.8 0.8 1.0 1.0
 fwet_rain: 0.8 0.8 0.8 1.0 1.0

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
@@ -4,13 +4,13 @@
 
 nbins: 5
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_NI.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_NI.v2.1.0.nc4
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_NI.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_NI.v2.1.0.nc4
 
-# Scavenging effici.nc4y per bin [km-1]
+# Scavenging efficency per bin [km-1]
 fscav: 0.0   0.4    0.4    0.4    0.4
 
-#Large scale rainout effici.nc4y per bin for gocart
+#Large scale rainout efficency per bin for gocart
 fwet: 1.0 1.0 1.0 1.0 0.3
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
@@ -4,13 +4,13 @@
 
 nbins: 5
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_NI.v2_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_NI.v2_6.nc
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_6.nc4
 
-# Scavenging efficiency per bin [km-1]
+# Scavenging effici.nc4y per bin [km-1]
 fscav: 0.0   0.4    0.4    0.4    0.4
 
-#Large scale rainout efficiency per bin for gocart
+#Large scale rainout effici.nc4y per bin for gocart
 fwet: 1.0 1.0 1.0 1.0 0.3
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
@@ -7,10 +7,10 @@ nbins: 5
 aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_NI.v2.1.0.RRTMG.nc4
 aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_NI.v2.1.0.nc4
 
-# Scavenging efficency per bin [km-1]
+# Scavenging efficiency per bin [km-1]
 fscav: 0.0   0.4    0.4    0.4    0.4
 
-#Large scale rainout efficency per bin for gocart
+#Large scale rainout efficiency per bin for gocart
 fwet: 1.0 1.0 1.0 1.0 0.3
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_instance_NI.rc
@@ -4,8 +4,8 @@
 
 nbins: 5
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_6.nc4
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_NI.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_NI.v2.1.0.nc4
 
 # Scavenging effici.nc4y per bin [km-1]
 fscav: 0.0   0.4    0.4    0.4    0.4

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
@@ -2,8 +2,8 @@
 # Resource file Sea Salt parameters
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SS.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_SS.v2.1.0.nc4
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SS.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_SS.v2.1.0.nc4
 
 particle_radius_microns: 0.079 0.316 1.119 2.818 7.772
 
@@ -16,12 +16,12 @@ particle_density: 2200. 2200. 2200. 2200. 2200.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging effici.nc4y per bin [km-1]
+# Scavenging efficency per bin [km-1]
 fscav: 0.4  0.4  0.4  0.4  0.4
-# Rainout effici.nc4y per bin for wet_removal_scheme == gocart
+# Rainout efficency per bin for wet_removal_scheme == gocart
 fwet: 1.0 1.0 1.0 1.0 1.0
 
-# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
+# Rainout efficency per bin for wet_removal_scheme == ufs
 fwet_ice: 1.0 1.0 1.0 1.0 1.0
 fwet_snow: 1.0 1.0 1.0 1.0 1.0
 fwet_rain: 1.0 1.0 1.0 1.0 1.0

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
@@ -2,8 +2,8 @@
 # Resource file Sea Salt parameters
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SS.v3_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SS.v3_6.nc
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SS.v3_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_SS.v3_6.nc4
 
 particle_radius_microns: 0.079 0.316 1.119 2.818 7.772
 
@@ -16,12 +16,12 @@ particle_density: 2200. 2200. 2200. 2200. 2200.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficiency per bin [km-1]
+# Scavenging effici.nc4y per bin [km-1]
 fscav: 0.4  0.4  0.4  0.4  0.4
-# Rainout efficiency per bin for wet_removal_scheme == gocart
+# Rainout effici.nc4y per bin for wet_removal_scheme == gocart
 fwet: 1.0 1.0 1.0 1.0 1.0
 
-# Rainout efficiency per bin for wet_removal_scheme == ufs
+# Rainout effici.nc4y per bin for wet_removal_scheme == ufs
 fwet_ice: 1.0 1.0 1.0 1.0 1.0
 fwet_snow: 1.0 1.0 1.0 1.0 1.0
 fwet_rain: 1.0 1.0 1.0 1.0 1.0

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
@@ -2,8 +2,8 @@
 # Resource file Sea Salt parameters
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SS.v3_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_SS.v3_6.nc4
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SS.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_SS.v2.1.0.nc4
 
 particle_radius_microns: 0.079 0.316 1.119 2.818 7.772
 

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
@@ -16,12 +16,12 @@ particle_density: 2200. 2200. 2200. 2200. 2200.
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart ! default value
 
-# Scavenging efficency per bin [km-1]
+# Scavenging efficiency per bin [km-1]
 fscav: 0.4  0.4  0.4  0.4  0.4
-# Rainout efficency per bin for wet_removal_scheme == gocart
+# Rainout efficiency per bin for wet_removal_scheme == gocart
 fwet: 1.0 1.0 1.0 1.0 1.0
 
-# Rainout efficency per bin for wet_removal_scheme == ufs
+# Rainout efficiency per bin for wet_removal_scheme == ufs
 fwet_ice: 1.0 1.0 1.0 1.0 1.0
 fwet_snow: 1.0 1.0 1.0 1.0 1.0
 fwet_rain: 1.0 1.0 1.0 1.0 1.0

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -20,18 +20,18 @@ so4_anthropogenic_fraction: 0.03
 # Aircraft emission factor: convert input unit to kg SO2
 aircraft_fuel_emission_factor: 1.0000
 
-# Scavenging efficency per bin [km-1]
+# Scavenging efficiency per bin [km-1]
 fscav: 0.0  0.0  0.4  0.4
 
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart
 
-# Rainout efficency for sulfate wet_removal_scheme == ufs
+# Rainout efficiency for sulfate wet_removal_scheme == ufs
 fwet_ice: 1.0
 fwet_snow: 1.0
 fwet_rain: 1.0
 
-#Dummy wet removal efficency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
+#Dummy wet removal efficiency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
 fwet: 1.0 1.0 1.0 1.0
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -2,14 +2,14 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_6.nc
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_6.nc4
 
 nbins: 4
 
 # Volcanic pointwise sources
-volcano_srcfilen_explosive: ExtData/chemistry/CARN/v202401/explosive/so2_explosive_volcanic_emissions_CARN_v202401.%y4%m2%d2.rc
-volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
+volcano_srcfilen_explosive: /discover/nobackup/pcolarco/fvInput/chemistry/CARN/v202401/explosive/so2_explosive_volcanic_emissions_CARN_v202401.%y4%m2%d2.rc
+volcano_srcfilen_degassing: /discover/nobackup/pcolarco/fvInput/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3
@@ -20,18 +20,18 @@ so4_anthropogenic_fraction: 0.03
 # Aircraft emission factor: convert input unit to kg SO2
 aircraft_fuel_emission_factor: 1.0000
 
-# Scavenging efficiency per bin [km-1]
+# Scavenging effici.nc4y per bin [km-1]
 fscav: 0.0  0.0  0.4  0.4
 
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart
 
-# Rainout efficiency for sulfate wet_removal_scheme == ufs
+# Rainout effici.nc4y for sulfate wet_removal_scheme == ufs
 fwet_ice: 1.0
 fwet_snow: 1.0
 fwet_rain: 1.0
 
-#Dummy wet removal efficiency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
+#Dummy wet removal effici.nc4y for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
 fwet: 1.0 1.0 1.0 1.0
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -2,14 +2,14 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_6.nc4
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SU.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_SU.v2.1.0.nc4
 
 nbins: 4
 
 # Volcanic pointwise sources
-volcano_srcfilen_explosive: /discover/nobackup/pcolarco/fvInput/chemistry/CARN/v202401/explosive/so2_explosive_volcanic_emissions_CARN_v202401.%y4%m2%d2.rc
-volcano_srcfilen_degassing: /discover/nobackup/pcolarco/fvInput/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
+volcano_srcfilen_explosive: ExtData/chemistry/CARN/v202401/explosive/so2_explosive_volcanic_emissions_CARN_v202401.%y4%m2%d2.rc
+volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -2,8 +2,8 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SU.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_SU.v2.1.0.nc4
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SU.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_SU.v2.1.0.nc4
 
 nbins: 4
 
@@ -20,18 +20,18 @@ so4_anthropogenic_fraction: 0.03
 # Aircraft emission factor: convert input unit to kg SO2
 aircraft_fuel_emission_factor: 1.0000
 
-# Scavenging effici.nc4y per bin [km-1]
+# Scavenging efficency per bin [km-1]
 fscav: 0.0  0.0  0.4  0.4
 
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart
 
-# Rainout effici.nc4y for sulfate wet_removal_scheme == ufs
+# Rainout efficency for sulfate wet_removal_scheme == ufs
 fwet_ice: 1.0
 fwet_snow: 1.0
 fwet_rain: 1.0
 
-#Dummy wet removal effici.nc4y for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
+#Dummy wet removal efficency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
 fwet: 1.0 1.0 1.0 1.0
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -20,18 +20,18 @@ so4_anthropogenic_fraction: 0.03
 # Aircraft emission factor: convert input unit to kg SO2
 aircraft_fuel_emission_factor: 1.0000
 
-# Scavenging efficency per bin [km-1]
+# Scavenging efficiency per bin [km-1]
 fscav: 0.0  0.0  0.4  0.4
 
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart
 
-# Rainout efficency for sulfate wet_removal_scheme == ufs
+# Rainout efficiency for sulfate wet_removal_scheme == ufs
 fwet_ice: 1.0
 fwet_snow: 1.0
 fwet_rain: 1.0
 
-#Dummy wet removal efficency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
+#Dummy wet removal efficiency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
 fwet: 1.0 1.0 1.0 1.0
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -2,14 +2,14 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opticsBands_SU.v1_6.RRTMG.nc
-aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/optics_SU.v1_6.nc
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_6.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_6.nc4
 
 nbins: 4
 
 # Volcanic pointwise sources
 volcano_srcfilen_explosive: /dev/null
-volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
+volcano_srcfilen_degassing: /discover/nobackup/pcolarco/fvInput/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3
@@ -20,18 +20,18 @@ so4_anthropogenic_fraction: 0.03
 # Aircraft emission factor: convert input unit to kg SO2
 aircraft_fuel_emission_factor: 1.0000
 
-# Scavenging efficiency per bin [km-1]
+# Scavenging effici.nc4y per bin [km-1]
 fscav: 0.0  0.0  0.4  0.4
 
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart
 
-# Rainout efficiency for sulfate wet_removal_scheme == ufs
+# Rainout effici.nc4y for sulfate wet_removal_scheme == ufs
 fwet_ice: 1.0
 fwet_snow: 1.0
 fwet_rain: 1.0
 
-#Dummy wet removal efficiency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
+#Dummy wet removal effici.nc4y for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
 fwet: 1.0 1.0 1.0 1.0
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -2,14 +2,14 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SU.v2.1.0.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_SU.v2.1.0.nc4
+aerosol_radBands_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SU.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v2.x.x/x/optics_SU.v2.1.0.nc4
 
 nbins: 4
 
 # Volcanic pointwise sources
 volcano_srcfilen_explosive: /dev/null
-volcano_srcfilen_degassing: /discover/nobackup/pcolarco/fvInput/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
+volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3
@@ -20,18 +20,18 @@ so4_anthropogenic_fraction: 0.03
 # Aircraft emission factor: convert input unit to kg SO2
 aircraft_fuel_emission_factor: 1.0000
 
-# Scavenging effici.nc4y per bin [km-1]
+# Scavenging efficency per bin [km-1]
 fscav: 0.0  0.0  0.4  0.4
 
 # Wet Removal Scheme Option | gocart, ufs
 wet_removal_scheme: gocart
 
-# Rainout effici.nc4y for sulfate wet_removal_scheme == ufs
+# Rainout efficency for sulfate wet_removal_scheme == ufs
 fwet_ice: 1.0
 fwet_snow: 1.0
 fwet_rain: 1.0
 
-#Dummy wet removal effici.nc4y for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
+#Dummy wet removal efficency for wet_removal_scheme == gocart. This is not used for sulfate as of GOCART v2.5 and should be revisited.
 fwet: 1.0 1.0 1.0 1.0
 
 # Dry particle radius [um], used for settling

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -2,8 +2,8 @@
 # Resource file for Sulfur parameters.
 #
 
-aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_6.RRTMG.nc4
-aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_6.nc4
+aerosol_radBands_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/opticsBands_SU.v2.1.0.RRTMG.nc4
+aerosol_monochromatic_optics_file: /discover/nobackup/pcolarco/fvInput/chemistry/AerosolOptics/v2.x.x/x/optics_SU.v2.1.0.nc4
 
 nbins: 4
 

--- a/Process_Library/GOCART2G_MieMod.F90
+++ b/Process_Library/GOCART2G_MieMod.F90
@@ -62,7 +62,7 @@ module GOCART2G_MieMod
 !ams  real, pointer  :: pback(:,:,:,:) => Null()  ! (r,c,b,p) Backscatter phase function
       real, pointer  :: p11(:,:,:) => Null()      ! (r,c,b) Backscatter phase function, index 1 
       real, pointer  :: p22(:,:,:) => Null()      ! (r,c,b) Backscatter phase function, index 5
-      real, pointer  :: pmom(:,:,:,:,:) => Null() ! (r,c,b,m,p) moments of phase function
+      real, pointer  :: pmom(:,:,:,:,:) => Null() ! (m,p,r,c,b) moments of phase function
       real, pointer  :: gf(:,:) => Null()         ! (r,b) hygroscopic growth factor
       real, pointer  :: rhop(:,:) => Null()       ! (r,b) wet particle density [kg m-3]
       real, pointer  :: rhod(:,:) => Null()       ! (r,b) dry particle density [kg m-3]
@@ -156,6 +156,7 @@ CONTAINS
      
      real :: yerr
      integer :: nmom_, imom, ipol
+     real, allocatable, dimension(:) :: real_tmp, bext_tmp, bsca_tmp, bbck_tmp, g_tmp,refr_tmp, refi_tmp
      integer :: status
 
 #define NF_VERIFY_(expr) rc = expr; if (rc /= 0) return
@@ -193,7 +194,7 @@ CONTAINS
 
 !     Channels
 !     --------
-      NF_VERIFY_(nf90_inq_dimid(ncid,'lambda',idimid))
+      NF_VERIFY_(nf90_inq_dimid(ncid,'wavelength',idimid))
       NF_VERIFY_(nf90_inquire_dimension(ncid,idimid,len=nch_table))
 
       if (present(wavelengths) ) then
@@ -204,20 +205,20 @@ CONTAINS
       
 !     Dry Effective radius
 !     --------------------
-      NF_VERIFY_(nf90_inq_dimid(ncid,'radius',idimid))
+      NF_VERIFY_(nf90_inq_dimid(ncid,'bin',idimid))
       NF_VERIFY_(nf90_inquire_dimension(ncid,idimid,len=nbin_table))
 
 !     Moments of phase function
 !     -------------------------
       if ( nmom_ > 0 ) then
-         NF_VERIFY_(nf90_inq_dimid(ncid,'nMom',idimid))
+         NF_VERIFY_(nf90_inq_dimid(ncid,'m',idimid))
          NF_VERIFY_(nf90_inquire_dimension(ncid,idimid,len=nmom_table))
          if ( nmom_ > nmom_table ) then
 !            rc = 99
             print*,'Error: nmom_ > nmom_table, see:'//myname
             NF_VERIFY_(1)
          end if
-         NF_VERIFY_(nf90_inq_dimid(ncid,'nPol',idimid))
+         NF_VERIFY_(nf90_inq_dimid(ncid,'p',idimid))
          NF_VERIFY_(nf90_inquire_dimension(ncid,idimid,len=nPol_table))
       endif
 
@@ -227,23 +228,23 @@ CONTAINS
       allocate(channels_table(nch_table), __NF_STAT__)
       allocate(rh_table(nrh_table), __NF_STAT__)
       allocate(reff_table(nrh_table,nbin_table), __NF_STAT__)
-      allocate(bext_table(nch_table,nrh_table,nbin_table), __NF_STAT__)
-      allocate(bsca_table(nch_table,nrh_table,nbin_table), __NF_STAT__)
-      allocate(bbck_table(nch_table,nrh_table,nbin_table),  __NF_STAT__)
-      allocate(g_table(nch_table,nrh_table,nbin_table), stat = rc )
-      allocate(pback_table(nch_table,nrh_table,nbin_table,nPol_table),  __NF_STAT__)
+      allocate(bext_table(nrh_table,nch_table,nbin_table), __NF_STAT__)
+      allocate(bsca_table(nrh_table,nch_table,nbin_table), __NF_STAT__)
+      allocate(bbck_table(nrh_table,nch_table,nbin_table),  __NF_STAT__)
+      allocate(g_table(nrh_table,nch_table,nbin_table), stat = rc )
+      allocate(pback_table(nPol_table,nrh_table,nch_table,nbin_table),  __NF_STAT__)
       allocate(gf_table(nrh_table,nbin_table), __NF_STAT__)
       allocate(rhop_table(nrh_table,nbin_table), __NF_STAT__)
       allocate(rhod_table(nrh_table,nbin_table), __NF_STAT__)
       allocate(vol_table(nrh_table,nbin_table), __NF_STAT__)
       allocate(area_table(nrh_table,nbin_table), __NF_STAT__)
-      allocate(refr_table(nch_table,nrh_table,nbin_table), __NF_STAT__)
-      allocate(refi_table(nch_table,nrh_table,nbin_table), __NF_STAT__)
+      allocate(refr_table(nrh_table,nch_table,nbin_table), __NF_STAT__)
+      allocate(refi_table(nrh_table,nch_table,nbin_table), __NF_STAT__)
 
       if ( nmom_ > 0 ) then
-         allocate(pmom_table(nch_table,nrh_table,nbin_table,nmom_table,nPol_table), __NF_STAT__)
+         allocate(pmom_table(nmom_table,nPol_table,nrh_table,nch_table,nbin_table), __NF_STAT__)
       end if
-      NF_VERIFY_(nf90_inq_varid(ncid,'lambda',ivarid))
+      NF_VERIFY_(nf90_inq_varid(ncid,'wavelength',ivarid))
       NF_VERIFY_(nf90_get_var(ncid,ivarid,channels_table))
       NF_VERIFY_(nf90_inq_varid(ncid,'rEff',ivarid))
       NF_VERIFY_(nf90_get_var(ncid,ivarid,reff_table))
@@ -354,9 +355,9 @@ CONTAINS
       allocate (this%bsca(this%nrh,this%nch,this%nbin), __NF_STAT__)
       allocate (this%bbck(this%nrh,this%nch,this%nbin), __NF_STAT__)
       allocate (this%g(this%nrh,this%nch,this%nbin),    __NF_STAT__)
-      allocate (pback(this%nrh,this%nch,this%nbin,this%nPol),    __NF_STAT__)
+      allocate (pback(this%nPol,this%nrh,this%nch,this%nbin),    __NF_STAT__)
       if ( nmom_ > 0 ) then
-         allocate (this%pmom(this%nrh,this%nch,this%nbin,this%nMom,this%nPol),    __NF_STAT__)
+         allocate (this%pmom(this%nMom,this%nPol,this%nrh,this%nch,this%nbin),    __NF_STAT__)
       end if
       allocate (this%gf(this%nrh,this%nbin),    __NF_STAT__)
       allocate (this%rhop(this%nrh,this%nbin),    __NF_STAT__)
@@ -402,51 +403,65 @@ CONTAINS
       if ( present(wavelengths) ) then
          do j = 1, this%nbin
             do i = 1, this%nrh
+               bext_tmp = bext_table(i,:,j)
+               bsca_tmp = bsca_table(i,:,j)
+               bbck_tmp = bbck_table(i,:,j)
+               g_tmp    = g_table(i,:,j)
+               refr_tmp = refr_table(i,:,j)
+               refi_tmp = refi_table(i,:,j)
                do n = 1, this%nch
-                  call polint(channels_table,bext_table(:,i,j),nch_table, &
+                  call polint(channels_table,bext_tmp,nch_table, &
                        this%wavelengths(n),this%bext(i,n,j),yerr)
-                  call polint(channels_table,bsca_table(:,i,j),nch_table, &
+                  call polint(channels_table,bsca_tmp,nch_table, &
                        this%wavelengths(n),this%bsca(i,n,j),yerr)
-                  call polint(channels_table,bbck_table(:,i,j),nch_table, &
+                  call polint(channels_table,bbck_tmp,nch_table, &
                        this%wavelengths(n),this%bbck(i,n,j),yerr)
-                  call polint(channels_table,g_table(:,i,j),nch_table,    &
+                  call polint(channels_table,g_tmp,nch_table,    &
                        this%wavelengths(n),this%g(i,n,j),yerr)
-                  call polint(channels_table,refr_table(:,i,j),nch_table, &
+                  call polint(channels_table,refr_tmp,nch_table, &
                        this%wavelengths(n),this%refr(i,n,j),yerr)
-                  call polint(channels_table,refi_table(:,i,j),nch_table, &
+                  call polint(channels_table,refi_tmp,nch_table, &
                        this%wavelengths(n),this%refi(i,n,j),yerr)
-                  do ipol = 1, this%nPol
-                      call polint(channels_table,pback_table(:,i,j,ipol),nch_table,    &
-                             this%wavelengths(n),pback(i,n,j,ipol),yerr)
-                  end do
-                  if ( nmom_ > 0 ) then
-                     do imom = 1, this%nMom
-                        do ipol = 1, this%nPol
-                           call polint(channels_table,pmom_table(:,i,j,imom,ipol),nch_table, &
-                                this%wavelengths(n),this%pmom(i,n,j,imom,ipol),yerr)
+               enddo !n
+
+               do ipol = 1, this%nPol
+                  real_tmp = pback_table(ipol,i,:,j)
+                  do n = 1, this%nch
+                      call polint(channels_table,real_tmp,nch_table,    &
+                             this%wavelengths(n),pback(ipol,i,n,j),yerr)
+                  end do !n
+               enddo !ipol
+
+               if ( nmom_ > 0 ) then
+                  do imom = 1, this%nMom
+                     do ipol = 1, this%nPol
+                        real_tmp = pmom_table(imom,ipol,i,:,j)
+                        do n = 1, this%nch
+                           call polint(channels_table, real_tmp,nch_table, &
+                                this%wavelengths(n),this%pmom(imom,ipol,i,n,j),yerr)
                         enddo
                      enddo
-                  endif
-               enddo
+                  enddo
+               endif
             enddo
          enddo
       else !(no wavelength)
          !swap the order
-         this%bext = reshape(bext_table, [nrh_table, nch, nbin_table],order =[2,1,3])
-         this%bsca = reshape(bsca_table, [nrh_table, nch, nbin_table],order =[2,1,3])
-         this%bbck = reshape(bbck_table, [nrh_table, nch, nbin_table],order =[2,1,3])
-         this%g    = reshape(   g_table, [nrh_table, nch, nbin_table],order =[2,1,3])
-         this%refr = reshape(refr_table, [nrh_table, nch, nbin_table],order =[2,1,3])
-         this%refi = reshape(refi_table, [nrh_table, nch, nbin_table],order =[2,1,3])
-         pback     = reshape(pback_table,[nrh_table, nch, nbin_table, npol_table],order =[2,1,3,4])
+         this%bext = bext_table
+         this%bsca = bsca_table
+         this%bbck = bbck_table
+         this%g    = g_table
+         this%refr = refr_table
+         this%refi = refi_table
+         pback     = pback_table
          if ( nmom_ > 0 ) then
-           this%pmom = reshape(pmom_table,[nrh_table,nch, nbin_table, nmom_, npol_table], order = [2,1,3,4,5])
+           this%pmom = pmom_table
          endif
       endif
 
 !     Pick p11, p12
-      this%p11 = pback(:,:,:,1)
-      this%p22 = pback(:,:,:,5)
+      this%p11 = pback(1,:,:,:)
+      this%p22 = pback(5,:,:,:)
 
 !     Now we do a mapping of the RH from the input table to some high
 !     resolution representation.  This is to spare us the need to

--- a/Process_Library/MieQuery.H
+++ b/Process_Library/MieQuery.H
@@ -13,7 +13,7 @@
 
 #define __RHINTERP2__(table,rh,ah,bin,sh) reshape((table(rh,bin) * (1-ah) + table(rh+1,bin)*ah), shape(sh))
 #define __RHINTERP3__(table,rh,ah,ch,bin,sh) reshape((table(rh,ch,bin) * (1-ah) + table(rh+1,ch,bin)*ah), shape(sh))
-#define __RHINTERP5__(table,rh,ah,ch,bin,k,l,sh) reshape((table(rh,ch,bin,k,l) * (1-ah) + table(rh+1,ch,bin,k,l)*ah), shape(sh))
+#define __RHINTERP5__(table,rh,ah,m,p,ch,bin,sh) reshape((table(m,p,rh,ch,bin) * (1-ah) + table(m,p,rh+1,ch,bin)*ah), shape(sh))
 
 #define SUBCHANNEL_ IDENTITY_(QueryByChannel)IDENTITY_(SUFFIX_)
 #define SUBWAVELENGTH_ IDENTITY_(QueryByWavelength)IDENTITY_(SUFFIX_)
@@ -48,8 +48,8 @@
      real,    optional,      intent(out) :: bext   (__DIMS__)      ! mass extinction efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bsca   (__DIMS__)      ! mass scattering efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bbck   (__DIMS__)      ! mass backscatter efficiency [m2 (kg dry mass)-1]
-     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (m)
-     real,    optional,      intent(out) :: pmom   (__DIMS__,:,:)  ! moments of phase function 
+     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (micron)
+     real,    optional,      intent(out) :: pmom   (:,:,__DIMS__)  ! moments of phase function 
      real,    optional,      intent(out) :: p11    (__DIMS__)      ! P11 phase function at backscatter
      real,    optional,      intent(out) :: p22    (__DIMS__)      ! P22 phase function at backscatter
      real,    optional,      intent(out) :: gf     (__DIMS__)      ! Growth factor (ratio of wet to dry radius)
@@ -83,7 +83,7 @@
      integer, allocatable, dimension(:)       :: irh, qrh
      real, allocatable, dimension(:)          :: rh_, arh
      real, allocatable, dimension(__DIMS__)   :: bext_, bsca_
-     integer :: i, j
+     integer :: m, p
 
      character(len=*), parameter  :: Iam = 'Query'
 
@@ -159,9 +159,9 @@
      endif
 
      if (present(pmom)) then
-       do j = 1, size(this%pmom,5)
-          do i = 1, size(this%pmom,4)
-             pmom(__DIMS__,i,j)  =  __RHINTERP5__(this%pmom, irh, arh, channel, bin, i, j, rh)
+       do p = 1, size(this%pmom,2)
+          do m = 1, size(this%pmom,1)
+             pmom( m, p, __DIMS__ )  =  __RHINTERP5__(this%pmom, irh, arh, m, p, channel, bin, rh)
           enddo
        enddo
      endif
@@ -204,8 +204,8 @@
      real,    optional,      intent(out) :: bext   (__DIMS__)      ! mass extinction efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bsca   (__DIMS__)      ! mass scattering efficiency [m2 (kg dry mass)-1]
      real,    optional,      intent(out) :: bbck   (__DIMS__)      ! mass backscatter efficiency [m2 (kg dry mass)-1]
-     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (m)
-     real,    optional,      intent(out) :: pmom   (__DIMS__,:,:)  ! moments of phase function
+     real,    optional,      intent(out) :: reff   (__DIMS__)      ! effective radius (micron)
+     real,    optional,      intent(out) :: pmom   (:,:,__DIMS__)  ! moments of phase function
      real,    optional,      intent(out) :: p11    (__DIMS__)      ! P11 phase function at backscatter
      real,    optional,      intent(out) :: p22    (__DIMS__)      ! P22 phase function at backscatter
      real,    optional,      intent(out) :: gf     (__DIMS__)      ! Growth factor (ratio of wet to dry radius)


### PR DESCRIPTION
This change promotes the dimension reordering and renaming introduced by Weiyuan for the new GEOSmie generated aerosol optical property LUTs (effectively deprecates https://github.com/GEOS-ESM/GOCART/pull/302). Tested with refactored version of v0.0.0 optical tables produces a zero-diff result. This version changes the aerosol LUTs in the instance.rc files to point to GEOSmie produced v2.x.x optical tables.