### PR TITLE
Deactivate non-ported components on release/MAPL-v3

### DIFF
--- a/ESMF/CMakeLists.txt
+++ b/ESMF/CMakeLists.txt
@@ -12,10 +12,9 @@ if (UFS_GOCART)
 else ()
   esma_add_subdirectories(
     Shared
-    Apps
+    # Apps              # not yet ported to MAPL3 - restore when ported
     Aerosol_GridComp
-    GOCART_GridComp
+    # GOCART_GridComp   # not yet ported to MAPL3 - restore when ported
     GOCART2G_GridComp
-    HEMCO_GridComp
   )
 endif ()


### PR DESCRIPTION
## Summary

- Comments out `Apps` and `GOCART_GridComp` (not yet ported to MAPL3)
- Keeps `Shared` (Chem_Shared2G), `Aerosol_GridComp`, and `GOCART2G_GridComp` active

## Context

Part of the MAPL3 flip work tracked in GEOS-ESM/GOCART#401. Only components already ported to MAPL3 are compiled on `release/MAPL-v3`.