### PR TITLE
prc: update AMIP volcanic sulfer emissions to v202601 of Carn inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- Updated version of volcanic sulfur emissions for AMIP configuration to v202601
 
 ### Fixed
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_instance_SU.rc
@@ -8,8 +8,8 @@ aerosol_monochromatic_optics_file: ExtData/chemistry/AerosolOptics/v0.0.0/x/opti
 nbins: 4
 
 # Volcanic pointwise sources
-volcano_srcfilen_explosive: ExtData/chemistry/CARN/v202401/explosive/so2_explosive_volcanic_emissions_CARN_v202401.%y4%m2%d2.rc
-volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
+volcano_srcfilen_explosive: ExtData/chemistry/CARN/v202601/explosive/so2_explosive_volcanic_emissions_Carn.%y4%m2%d2.rc
+volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202601/degassing/so2_degassing_volcanic_emissions_Carn.%y4%m2%d2.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -9,7 +9,7 @@ nbins: 4
 
 # Volcanic pointwise sources
 volcano_srcfilen_explosive: /dev/null
-volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202401/sfc/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
+volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202601/so2_degassing_volcanic_emissions_Carn.2025value.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_instance_SU.rc
@@ -9,7 +9,7 @@ nbins: 4
 
 # Volcanic pointwise sources
 volcano_srcfilen_explosive: /dev/null
-volcano_srcfilen_degassing: ExtData/chemistry/CARN/v202601/so2_degassing_volcanic_emissions_Carn.2025value.rc
+volcano_srcfilen_degassing: ExtData/chemistry/CARN/so2_degassing_volcanic_emissions_Carn.latest.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3


### PR DESCRIPTION
Updates volcanic sulfur emissions to v202601 of Carn database in SU/AMIP configuration only