### PR TITLE
v2.6: Fix data-driven SU

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,8 +18,9 @@ concurrency:
 jobs:
   build_gcm:
     strategy:
+      fail-fast: false
       matrix:
-        compiler: [ifort, gfortran-14, gfortran-15]
+        compiler: [ifort, gfortran-15, ifx]
         build-type: [Debug]
     uses: GEOS-ESM/CI-workflows/.github/workflows/geosgcm_build_tests.yml@project/geosgcm
     with:
@@ -46,11 +47,11 @@ jobs:
       BUILDCACHE_TOKEN: ${{ secrets.BUILDCACHE_TOKEN }}
     with:
       fixture-repo: GEOS-ESM/GEOSgcm
-      fixture-ref: release/MAPL-v3
       run-mepo-develop: false
       patch-esmf: true
       # For some reason, Spack builds have weird install issues. For now, skip install.
       run-install: false
+      load-fms: true
 
   spack_build_gocart:
     uses: GEOS-ESM/CI-workflows/.github/workflows/spack_gcc_build.yml@project/geosgcm
@@ -63,4 +64,5 @@ jobs:
       patch-esmf: true
       # Note: you cannot build the install target with plain gocart
       run-install: false
+      load-fms: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [v2.6.5] - 2026-05-15
+
+### Fixed
+
+- Fixed an issue with data-driven SU and `PSO4`
+  - `PSO4` is only an export of computational SU but an Export was being added in the data-driven SU instance.
+
 ## [v2.6.4] - 2026-05-12
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.6.4
+          VERSION 2.6.5
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -221,7 +221,9 @@ contains
 #include "GOCART2G_Import___.h"
 
 !   Allow children of Chemistry to connect to these fields
-    if ((self%SU%instances(1)%is_active)) call MAPL_AddExportSpec (GC, SHORT_NAME='PSO4', CHILD_ID=self%SU%instances(1)%id, __RC__)
+    if ((self%SU%instances(1)%is_active) .and. (index(self%SU%instances(1)%name, 'data') == 0 )) then
+       call MAPL_AddExportSpec (GC, SHORT_NAME='PSO4', CHILD_ID=self%SU%instances(1)%id, __RC__)
+    end if
 
 !   Add connectivities for Nitrate component
 !   Nitrate currently only supports one Nitrate component. Nitrate only


### PR DESCRIPTION
This is the v2.6 version of #440 as both have the same issue.

Closes #439 

This is a simple fix for #439 where we do not add a `PSO4` export when running data-driven SU.

Tests show this allows data-driven to run and is zero-diff for actual gocart.