### PR TITLE
Migrate packed-time calls away from legacy MAPL umbrella

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `DU2G_GridCompMod.F90`, `SU2G_GridCompMod.F90`, `CA2G_GridCompMod.F90` from `MAPL_PackTime` to `MAPL_PackedDateCreate`/`MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`
+- Migrate `ReplenishAlarm.F90`: remove `MAPL_UnpackTime`; inline HHMMSS arithmetic directly into `ESMF_TimeIntervalSet`
 - Migrate `ReplenishAlarm.F90` from bare `use MAPL2` to `use MAPL` + `use MAPL2, only: MAPL_UnpackTime`; replace `MAPL_GetObjectFromGC`/`MAPL_GetResource` with `MAPL_GridCompGetResource`
 - The pressure lid change associated with the introduction of run0 to set 0 above the lid
 - Fwet value in dust modified from 0.8 to 1.0

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -18,6 +18,8 @@ module CA2G_GridCompMod
    use GOCART2G_Process       ! GOCART2G process library
    use GA_EnvironmentMod
    use MAPL_StringTemplate, only: StrTemplate
+   use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
+                                  MAPL_PackedTimeCreate => PackedTimeCreate
    !$ use omp_lib
 
    implicit none
@@ -816,8 +818,8 @@ contains
 !   ---------------------------------
     call ESMF_ClockGet (clock, currTime=time, __RC__)
     call ESMF_TimeGet (time ,YY=iyr, MM=imm, DD=idd, H=ihr, M=imn, S=isc, __RC__)
-    call MAPL_PackTime (nymd, iyr, imm , idd)
-    call MAPL_PackTime (nhms, ihr, imn, isc)
+    nymd = MAPL_PackedDateCreate(iyr, imm, idd)
+    nhms = MAPL_PackedTimeCreate(ihr, imn, isc)
 
 !   Reset tracer to zero at 0Z on specific day of week
 !   --------------------------------------------------

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -24,7 +24,8 @@ module DU2G_GridCompMod
    use mapl3g_RestartModes, only: MAPL_RESTART_SKIP
    use mapl3g_UngriddedDim, only: UngriddedDim
    use mapl3g_State_API, only: MAPL_StateGetPointer
-   use mapl3g_Utilities, only: MAPL_PackTime
+   use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
+                                  MAPL_PackedTimeCreate => PackedTimeCreate
    use mapl3g_Geom_API, only: MAPL_GeomGetHorzIJIndex
    use GOCART2G_MieMod
    use Chem_AeroGeneric
@@ -625,8 +626,8 @@ contains
       ! Extract nymd(yyyymmdd) from clock
       call ESMF_ClockGet(clock, currTime=time, _RC)
       call ESMF_TimeGet(time ,YY=iyr, MM=imm, DD=idd, H=ihr, M=imn, S=isc, _RC)
-      call MAPL_PackTime(nymd, iyr, imm , idd)
-      call MAPL_PackTime(nhms, ihr, imn, isc)
+      nymd = MAPL_PackedDateCreate(iyr, imm, idd)
+      nhms = MAPL_PackedTimeCreate(ihr, imn, isc)
 
       associate (scheme => self%emission_scheme)
 #include "DU2G_GetPointer___.h"

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -19,6 +19,8 @@ module SU2G_GridCompMod
    use GOCART2G_Process       ! GOCART2G process library
    use GA_EnvironmentMod
    use MAPL_StringTemplate, only: StrTemplate
+   use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
+                                  MAPL_PackedTimeCreate => PackedTimeCreate
    !$ use omp_lib
 
    implicit none
@@ -847,8 +849,8 @@ contains
 !   ---------------------------------
     call ESMF_ClockGet (clock, currTime=time, __RC__)
     call ESMF_TimeGet (time ,YY=iyr, MM=imm, DD=idd, H=ihr, M=imn, S=isc, __RC__)
-    call MAPL_PackTime (nymd, iyr, imm , idd)
-    call MAPL_PackTime (nhms, ihr, imn, isc)
+    nymd = MAPL_PackedDateCreate(iyr, imm, idd)
+    nhms = MAPL_PackedTimeCreate(ihr, imn, isc)
 
 !   Reset tracer to zero at 0Z on specific day of week
 !   --------------------------------------------------
@@ -1134,8 +1136,8 @@ contains
 !   ---------------------------------
     call ESMF_ClockGet (clock, currTime=time, __RC__)
     call ESMF_TimeGet (time ,YY=iyr, MM=imm, DD=idd, H=ihr, M=imn, S=isc, __RC__)
-    call MAPL_PackTime (nymd, iyr, imm , idd)
-    call MAPL_PackTime (nhms, ihr, imn, isc)
+    nymd = MAPL_PackedDateCreate(iyr, imm, idd)
+    nhms = MAPL_PackedTimeCreate(ihr, imn, isc)
 
 !   Get my private internal state
 !   ------------------------------

--- a/ESMF/Shared/ReplenishAlarm.F90
+++ b/ESMF/Shared/ReplenishAlarm.F90
@@ -3,7 +3,7 @@
 module ReplenishAlarm
    use ESMF
    use MAPL
-   use MAPL2, only: MAPL_UnpackTime
+
 
    implicit none
    private
@@ -22,7 +22,6 @@ module ReplenishAlarm
 
       integer :: status
       logical :: run_at_interval_start
-      integer :: nhh, nmm, nss
       integer :: year, month, day
       integer :: hh, mm, ss, yyyymmdd, hhmmss
       integer :: reference_date, reference_time
@@ -39,10 +38,7 @@ module ReplenishAlarm
       call ESMF_GridCompGet(gc, name=comp_name, _RC)
 
       call ESMF_ClockGet(clock, currTime=currTime, timestep=tstep, _RC)
-      call MAPL_UnpackTime(freq,nhh,nmm,nss)
-
-      !?call ESMF_TimeSet(reff_time,yy=year,mm=month,dd=day,h=0,m=0,s=0,_RC)
-      call ESMF_TimeIntervalSet(timeint,h=nhh,m=nmm,s=nss,_RC)
+      call ESMF_TimeIntervalSet(timeint, h=freq/10000, m=mod(freq,10000)/100, s=mod(freq,100), _RC)
 
       ! get current time from clock and create a referenace time with optonal override
       call ESMF_TimeGet(currTime, YY=YEAR, MM=MONTH, DD=DAY, &


### PR DESCRIPTION
## Summary
- `DU2G_GridCompMod.F90`, `SU2G_GridCompMod.F90`, `CA2G_GridCompMod.F90`: replace `MAPL_PackTime` calls with `MAPL_PackedDateCreate`/`MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`
- `ReplenishAlarm.F90`: remove `MAPL_UnpackTime`; inline HHMMSS arithmetic directly into `ESMF_TimeIntervalSet`

Part of GEOS-ESM/MAPL#4811 — enables deletion of legacy packed-time symbols from `Base_Base`.

Closes #417