### PR TITLE
Localize OpenMP thread use and count to the GCs theaded with mini-GS approach

### DIFF
--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -114,6 +114,7 @@ contains
     logical                                  :: data_driven = .true.
     logical                                  :: file_exists
     integer :: num_threads
+    type (MAPL_MetaComp), pointer        :: MAPL
 
     __Iam__('SetServices')
 
@@ -133,11 +134,13 @@ contains
        GCsuffix = 'BR'
     end if
 
+    call MAPL_GetObjectFromGC (GC, MAPL, __RC__)
+
 !   Wrap internal state for storing in GC
 !   -------------------------------------
     allocate (self, __STAT__)
     wrap%ptr => self
-    num_threads = MAPL_get_num_threads()
+    num_threads = MAPL%get_num_threads()
     allocate(self%workspaces(0:num_threads-1), __STAT__)
 
 !   Load resource file

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -119,6 +119,7 @@ contains
     logical                            :: data_driven = .true.
     logical                            :: file_exists
     integer :: num_threads
+    type (MAPL_MetaComp),       pointer  :: MAPL
 
     __Iam__('SetServices')
 
@@ -130,12 +131,15 @@ contains
     call ESMF_GridCompGet (GC, NAME=COMP_NAME, config=universal_cfg, __RC__)
     Iam = trim(COMP_NAME) //'::'// Iam
 
+
+    call MAPL_GetObjectFromGC (GC, MAPL, __RC__)
+
 !   Wrap internal state for storing in GC
 !   -------------------------------------
     allocate (self, __STAT__)
     wrap%ptr => self
 
-    num_threads = MAPL_get_num_threads()
+    num_threads = MAPL%get_num_threads()
     allocate(self%workspaces(0:num_threads-1), __STAT__)
 
 !   Load resource file

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -14,6 +14,7 @@ module GOCART2G_GridCompMod
    use ESMF
    use MAPL
    use Chem_AeroGeneric
+   !$ use omp_lib
 
 ! !Establish the Childen's SetServices
  !-----------------------------------
@@ -112,6 +113,7 @@ contains
     integer, allocatable, dimension(:) :: wavelengths_diagmie
     type (MAPL_MetaComp),       pointer    :: MAPL
     logical :: use_threads
+    integer :: num_threads
 
     __Iam__('SetServices')
 
@@ -166,6 +168,10 @@ contains
     call MAPL_GetObjectFromGC (GC, MAPL, __RC__)
 !   set use_threads
     call MAPL%set_use_threads(use_threads)
+!   set num_threads
+    num_threads = 1
+    if (use_threads) num_threads = omp_get_max_threads()
+    call MAPL%set_num_threads(num_threads)
 
 !   Get instances to determine what children will be born
 !   -----------------------------------------------------

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -103,6 +103,7 @@ contains
     real                                        :: DEFVAL
     logical                                     :: data_driven=.true.
     logical                                     :: file_exists
+    type (MAPL_MetaComp),      pointer   :: MAPL
     integer :: num_threads
 
     __Iam__('SetServices')
@@ -115,12 +116,14 @@ contains
     call ESMF_GridCompGet (GC, NAME=COMP_NAME, config=universal_cfg, __RC__)
     Iam = trim(COMP_NAME) // '::' // Iam
 
+    call MAPL_GetObjectFromGC (GC, MAPL, __RC__)
+
 !   Wrap internal state for storing in GC
 !   -------------------------------------
     allocate (self, __STAT__)
     wrap%ptr => self
 
-    num_threads = MAPL_get_num_threads()
+    num_threads = MAPL%get_num_threads()
     allocate(self%workspaces(0:num_threads-1), __STAT__)
 
 !   Load resource file

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -140,6 +140,7 @@ contains
     logical                                     :: data_driven=.true.
     logical                                     :: file_exists
     integer :: num_threads
+    type (MAPL_MetaComp),      pointer   :: MAPL
 
     __Iam__('SetServices')
 
@@ -151,12 +152,13 @@ contains
     call ESMF_GridCompGet (GC, NAME=COMP_NAME, config=universal_cfg, __RC__)
     Iam = trim(COMP_NAME) // '::' // Iam
 
+    call MAPL_GetObjectFromGC (GC, MAPL, __RC__)
 !   Wrap internal state for storing in GC
 !   -------------------------------------
     allocate (self, __STAT__)
     wrap%ptr => self
 
-    num_threads = MAPL_get_num_threads()
+    num_threads = MAPL%get_num_threads()
     allocate(self%workspaces(0:num_threads-1), __STAT__)
 
 !   Load resource file


### PR DESCRIPTION
Related Issue: 1411

For GWD and GOCART2G threaded with the mini-gridcomp approach, the ability to selectively turn OpenMP off for those components where OpenMP is required for other components is not working as inteneded. The runtime option <use_threads: .FALSE.> to achieve that is being ignored. A branch called bugfix/aoloso/gridComp_level_numthrds has been created fro MAPL, GEOSgcm_GridComp, and GOCART to resolve this bug.

The affected files are <MAPL.F90, MAPL_Generic.F90, MaplGenericComponent.F90, OpenMP_Support.F90, GOCART2G_GridCompMod.F90, CA2G_GridCompMod.F90, DU2G_GridCompMod.F90, NI2G_GridCompMod.F90, SU2G_GridCompMod.F90 GEOS_GwdGridComp.F90>.

