### PR TITLE
Feature/pcolarco/fix volcanic emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - There was a bug where the degassing lat/lon were used to assign emission points for
-  explosive volcanic emissions; this has been corrected.
+  explosive volcanic SO2 emissions; this has been corrected.
+- There was a bug where the scaling of explosive volcanic SO2 emissions was mistakenely
+  being applied to the degassing (effectively further doubling the degassing and not
+  correctly scaling the explosive; this has been corrected.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- There was a bug where the degassing lat/lon were used to assign emission points for
+  explosive volcanic emissions; this has been corrected.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
+### Added
+
+## [v2.6.3] - 2026-05-11
+
+### Fixed
+
 - There was a bug where the degassing lat/lon were used to assign emission points for
   explosive volcanic SO2 emissions; this has been corrected.
 - There was a bug where the scaling of explosive volcanic SO2 emissions was mistakenely
   being applied to the degassing (effectively further doubling the degassing and not
   correctly scaling the explosive; this has been corrected.
-
-### Added
 
 ## [v2.6.2] - 2026-03-09
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.6.2
+          VERSION 2.6.3
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -993,7 +993,7 @@ contains
              call ReadPointEmissions (nymd, fname, workspace%nVolcE, workspace%vLatE, workspace%vLonE, &
                                    workspace%vElevE, workspace%vCloudE, workspace%vSO2E, workspace%vStartE, &
                                    workspace%vEndE, label='volcano', __RC__)
-             workspace%vSO2 = workspace%vSO2 * fMassSO2 / fMassSulfur
+             workspace%vSO2E = workspace%vSO2E * fMassSO2 / fMassSulfur
           end if
        end if
 

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -1027,8 +1027,8 @@ contains
        allocate(iPoint(workspace%nVolcE), jPoint(workspace%nVolcE),  __STAT__)
        call MAPL_GetHorzIJIndex(workspace%nVolcE, iPoint, jPoint, &
                                 grid = grid,               &
-                                lon  = workspace%vLon/real(MAPL_RADIANS_TO_DEGREES), &
-                                lat  = workspace%vLat/real(MAPL_RADIANS_TO_DEGREES), &
+                                lon  = workspace%vLonE/real(MAPL_RADIANS_TO_DEGREES), &
+                                lat  = workspace%vLatE/real(MAPL_RADIANS_TO_DEGREES), &
                                 rc   = status)
            if ( status /= 0 ) then
               if (mapl_am_i_root()) print*, trim(Iam), ' - cannot get indices for point emissions'


### PR DESCRIPTION
This is a bug fix:

-    There was a bug where the degassing lat/lon were used to assign emission points for explosive volcanic SO2 emissions; this has been corrected.
-    There was a bug where the scaling of explosive volcanic SO2 emissions was mistakenely being applied to the degassing (effectively further doubling the degassing and not correctly scaling the explosive; this has been corrected.
