### PR TITLE
Replace 'use MAPL' with 'use MAPL2' and update CMake deps for MAPL→MAPL2→MAPL3 rename

### DIFF
--- a/ESMF/CMakeLists.txt
+++ b/ESMF/CMakeLists.txt
@@ -2,19 +2,16 @@ set (HEMCO_EXTERNAL_CONFIG TRUE)
 set (MAPL_ESMF TRUE)
 set (BUILD_GEOS_INTERFACE TRUE)
 
+esma_add_subdirectories(
+  Shared
+  # Apps              # not yet ported to MAPL3 - restore when ported
+  # Aerosol_GridComp  # not yet ported to MAPL3 - restore when ported
+  # GOCART_GridComp   # not yet ported to MAPL3 - restore when ported
+  GOCART2G_GridComp
+)
+
 if (UFS_GOCART)
   esma_add_subdirectories(
-    Aerosol_GridComp
-    GOCART2G_GridComp
-    Shared
-    UFS
-  )
-else ()
-  esma_add_subdirectories(
-    Shared
-    # Apps              # not yet ported to MAPL3 - restore when ported
-    Aerosol_GridComp
-    # GOCART_GridComp   # not yet ported to MAPL3 - restore when ported
-    GOCART2G_GridComp
+    # UFS             # not yet ported to MAPL3 - restore when ported
   )
 endif ()

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL MAPL.generic3g MAPL.utilities Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
+  DEPENDENCIES GA_Environment MAPL2 MAPL.generic3g MAPL.utilities Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 mapl_acg (

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -11,7 +11,7 @@ module DU2G_GridCompMod
    use pflogger, only: logger_t => logger
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    ! use MAPL
-   use MAPL, only: MAPL_get_num_threads, MAPL_get_current_thread
+   use MAPL2, only: MAPL_get_num_threads, MAPL_get_current_thread
    use MAPL_BaseMod, only: MAPL2_GridGet => MAPL_GridGet
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource, MAPL_GridCompGetInternalState

--- a/ESMF/Shared/CMakeLists.txt
+++ b/ESMF/Shared/CMakeLists.txt
@@ -7,7 +7,7 @@ set (srcs
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL MAPL.field_bundle ESMF::ESMF
+  DEPENDENCIES MAPL2 MAPL.field_bundle ESMF::ESMF
 )
 
 if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/@GSW )

--- a/ESMF/Shared/ReplenishAlarm.F90
+++ b/ESMF/Shared/ReplenishAlarm.F90
@@ -2,7 +2,7 @@
 
 module ReplenishAlarm
    use ESMF
-   use MAPL
+   use MAPL2
 
    implicit none
    private


### PR DESCRIPTION
## Summary

- Replaces `use MAPL` with `use MAPL2` in `DU2G_GridCompMod.F90` and `ReplenishAlarm.F90`
- Adds `MAPL2` to CMake `DEPENDENCIES` in `ESMF/CMakeLists.txt`, `DU2G_GridComp/CMakeLists.txt`, and `Shared/CMakeLists.txt`

These changes support the transitional MAPL→MAPL2→MAPL3 rename being coordinated across GEOS-ESM repos.

## References

- Closes #403
- Part of the broader `release/MAPL-v3` / MAPL #4600 rename effort