### PR TITLE
Migrate MAPL_BaseMod to mapl_MaplGrid in DU2G_GridCompMod.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `DU2G_GridCompMod.F90` from `use MAPL_BaseMod` to `use mapl_MaplGrid` for `MAPL_GridGet` (MAPL#4857)
 - Migrate `GOCART2G_GridCompMod.F90`, `DU2G_GridCompMod.F90`, `SS2G_GridCompMod.F90` from `MAPL_GetPointer` to `MAPL_StateGetPointer` (calls remain commented out pending full diagnostic port)
 - Migrate `GOCART_GridCompMod.F90` and `Aerosol_GridComp.F90` from `MAPL_AllocateCoupling` to `MAPL_FieldEmptyComplete` (MAPL3 replacement)
 - Migrate `DU2G_GridCompMod.F90`, `SU2G_GridCompMod.F90`, `CA2G_GridCompMod.F90` from `MAPL_PackTime` to `MAPL_PackedDateCreate`/`MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrate `DU2G_GridCompMod.F90` from `use MAPL_BaseMod` to `use mapl_MaplGrid` for `MAPL_GridGet` (MAPL#4857)
+- Migrate `DU2G_GridCompMod.F90` from `use MAPL_BaseMod`/`use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim` (MAPL#4857)
 - Migrate `GOCART2G_GridCompMod.F90`, `DU2G_GridCompMod.F90`, `SS2G_GridCompMod.F90` from `MAPL_GetPointer` to `MAPL_StateGetPointer` (calls remain commented out pending full diagnostic port)
 - Migrate `GOCART_GridCompMod.F90` and `Aerosol_GridComp.F90` from `MAPL_AllocateCoupling` to `MAPL_FieldEmptyComplete` (MAPL3 replacement)
 - Migrate `DU2G_GridCompMod.F90`, `SU2G_GridCompMod.F90`, `CA2G_GridCompMod.F90` from `MAPL_PackTime` to `MAPL_PackedDateCreate`/`MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -12,7 +12,7 @@ module DU2G_GridCompMod
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    ! use MAPL
    use MAPL, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread
-   use MAPL_BaseMod, only: MAPL2_GridGet => MAPL_GridGet
+   use mapl_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource, MAPL_GridCompGetInternalState
    use mapl3g_generic, only: MAPL_GridCompSetEntryPoint

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -12,7 +12,7 @@ module DU2G_GridCompMod
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    ! use MAPL
    use MAPL, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread
-   use mapl_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet
+   use MAPL, only: mapl_GridGetGlobalCellCountPerDim
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource, MAPL_GridCompGetInternalState
    use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
@@ -350,7 +350,8 @@ contains
       integer, allocatable :: mieTable_pointer(:), channels_(:)
       real :: CDT ! chemistry timestep (secs)
       real :: HDT ! model timestep (secs)
-      integer :: ibin, dims(3), km, instance, nmom_, status
+      integer :: ibin, km, instance, nmom_, status
+      integer, allocatable :: dims(:)
       logical :: data_driven
       character(len=ESMF_MAXSTR) :: bin_index, prefix
       character(len=:), allocatable :: comp_name, file_
@@ -362,7 +363,7 @@ contains
 
       ! Global dimensions are needed here for choosing tuning parameters
       call MAPL_GridCompGet(gc, grid=grid, num_levels=km, _RC)
-      call MAPL2_GridGet(grid, globalCellCountPerDim=dims, _RC)
+      call mapl_GridGetGlobalCellCountPerDim(grid, globalCellCountPerDim=dims, _RC)
       self%km = km
 
       ! Dust emission tuning coefficient [kg s2 m-5]. NOT bin specific.


### PR DESCRIPTION
## Summary

Replaces `use MAPL_BaseMod, only: MAPL2_GridGet => MAPL_GridGet` with `use mapl_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet` in `DU2G_GridCompMod.F90`, as `MAPL_BaseMod` is being deleted in GEOS-ESM/MAPL#4857.

Closes #429
Part of GEOS-ESM/MAPL#4857