### PR TITLE
Replace MAPL2 dependency with MAPL in CMakeLists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove `MAPL2` from `Chem_Shared2G` and `DU2G_GridComp` CMake dependencies; replace with `MAPL` (#437)
 - Migrate `SS2G_GridCompMod.F90` from `use MAPL_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `dims` made allocatable (MAPL#4875)
 - Migrate `DU2G_GridCompMod.F90` from `use MAPL_BaseMod`/`use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim` (MAPL#4857)
 - Migrate `GOCART2G_GridCompMod.F90`, `DU2G_GridCompMod.F90`, `SS2G_GridCompMod.F90` from `MAPL_GetPointer` to `MAPL_StateGetPointer` (calls remain commented out pending full diagnostic port)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL2 MAPL.generic3g MAPL.utilities Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
+  DEPENDENCIES GA_Environment MAPL MAPL.generic3g MAPL.utilities Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 mapl_acg (

--- a/ESMF/Shared/CMakeLists.txt
+++ b/ESMF/Shared/CMakeLists.txt
@@ -7,7 +7,7 @@ set (srcs
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL2 MAPL.field_bundle ESMF::ESMF
+  DEPENDENCIES MAPL MAPL.field_bundle ESMF::ESMF
 )
 
 if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/@GSW )


### PR DESCRIPTION
## Summary

- Removes `MAPL2` from `DEPENDENCIES` in `ESMF/Shared/CMakeLists.txt` (Chem_Shared2G)
- Removes `MAPL2` from `DEPENDENCIES` in `ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt`

## Motivation

Part of the MAPL2 retirement sequence. Contingent on GEOS-ESM/MAPL#4889 (PR1) being merged.

## Related Issues

Closes #437