### PR TITLE
Migrate SS2G_GridCompMod off mapl_MaplGrid to use MAPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `SS2G_GridCompMod.F90` from `use MAPL_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `dims` made allocatable (MAPL#4875)
 - Migrate `DU2G_GridCompMod.F90` from `use MAPL_BaseMod`/`use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim` (MAPL#4857)
 - Migrate `GOCART2G_GridCompMod.F90`, `DU2G_GridCompMod.F90`, `SS2G_GridCompMod.F90` from `MAPL_GetPointer` to `MAPL_StateGetPointer` (calls remain commented out pending full diagnostic port)
 - Migrate `GOCART_GridCompMod.F90` and `Aerosol_GridComp.F90` from `MAPL_AllocateCoupling` to `MAPL_FieldEmptyComplete` (MAPL3 replacement)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -12,7 +12,6 @@ module SS2G_GridCompMod
    use pflogger, only: logger_t => logger
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    use MAPL_Constants, only: MAPL_RADIANS_TO_DEGREES, MAPL_PI, MAPL_GRAV, MAPL_KARMAN
-   use MAPL_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet
    use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
    use mapl3g_generic, only: MAPL_GridCompAddSpec
    use mapl3g_generic, only: MAPL_GridCompGet
@@ -23,7 +22,7 @@ module SS2G_GridCompMod
    use mapl3g_generic, only: MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState
    use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
    use mapl3g_RestartModes, only: MAPL_RESTART_SKIP
-   use mapl3g_Geom_API, only: MAPL_GridGet, MAPL_GridGetCoordinates
+   use MAPL, only: MAPL_GridGet, MAPL_GridGetCoordinates, mapl_GridGetGlobalCellCountPerDim
    use mapl3g_State_API, only: MAPL_StateGetPointer
    use mapl3g_UngriddedDim, only: UngriddedDim
    use GOCART2G_MieMod
@@ -329,7 +328,8 @@ contains
       logical :: data_driven
       integer, allocatable, dimension(:) :: mieTable_pointer, channels_
       integer :: instance, nmom_
-      integer :: i, dims(3), km
+      integer :: i, km
+      integer, allocatable :: dims(:)
       integer :: status
 
       call MAPL_GridCompGet(gc, name=comp_name, geom=geom, grid=grid, num_levels=km, _RC)
@@ -338,7 +338,7 @@ contains
       _GET_NAMED_PRIVATE_STATE(gc, SS2G_GridComp, PRIVATE_STATE, self)
 
       ! Global dimensions are needed here for choosing tuning parameters
-      call MAPL2_GridGet(grid, globalCellCountPerDim=dims, _RC)
+      call mapl_GridGetGlobalCellCountPerDim(grid, globalCellCountPerDim=dims, _RC)
       self%km = km
 
       ! Scaling factor to multiply calculated emissions by.  Applies to all size bins.


### PR DESCRIPTION
## Summary

Closes #434

Depends on GEOS-ESM/MAPL#4877.

- Replace `use MAPL_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet` with `use MAPL, only: mapl_GridGetGlobalCellCountPerDim`
- Make `dims` allocatable to match the MAPL3 interface