### PR TITLE
Port DU2G off MAPL2 OpenMP symbols to use MAPL (mapl3g) directly

### DIFF
--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -11,7 +11,7 @@ module DU2G_GridCompMod
    use pflogger, only: logger_t => logger
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    ! use MAPL
-   use MAPL2, only: MAPL_get_num_threads, MAPL_get_current_thread
+   use mapl3g_OpenMP_Support, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread
    use MAPL_BaseMod, only: MAPL2_GridGet => MAPL_GridGet
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource, MAPL_GridCompGetInternalState

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -11,7 +11,7 @@ module DU2G_GridCompMod
    use pflogger, only: logger_t => logger
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    ! use MAPL
-   use mapl3g_OpenMP_Support, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread
+   use MAPL, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread
    use MAPL_BaseMod, only: MAPL2_GridGet => MAPL_GridGet
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource, MAPL_GridCompGetInternalState


### PR DESCRIPTION
## Summary

- Closes #410
- `DU2G_GridCompMod.F90`: replace `use MAPL2` OpenMP symbols with `use MAPL, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread` to get OpenMP support directly from mapl3g instead of via MAPL2 re-exports
- CMake: add `MAPL` link dependency to `DU2G` target