### PR TITLE
Replace mapl3g_ uses with use MAPL in GOCART2G components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace all `use mapl3g_*` statements with `use MAPL` (umbrella) or
+  `use mapl_*` (for symbols not yet re-exported by the umbrella) following
+  the MAPL Phase 9 `mapl3g_` → `mapl_` module rename. `UngriddedDim` is
+  accessed directly via `use mapl_UngriddedDim` since it is not re-exported
+  by the MAPL umbrella. Affected files: `DU2G_GridCompMod.F90`,
+  `SS2G_GridCompMod.F90`, `GOCART2G_GridCompMod.F90`,
+  `Chem_AeroGeneric.F90`, `GA_EnvironmentMod.F90`
 - Remove `MAPL2` from `Chem_Shared2G` and `DU2G_GridComp` CMake dependencies; replace with `MAPL` (#437)
 - Migrate `SS2G_GridCompMod.F90` from `use MAPL_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `dims` made allocatable (MAPL#4875)
 - Migrate `DU2G_GridCompMod.F90` from `use MAPL_BaseMod`/`use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim` (MAPL#4857)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -11,22 +11,17 @@ module DU2G_GridCompMod
    use pflogger, only: logger_t => logger
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    ! use MAPL
-   use MAPL, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread
-   use MAPL, only: mapl_GridGetGlobalCellCountPerDim
+   use MAPL, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread, &
+                   mapl_GridGetGlobalCellCountPerDim, MAPL_GridCompGet, MAPL_GridCompGetResource, &
+                   MAPL_GridCompGetInternalState, MAPL_GridCompSetEntryPoint, MAPL_GridCompAddSpec, &
+                   MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE, MAPL_ClockGet, &
+                   MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
+                   VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
+                   MAPL_RESTART_SKIP, MAPL_StateGetPointer, MAPL_GeomGetHorzIJIndex
+   use mapl_UngriddedDim, only: UngriddedDim
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
-   use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource, MAPL_GridCompGetInternalState
-   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
-   use mapl3g_generic, only: MAPL_GridCompAddSpec
-   use mapl3g_generic, only: MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE
-   use mapl3g_generic, only: MAPL_ClockGet
-   use mapl3g_generic, only: MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState
-   use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
-   use mapl3g_RestartModes, only: MAPL_RESTART_SKIP
-   use mapl3g_UngriddedDim, only: UngriddedDim
-   use mapl3g_State_API, only: MAPL_StateGetPointer
    use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
                                   MAPL_PackedTimeCreate => PackedTimeCreate
-   use mapl3g_Geom_API, only: MAPL_GeomGetHorzIJIndex
    use GOCART2G_MieMod
    use Chem_AeroGeneric
    use iso_c_binding, only: c_loc, c_f_pointer, c_ptr

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -18,7 +18,7 @@ module DU2G_GridCompMod
                    MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
                    VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
                    MAPL_RESTART_SKIP, MAPL_StateGetPointer, MAPL_GeomGetHorzIJIndex
-   use mapl_UngriddedDim, only: UngriddedDim
+   use mapl3g_UngriddedDim, only: UngriddedDim
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
    use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
                                   MAPL_PackedTimeCreate => PackedTimeCreate

--- a/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
@@ -5,7 +5,6 @@ module GA_EnvironmentMod
    use ESMF
    use MAPL
    use GOCART2G_MieMod
-   use mapl3g_generic, only: MAPL_GridCompGetResource
 
    implicit none
    private

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -17,7 +17,7 @@ module GOCART2G_GridCompMod
                    MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState, &
                    MAPL_RESTART_SKIP, VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
                    MAPL_FieldBundleAdd, MAPL_FieldBundleGet, MAPL_StateGetPointer, MAPL_GridGet
-   use mapl_UngriddedDim, only: UngriddedDim
+   use mapl3g_UngriddedDim, only: UngriddedDim
 
    use Chem_AeroGeneric
 

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -1182,7 +1182,7 @@ contains
    end subroutine create_instances_
 
    subroutine add_children__(gc, species, setservices, rc)
-      use mapl_UserSetServices, only: user_setservices
+      use mapl3g_UserSetServices, only: user_setservices
       type (ESMF_GridComp), intent(inout) :: gc
       type(Constituent), intent(inout) :: species
       external :: setservices

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -10,18 +10,14 @@ module GOCART2G_GridCompMod
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Return, MAPL_Assert
    use MAPL_Constants, only: MAPL_GRAV, MAPL_PI
 
-   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGet, MAPL_GridCompAddSpec
-   use mapl3g_generic, only: MAPL_GridCompAddChild, MAPL_GridCompGetChildName, MAPL_GridCompRunChild
-   use mapl3g_generic, only: MAPL_GridCompAddConnectivity
-   use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompReexport
-   use mapl3g_generic, only: MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE
-   use mapl3g_generic, only: MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState
-   use mapl3g_RestartModes, only: MAPL_RESTART_SKIP
-   use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
-   use mapl3g_FieldBundle_API, only: MAPL_FieldBundleAdd, MAPL_FieldBundleGet
-   use mapl3g_State_API, only: MAPL_StateGetPointer
-   use mapl3g_Geom_API, only: MAPL_GridGet
-   use mapl3g_UngriddedDim, only: UngriddedDim
+   use MAPL, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGet, MAPL_GridCompAddSpec, &
+                   MAPL_GridCompAddChild, MAPL_GridCompGetChildName, MAPL_GridCompRunChild, &
+                   MAPL_GridCompAddConnectivity, MAPL_GridCompGetResource, MAPL_GridCompReexport, &
+                   MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE, &
+                   MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState, &
+                   MAPL_RESTART_SKIP, VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
+                   MAPL_FieldBundleAdd, MAPL_FieldBundleGet, MAPL_StateGetPointer, MAPL_GridGet
+   use mapl_UngriddedDim, only: UngriddedDim
 
    use Chem_AeroGeneric
 
@@ -1186,7 +1182,7 @@ contains
    end subroutine create_instances_
 
    subroutine add_children__(gc, species, setservices, rc)
-      use mapl3g_UserSetServices, only: user_setservices
+      use mapl_UserSetServices, only: user_setservices
       type (ESMF_GridComp), intent(inout) :: gc
       type(Constituent), intent(inout) :: species
       external :: setservices

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -19,7 +19,7 @@ module SS2G_GridCompMod
                    MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
                    VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
                    MAPL_RESTART_SKIP, MAPL_StateGetPointer
-   use mapl_UngriddedDim, only: UngriddedDim
+   use mapl3g_UngriddedDim, only: UngriddedDim
    use GOCART2G_MieMod
    use Chem_AeroGeneric
    use iso_c_binding, only: c_loc, c_f_pointer, c_ptr

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -12,19 +12,14 @@ module SS2G_GridCompMod
    use pflogger, only: logger_t => logger
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
    use MAPL_Constants, only: MAPL_RADIANS_TO_DEGREES, MAPL_PI, MAPL_GRAV, MAPL_KARMAN
-   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
-   use mapl3g_generic, only: MAPL_GridCompAddSpec
-   use mapl3g_generic, only: MAPL_GridCompGet
-   use mapl3g_generic, only: MAPL_GridCompGetResource
-   use mapl3g_generic, only: MAPL_GridCompGetInternalState
-   use mapl3g_generic, only: MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE
-   use mapl3g_generic, only: MAPL_ClockGet
-   use mapl3g_generic, only: MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState
-   use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
-   use mapl3g_RestartModes, only: MAPL_RESTART_SKIP
-   use MAPL, only: MAPL_GridGet, MAPL_GridGetCoordinates, mapl_GridGetGlobalCellCountPerDim
-   use mapl3g_State_API, only: MAPL_StateGetPointer
-   use mapl3g_UngriddedDim, only: UngriddedDim
+   use MAPL, only: MAPL_GridGet, MAPL_GridGetCoordinates, mapl_GridGetGlobalCellCountPerDim, &
+                   MAPL_GridCompSetEntryPoint, MAPL_GridCompAddSpec, MAPL_GridCompGet, &
+                   MAPL_GridCompGetResource, MAPL_GridCompGetInternalState, &
+                   MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE, MAPL_ClockGet, &
+                   MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
+                   VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
+                   MAPL_RESTART_SKIP, MAPL_StateGetPointer
+   use mapl_UngriddedDim, only: UngriddedDim
    use GOCART2G_MieMod
    use Chem_AeroGeneric
    use iso_c_binding, only: c_loc, c_f_pointer, c_ptr

--- a/ESMF/Shared/Chem_AeroGeneric.F90
+++ b/ESMF/Shared/Chem_AeroGeneric.F90
@@ -12,11 +12,8 @@ module Chem_AeroGeneric
    !USES:
    use ESMF
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
-   use mapl3g_State_API, only: MAPL_StateGetPointer
-   use mapl3g_Field_API, only: MAPL_FieldGet, MAPL_FieldCreate
-   use mapl3g_FieldBundle_API, only: MAPL_FieldBundleAdd
-   use mapl3g_VerticalStaggerLoc, only: VerticalStaggerLoc, VERTICAL_STAGGER_EDGE, VERTICAL_STAGGER_CENTER
-   use mapl3g_UngriddedDims, only: UngriddedDims
+   use MAPL, only: MAPL_StateGetPointer, MAPL_FieldGet, MAPL_FieldCreate, MAPL_FieldBundleAdd, &
+                   VerticalStaggerLoc, VERTICAL_STAGGER_EDGE, VERTICAL_STAGGER_CENTER, UngriddedDims
    ! USE Chem_MieMod2G
 
    implicit none


### PR DESCRIPTION
## Summary

- Replace all `use mapl3g_*` statements with `use MAPL` (umbrella) or `use mapl_*` in:
  - `ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90`
  - `ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90`
  - `ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90`
  - `ESMF/Shared/Chem_AeroGeneric.F90`
  - `ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90`
- `UngriddedDim` is not yet re-exported by the MAPL umbrella; accessed directly via `use mapl_UngriddedDim`
- Update CHANGELOG

## Motivation

MAPL Phase 9 (#4944) renamed all `mapl3g_` module prefixes to `mapl_`. This PR updates all affected GOCART2G components to use the standard MAPL umbrella module.