### PR TITLE
v2.5: Update ExtData.yaml files to use science quality QFED3 emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ExtData yaml files for CA, NI, SU, and CO to use QFED3 files beginning 1/15/2026 for OPS emissions and 3/1/2023 for AMIP emissions
-
 ### Fixed
 
 ### Added
+
+## [v2.5.3] - 2026-05-12
+
+### Changed
+
+- ExtData yaml files for CA, NI, SU, and CO to use QFED3 files beginning 1/15/2026 for OPS emissions and 3/1/2023 for AMIP emissions
+- Updated `GOCART2G_GridComp.rc` to output AOD profile at 470 nm and 870 nm
+  for JEDI (in addition to the existing 550 nm vertically integrated AOD),
+  without changing behavior for the PSAS AOD analysis
 
 ## [v2.5.2] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ExtData yaml files for CA, NI, SU, and CO to use QFED3 files beginning 1/15/2026 for OPS emissions and 3/1/2023 for AMIP emissions
+
 ### Fixed
 
 ### Added
@@ -202,6 +204,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `soil_moisture_factor` to the DU2G_instance_DU.rc (same name used in the K14 scheme) and DU2G_GridCompMod.F90 files for FENGSHA
 - Add `soil_drylimit_factor` to the DU2G_instance_DU.rc and DU2G_GridCompMod.F90 files for FENGSHA
 - Moved process library macros to header file.
+
+## [v2.3.1] - 2026-03-10
+
+### Changed
+
+- ExtData yaml files for CA, NI, SU, and CO to use QFED3 files beginning 1/15/2026 for OPS emissions and 3/1/2023 for AMIP emissions
 
 ## [v2.3.0] - 2025-01-16
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.5.2
+          VERSION 2.5.3
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/AMIP/CA2G_GridComp_ExtData.yaml
@@ -38,6 +38,12 @@ Collections:
   CA2G_hfed.emis_oc.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_oc.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-12-16T12:00"
+  CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
+  CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   CA2G_sample_0:
@@ -91,6 +97,7 @@ Exports:
   BC_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CA2G_hfed.emis_bc.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BC_SHIP:
     - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_shipping}
     - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_shipping}
@@ -132,6 +139,7 @@ Exports:
   BRC_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CA2G_hfed.emis_oc.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BRC_SHIP:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridComp_ExtData.yaml
@@ -35,10 +35,16 @@ Collections:
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
   CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_bc.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
   CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_oc.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
+  CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-01-15T12:00/2028-01-01"
+  CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-01-15T12:00/2028-01-01"
 
 Samplings:
   CA2G_sample_0:
@@ -92,6 +98,7 @@ Exports:
   BC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_bc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: CA2G_qfed_emis_x3600y1800_bc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BC_SHIP:
     - {starting: "1979-01-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: CA2G_sample_1, regrid: CONSERVE, variable: bc_shipping}
     - {starting: "2019-12-15T12:00", collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: CA2G_sample_3, variable: bc_shipping}
@@ -133,6 +140,7 @@ Exports:
   BRC_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_oc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: CA2G_qfed_emis_x3600y1800_oc.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
   BRC_SHIP:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridComp.rc
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridComp.rc
@@ -19,26 +19,26 @@
 
 # Include the constituent in the simulation?
 # ----------------------------------------------------
-ACTIVE_INSTANCES_DU:  DU #DU.test   
-PASSIVE_INSTANCES_DU:  
+ACTIVE_INSTANCES_DU:  DU #DU.test
+PASSIVE_INSTANCES_DU:
 
 ACTIVE_INSTANCES_SS:   SS #  SS.data
 PASSIVE_INSTANCES_SS:
 
-ACTIVE_INSTANCES_SU:  SU   #SU.data 
+ACTIVE_INSTANCES_SU:  SU   #SU.data
 PASSIVE_INSTANCES_SU:
 
-ACTIVE_INSTANCES_CA:   CA.oc  CA.bc  CA.br  #CA.oc.data CA.bc.datac 
+ACTIVE_INSTANCES_CA:   CA.oc  CA.bc  CA.br  #CA.oc.data CA.bc.datac
 PASSIVE_INSTANCES_CA:
 
-ACTIVE_INSTANCES_NI:  NI  #NI.data 
+ACTIVE_INSTANCES_NI:  NI  #NI.data
 PASSIVE_INSTANCES_NI:
 
 # Set optics parameters
 # ---------------------
 aerosol_monochromatic_optics_wavelength_in_nm_from_LUT: 470 550 670 870
 
-wavelengths_for_profile_aop_in_nm: 550               # must be included in LUT
+wavelengths_for_profile_aop_in_nm: 470 870           # must be included in LUT
 wavelengths_for_vertically_integrated_aop_in_nm: 550 # must be included in LUT
 
 aerosol_photolysis_wavelength_in_nm_from_LUT: 200 300 400 500 600

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/AMIP/NI2G_GridComp_ExtData.yaml
@@ -10,10 +10,13 @@ Collections:
     valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.6r1/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
-    valid_range: "2000-02-29T12:00/2025-01-01"
+    valid_range: "2000-02-29T12:00/2026-02-01"
   NI2G_hfed.emis_nh3.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_nh3.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-12-16T12:00"
+  NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   NI2G_sample_0:
@@ -44,6 +47,7 @@ Exports:
   EMI_NH3_BB:
     - {starting: "1960-01-16T12:00", collection: NI2G_hfed.emis_nh3.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
   EMI_NH3_EN:
     - {starting: "1979-01-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, sample: NI2G_sample_1, regrid: CONSERVE, variable: nh3}
     - {starting: "2019-12-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: NI2G_sample_4, variable: nh3}

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridComp_ExtData.yaml
@@ -15,7 +15,10 @@ Collections:
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
   NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
+  NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-01-15T12:00/2028-01-01"
 
 Samplings:
   NI2G_sample_0:
@@ -46,6 +49,7 @@ Exports:
   EMI_NH3_BB:
     - {starting: "2014-12-01T12:00", collection: NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: NI2G_qfed_emis_x3600y1800_nh3.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
   EMI_NH3_EN:
     - {starting: "1979-01-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, sample: NI2G_sample_1, regrid: CONSERVE, variable: nh3}
     - {starting: "2019-12-15T12:00", collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: NI2G_sample_4, variable: nh3}

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/AMIP/SU2G_GridComp_ExtData.yaml
@@ -27,6 +27,9 @@ Collections:
   SU2G_hfed.emis_so2.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_so2.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-012-16T12:00"
+  SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   SU2G_sample_0:
@@ -75,6 +78,7 @@ Exports:
   SU_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: SU2G_hfed.emis_so2.x576_y361.%y4%m2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
   SU_DMSO:
     collection: SU2G_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridComp_ExtData.yaml
@@ -27,7 +27,10 @@ Collections:
     valid_range: "2014-12-01T12:00/2021-11-01T12:00"
   SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.061.%y4%m2%d2.nc4
-    valid_range: "2021-11-01T12:00/2025-01-01"
+    valid_range: "2021-11-01T12:00/2026-02-01"
+  SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-01-15T12:00/2028-01-01"
 
 Samplings:
   SU2G_sample_0:
@@ -76,6 +79,7 @@ Exports:
   SU_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: SU2G_qfed2.emis_so2.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: SU2G_qfed_emis_x3600y1800_so2.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
   SU_DMSO:
     collection: SU2G_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
     regrid: CONSERVE

--- a/ESMF/GOCART_GridComp/CO_GridComp/AMIP/CO_GridComp_ExtData.yaml
+++ b/ESMF/GOCART_GridComp/CO_GridComp/AMIP/CO_GridComp_ExtData.yaml
@@ -15,6 +15,9 @@ Collections:
   CO_hfed.emis_co.x576_y361.%y4%m2.nc4:
     template: ExtData/chemistry/HFED/v1.0/Y%y4/M%m2/hfed.emis_co.x576_y361.%y4%m2.nc4
     valid_range: "1960-01-16T12:00/2000-12-16T12:00"
+  CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2023-03-01T12:00/2028-01-01"
 
 Samplings:
   CO_sample_0:
@@ -68,6 +71,7 @@ Exports:
   CO_BIOMASS:
     - {starting: "1960-01-16T12:00", collection: CO_hfed.emis_co.x576_y361.%y4%m2.nc4, linear_transformation: [0.0,1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
     - {starting: "2000-03-01T00:00", collection: CO_qfed2.emis_co.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
+    - {starting: "2023-03-01T00:00", collection: CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
   CO_BIOMASSnbas:
     collection: /dev/null
     regrid: CONSERVE

--- a/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
+++ b/ESMF/GOCART_GridComp/CO_GridComp/CO_GridComp_ExtData.yaml
@@ -15,6 +15,9 @@ Collections:
   CO_qfed2.emis_co.061.%y4%m2%d2.nc4:
     template: ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_co.061.%y4%m2%d2.nc4
     valid_range: "2021-11-01T12:00/2025-01-01"
+  CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/v3.2r2-nrt/sfc/0.1/QFED/Y%y4/M%m2/qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4
+    valid_range: "2026-01-15T12:00/2028-01-01"
 
 Samplings:
   CO_sample_0:
@@ -68,6 +71,7 @@ Exports:
   CO_BIOMASS:
     - {starting: "2014-12-01T12:00", collection: CO_qfed2.emis_co.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
     - {starting: "2021-11-01T12:00", collection: CO_qfed2.emis_co.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
+    - {starting: "2026-02-01T12:00", collection: CO_qfed_emis_x3600y1800_co.v3_2_2.%y4%m2%d2.nc4, linear_transformation: [0.0, 1.11], regrid: CONSERVE, sample: CO_sample_0, variable: biomass}
   CO_BIOMASSnbas:
     collection: /dev/null
     regrid: CONSERVE


### PR DESCRIPTION
## NOTE

When updating the GEOSgcm fixture, this should be taken with [ACHEM v1.1.0](https://github.com/GEOS-ESM/ACHEM/releases/tag/v1.1.0) which has as similar fix from @acollow (see https://github.com/GEOS-ESM/ACHEM/pull/6)

---

This is essentially #390 for `release/v2.5` (as #390 was released as v2.3.1).