### PR TITLE
Migrate MAPL_AllocateCoupling callers to MAPL_FieldEmptyComplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `GOCART_GridCompMod.F90` and `Aerosol_GridComp.F90` from `MAPL_AllocateCoupling` to `MAPL_FieldEmptyComplete` (MAPL3 replacement)
 - Migrate `DU2G_GridCompMod.F90`, `SU2G_GridCompMod.F90`, `CA2G_GridCompMod.F90` from `MAPL_PackTime` to `MAPL_PackedDateCreate`/`MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`
 - Migrate `ReplenishAlarm.F90`: remove `MAPL_UnpackTime`; inline HHMMSS arithmetic directly into `ESMF_TimeIntervalSet`
 - Migrate `ReplenishAlarm.F90` from bare `use MAPL2` to `use MAPL` + `use MAPL2, only: MAPL_UnpackTime`; replace `MAPL_GetObjectFromGC`/`MAPL_GetResource` with `MAPL_GridCompGetResource`

--- a/ESMF/Aerosol_GridComp/Aerosol_GridComp.F90
+++ b/ESMF/Aerosol_GridComp/Aerosol_GridComp.F90
@@ -195,7 +195,7 @@ contains
                  call ESMF_StateGet(state, trim(itemNameList(i)), field, __RC__)
                  call ESMF_FieldGet(field, status=fieldStatus, __RC__)
                  if (fieldStatus == ESMF_FIELDSTATUS_GRIDSET) then
-                    call MAPL_AllocateCoupling(field, __RC__)
+                    call MAPL_FieldEmptyComplete(field, __RC__)
                  end if
               end if
            end do

--- a/ESMF/GOCART_GridComp/GOCART_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/GOCART_GridCompMod.F90
@@ -1036,7 +1036,7 @@ CONTAINS
          type(ESMF_Field) :: FIELD
                    __Iam__('AddFromExportToBundle_')
          call ESMF_StateGet( STATE, NAME, FIELD, __RC__ )
-         call MAPL_AllocateCoupling( FIELD, __RC__ )
+         call MAPL_FieldEmptyComplete( FIELD, __RC__ )
          call MAPL_FieldBundleAdd ( BUNDLE, FIELD, __RC__ )
          RETURN_(ESMF_SUCCESS)
        end subroutine AddFromExportToBundle_


### PR DESCRIPTION
## Summary

- Replaces `call MAPL_AllocateCoupling(...)` with `call MAPL_FieldEmptyComplete(...)` in two files:
  - `ESMF/GOCART_GridComp/GOCART_GridCompMod.F90` (inside `AddFromExportToBundle_`)
  - `ESMF/Aerosol_GridComp/Aerosol_GridComp.F90` (inside `ForceAllocation`)

## Context

`MAPL_AllocateCoupling` is a legacy MAPL2 Base symbol being removed as part of the MAPL3 migration (GEOS-ESM/MAPL#4820). `MAPL_FieldEmptyComplete` is the MAPL3 replacement with identical behavior — it reads all field metadata from `ESMF_Info` and allocates accordingly. It is now available transitively via `use MAPL` following GEOS-ESM/MAPL#4823.

Closes #420.
