### PR TITLE
Replace remaining mapl3g_ uses with use MAPL (closes #447)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -53,6 +53,7 @@ jobs:
       patch-esmf: true
       # For some reason, Spack builds have weird install issues. For now, skip install.
       run-install: false
+      load-fms: true
 
   spack_build_gocart:
     uses: GEOS-ESM/CI-workflows/.github/workflows/spack_gcc_build.yml@project/geosgcm
@@ -65,4 +66,5 @@ jobs:
       patch-esmf: true
       # Note: you cannot build the install target with plain GOCART
       run-install: false
+      load-fms: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by the MAPL umbrella. Affected files: `DU2G_GridCompMod.F90`,
   `SS2G_GridCompMod.F90`, `GOCART2G_GridCompMod.F90`,
   `Chem_AeroGeneric.F90`, `GA_EnvironmentMod.F90`
+- Replace remaining `use mapl3g_UngriddedDim` and `use mapl3g_UserSetServices`
+  with `use MAPL` now that `UngriddedDim` and `user_setservices` are
+  re-exported by the MAPL umbrella (closes #447). Affected files:
+  `DU2G_GridCompMod.F90`, `SS2G_GridCompMod.F90`, `GOCART2G_GridCompMod.F90`,
+  `Chem_AeroGeneric.F90`
 - Remove `MAPL2` from `Chem_Shared2G` and `DU2G_GridComp` CMake dependencies; replace with `MAPL` (#437)
 - Migrate `SS2G_GridCompMod.F90` from `use MAPL_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `dims` made allocatable (MAPL#4875)
 - Migrate `DU2G_GridCompMod.F90` from `use MAPL_BaseMod`/`use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim` (MAPL#4857)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -9,16 +9,14 @@ module DU2G_GridCompMod
    !USES:
    use ESMF
    use pflogger, only: logger_t => logger
-   use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
-   ! use MAPL
-   use MAPL, only: MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread, &
+   use MAPL, only: MAPL_Verify, MAPL_Assert, MAPL_Return, &
+                   MAPL_get_num_threads => get_num_threads, MAPL_get_current_thread => get_current_thread, &
                    mapl_GridGetGlobalCellCountPerDim, MAPL_GridCompGet, MAPL_GridCompGetResource, &
                    MAPL_GridCompGetInternalState, MAPL_GridCompSetEntryPoint, MAPL_GridCompAddSpec, &
                    MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE, MAPL_ClockGet, &
                    MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
                    VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
-                   MAPL_RESTART_SKIP, MAPL_StateGetPointer, MAPL_GeomGetHorzIJIndex
-   use mapl3g_UngriddedDim, only: UngriddedDim
+                   MAPL_RESTART_SKIP, MAPL_StateGetPointer, MAPL_GeomGetHorzIJIndex, UngriddedDim
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
    use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
                                   MAPL_PackedTimeCreate => PackedTimeCreate

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -7,17 +7,15 @@ module GOCART2G_GridCompMod
 
    !USES:
    use ESMF
-   use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Return, MAPL_Assert
-   use MAPL_Constants, only: MAPL_GRAV, MAPL_PI
-
-   use MAPL, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGet, MAPL_GridCompAddSpec, &
+   use MAPL, only: MAPL_Verify, MAPL_Return, MAPL_Assert, &
+                   MAPL_GridCompSetEntryPoint, MAPL_GridCompGet, MAPL_GridCompAddSpec, &
                    MAPL_GridCompAddChild, MAPL_GridCompGetChildName, MAPL_GridCompRunChild, &
                    MAPL_GridCompAddConnectivity, MAPL_GridCompGetResource, MAPL_GridCompReexport, &
                    MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE, &
                    MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState, &
                    MAPL_RESTART_SKIP, VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
-                   MAPL_FieldBundleAdd, MAPL_FieldBundleGet, MAPL_StateGetPointer, MAPL_GridGet
-   use mapl3g_UngriddedDim, only: UngriddedDim
+                   MAPL_FieldBundleAdd, MAPL_FieldBundleGet, MAPL_StateGetPointer, MAPL_GridGet, UngriddedDim
+   use MAPL_Constants, only: MAPL_GRAV, MAPL_PI
 
    use Chem_AeroGeneric
 
@@ -1182,7 +1180,7 @@ contains
    end subroutine create_instances_
 
    subroutine add_children__(gc, species, setservices, rc)
-      use mapl3g_UserSetServices, only: user_setservices
+      use MAPL, only: user_setservices
       type (ESMF_GridComp), intent(inout) :: gc
       type(Constituent), intent(inout) :: species
       external :: setservices

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -10,16 +10,15 @@ module SS2G_GridCompMod
    !USES:
    use ESMF
    use pflogger, only: logger_t => logger
-   use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
-   use MAPL_Constants, only: MAPL_RADIANS_TO_DEGREES, MAPL_PI, MAPL_GRAV, MAPL_KARMAN
-   use MAPL, only: MAPL_GridGet, MAPL_GridGetCoordinates, mapl_GridGetGlobalCellCountPerDim, &
+   use MAPL, only: MAPL_Verify, MAPL_Assert, MAPL_Return, &
+                   MAPL_GridGet, MAPL_GridGetCoordinates, mapl_GridGetGlobalCellCountPerDim, &
                    MAPL_GridCompSetEntryPoint, MAPL_GridCompAddSpec, MAPL_GridCompGet, &
                    MAPL_GridCompGetResource, MAPL_GridCompGetInternalState, &
                    MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE, MAPL_ClockGet, &
                    MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
                    VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
-                   MAPL_RESTART_SKIP, MAPL_StateGetPointer
-   use mapl3g_UngriddedDim, only: UngriddedDim
+                   MAPL_RESTART_SKIP, MAPL_StateGetPointer, UngriddedDim
+   use MAPL_Constants, only: MAPL_RADIANS_TO_DEGREES, MAPL_PI, MAPL_GRAV, MAPL_KARMAN
    use GOCART2G_MieMod
    use Chem_AeroGeneric
    use iso_c_binding, only: c_loc, c_f_pointer, c_ptr

--- a/ESMF/Shared/Chem_AeroGeneric.F90
+++ b/ESMF/Shared/Chem_AeroGeneric.F90
@@ -11,8 +11,8 @@ module Chem_AeroGeneric
 
    !USES:
    use ESMF
-   use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Assert, MAPL_Return
-   use MAPL, only: MAPL_StateGetPointer, MAPL_FieldGet, MAPL_FieldCreate, MAPL_FieldBundleAdd, &
+   use MAPL, only: MAPL_Verify, MAPL_Assert, MAPL_Return, &
+                   MAPL_StateGetPointer, MAPL_FieldGet, MAPL_FieldCreate, MAPL_FieldBundleAdd, &
                    VerticalStaggerLoc, VERTICAL_STAGGER_EDGE, VERTICAL_STAGGER_CENTER, UngriddedDims
    ! USE Chem_MieMod2G
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,35 +5,37 @@ GOCART:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v5.16.0
+  tag: v5.21.0
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.68.0
+  tag: v4.36.0
   develop: develop
 
 ecbuild:
   local: ./cmake@/ecbuild@
   remote: ../ecbuild.git
-  tag: geos/v1.4.0
+  tag: geos/v3.13.1
 
 HEMCO:
   local: ./ESMF/HEMCO_GridComp@
   remote: ../HEMCO.git
-  tag: geos/v2.3.0
+  # NOTE: The MAPL3 branch in HEMCO is *NOT* based off of geos/develop as that is far ahead of current where GEOSgcm
+  #       is. This is based on release/geos/2.3.0 which was off of geos/v2.3.0
+  branch: geos/release/MAPL-v3
   develop: geos/develop
 
 GMAO_Shared:
   local: ./ESMF/Shared/GMAO_Shared@
   remote: ../GMAO_Shared.git
-  tag: v2.1.4
+  branch: release/MAPL-v3
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./ESMF/Shared/MAPL@
   remote: ../MAPL.git
-  tag: release/MAPL-v3
+  branch: develop
   develop: develop


### PR DESCRIPTION
## Summary

- Removes the reverts from PR #446 that left `use mapl3g_UngriddedDim` and `use mapl3g_UserSetServices` in place.
- `UngriddedDim` and `user_setservices` are now re-exported by the MAPL umbrella (via MAPL PR #4954), so direct `use MAPL` works.
- Affected files: `DU2G_GridCompMod.F90`, `SS2G_GridCompMod.F90`, `GOCART2G_GridCompMod.F90`, `Chem_AeroGeneric.F90`

## Testing

- Local clean build with Intel Fortran (`ifx`) passes.