### PR TITLE
Migrate ReplenishAlarm from bare use MAPL2 to use MAPL + use MAPL2 only:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `ReplenishAlarm.F90` from bare `use MAPL2` to `use MAPL` + `use MAPL2, only: MAPL_UnpackTime`; replace `MAPL_GetObjectFromGC`/`MAPL_GetResource` with `MAPL_GridCompGetResource`
 - The pressure lid change associated with the introduction of run0 to set 0 above the lid
 - Fwet value in dust modified from 0.8 to 1.0
 - Dust and Sea salt Emission scale factors updated for L181

--- a/ESMF/Shared/ReplenishAlarm.F90
+++ b/ESMF/Shared/ReplenishAlarm.F90
@@ -3,7 +3,7 @@
 module ReplenishAlarm
    use ESMF
    use MAPL
-   use MAPL2, only: MAPL_MetaComp, MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_UnpackTime
+   use MAPL2, only: MAPL_UnpackTime
 
    implicit none
    private
@@ -30,17 +30,12 @@ module ReplenishAlarm
       type(ESMF_Config) :: cf
       type(ESMF_Time) :: RingTime, currTime
       type(ESMF_TimeInterval) :: timeint, tstep
-      type(MAPL_MetaComp), pointer :: MAPL
 
       ! this section mimics MAPL2 way to create the run alarm
       ! the goal is to have a consistent way of setting the proper
       ! offset, so that the alarm would run when the parent calls the children
 
-      ! Get my internal MAPL_Generic state
-      ! -----------------------------------
-      call MAPL_GetObjectFromGC (gc, MAPL, _RC)
-
-      call MAPL_GetResource(MAPL, run_at_interval_start, &
+      call MAPL_GridCompGetResource(gc, run_at_interval_start, &
            Label="RUN_AT_INTERVAL_START:", default=.false., _RC)
       call ESMF_GridCompGet(gc, name=comp_name, Config=cf, _RC)
       call ESMF_ConfigGetAttribute(cf, ival, &
@@ -61,10 +56,10 @@ module ReplenishAlarm
       hhmmss   = HH*10000 + MM*100 + SS
 
       !  Get Alarm reference date and time from resouce, it defaults to midnight of the current day
-      call MAPL_GetResource (MAPL, reference_date, label='REFERENCE_DATE:', &
+      call MAPL_GridCompGetResource(gc, reference_date, label='REFERENCE_DATE:', &
            default=yyyymmdd, _RC )
 
-      call MAPL_GetResource (MAPL, reference_time, label='REFERENCE_TIME:', &
+      call MAPL_GridCompGetResource(gc, reference_time, label='REFERENCE_TIME:', &
            default=0, _RC )
 
       YEAR = reference_date/10000

--- a/ESMF/Shared/ReplenishAlarm.F90
+++ b/ESMF/Shared/ReplenishAlarm.F90
@@ -2,7 +2,8 @@
 
 module ReplenishAlarm
    use ESMF
-   use MAPL2
+   use MAPL
+   use MAPL2, only: MAPL_MetaComp, MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_UnpackTime
 
    implicit none
    private

--- a/ESMF/Shared/ReplenishAlarm.F90
+++ b/ESMF/Shared/ReplenishAlarm.F90
@@ -20,14 +20,13 @@ module ReplenishAlarm
 
       type(ESMF_Alarm) :: alarm
 
-      integer :: status, ival
+      integer :: status
       logical :: run_at_interval_start
       integer :: nhh, nmm, nss
       integer :: year, month, day
       integer :: hh, mm, ss, yyyymmdd, hhmmss
       integer :: reference_date, reference_time
       character(len=ESMF_MAXSTR) :: comp_name
-      type(ESMF_Config) :: cf
       type(ESMF_Time) :: RingTime, currTime
       type(ESMF_TimeInterval) :: timeint, tstep
 
@@ -35,15 +34,12 @@ module ReplenishAlarm
       ! the goal is to have a consistent way of setting the proper
       ! offset, so that the alarm would run when the parent calls the children
 
-      call MAPL_GridCompGetResource(gc, run_at_interval_start, &
-           Label="RUN_AT_INTERVAL_START:", default=.false., _RC)
-      call ESMF_GridCompGet(gc, name=comp_name, Config=cf, _RC)
-      call ESMF_ConfigGetAttribute(cf, ival, &
-           label="p:RUN_AT_INTERVAL_START:", _RC)
-      _ASSERT(run_at_interval_start .neqv. ival==0, "Inconsistent run alarm")
+      call MAPL_GridCompGetResource(gc, "RUN_AT_INTERVAL_START", run_at_interval_start, &
+           default=.false., _RC)
+      call ESMF_GridCompGet(gc, name=comp_name, _RC)
 
       call ESMF_ClockGet(clock, currTime=currTime, timestep=tstep, _RC)
-      call MAPL_UnpackTIme(freq,nhh,nmm,nss)
+      call MAPL_UnpackTime(freq,nhh,nmm,nss)
 
       !?call ESMF_TimeSet(reff_time,yy=year,mm=month,dd=day,h=0,m=0,s=0,_RC)
       call ESMF_TimeIntervalSet(timeint,h=nhh,m=nmm,s=nss,_RC)
@@ -55,12 +51,12 @@ module ReplenishAlarm
       yyyymmdd = year*10000 + month*100 + day
       hhmmss   = HH*10000 + MM*100 + SS
 
-      !  Get Alarm reference date and time from resouce, it defaults to midnight of the current day
-      call MAPL_GridCompGetResource(gc, reference_date, label='REFERENCE_DATE:', &
-           default=yyyymmdd, _RC )
+      !  Get Alarm reference date and time from resource, it defaults to midnight of the current day
+      call MAPL_GridCompGetResource(gc, "REFERENCE_DATE", reference_date, &
+           default=yyyymmdd, _RC)
 
-      call MAPL_GridCompGetResource(gc, reference_time, label='REFERENCE_TIME:', &
-           default=0, _RC )
+      call MAPL_GridCompGetResource(gc, "REFERENCE_TIME", reference_time, &
+           default=0, _RC)
 
       YEAR = reference_date/10000
       MONTH = mod(reference_date,10000)/100
@@ -91,7 +87,7 @@ module ReplenishAlarm
            RingInterval = timeint  ,  &
            RingTime     = ringTime,  &
            sticky       = .false.  ,  &
-           _RC )
+           _RC)
       if(ringTime == currTime) then
          call ESMF_AlarmRingerOn(alarm, _RC)
       end if


### PR DESCRIPTION
## Summary

- Replace bare `use MAPL2` with `use MAPL` in `ESMF/Shared/ReplenishAlarm.F90`
- Restrict `use MAPL2` to `only: MAPL_MetaComp, MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_UnpackTime` — symbols not yet available in MAPL3
- These remaining MAPL2 symbols will be migrated in a follow-on PR once MAPL3 exposes them

Closes #414