### PR TITLE
Replace internal MAPL module references with USE MAPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace internal MAPL module references with `USE MAPL` in `aop_calculator.F90`
+  (`MAPL_LatLonGridFactoryMod`), `CA2G_GridCompMod.F90`, `DU2G_GridCompMod.F90`,
+  and `SU2G_GridCompMod.F90` (`MAPL_StringTemplate`, `MAPL_PackedTimeMod`). All
+  MAPL symbols now accessed via the public `MAPL` or `MAPL_Constants` wrapper
+  modules (closes #449).
 - Replace all `use mapl3g_*` statements with `use MAPL` (umbrella) or
   `use mapl_*` (for symbols not yet re-exported by the umbrella) following
   the MAPL Phase 9 `mapl3g_` → `mapl_` module rename. `UngriddedDim` is

--- a/ESMF/Apps/aop_calculator.F90
+++ b/ESMF/Apps/aop_calculator.F90
@@ -17,7 +17,6 @@
 !
       use  ESMF
       use  MAPL
-      use  MAPL_LatLonGridFactoryMod 
       use  GOCART2G_SimpleBundleMod
       use  GOCART2G_MieMod
       use  GOCART2G_AopMod

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -17,9 +17,6 @@ module CA2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_EnvironmentMod
-   use MAPL_StringTemplate, only: StrTemplate
-   use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
-                                  MAPL_PackedTimeCreate => PackedTimeCreate
    !$ use omp_lib
 
    implicit none

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -16,17 +16,17 @@ module DU2G_GridCompMod
                    MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE, MAPL_ClockGet, &
                    MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
                    VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
-                   MAPL_RESTART_SKIP, MAPL_StateGetPointer, MAPL_GeomGetHorzIJIndex, UngriddedDim
+                   MAPL_RESTART_SKIP, MAPL_StateGetPointer, MAPL_GeomGetHorzIJIndex, UngriddedDim, &
+                   StrTemplate
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL, MAPL_GRAV, MAPL_KARMAN, MAPL_RADIANS_TO_DEGREES
-   use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
-                                  MAPL_PackedTimeCreate => PackedTimeCreate
+   use MAPL, only: MAPL_PackedDateCreate => PackedDateCreate, &
+                   MAPL_PackedTimeCreate => PackedTimeCreate
    use GOCART2G_MieMod
    use Chem_AeroGeneric
    use iso_c_binding, only: c_loc, c_f_pointer, c_ptr
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_EnvironmentMod
-   use MAPL_StringTemplate, only: StrTemplate
    !$ use omp_lib
 
    implicit none

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -18,9 +18,6 @@ module SU2G_GridCompMod
 
    use GOCART2G_Process       ! GOCART2G process library
    use GA_EnvironmentMod
-   use MAPL_StringTemplate, only: StrTemplate
-   use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
-                                  MAPL_PackedTimeCreate => PackedTimeCreate
    !$ use omp_lib
 
    implicit none


### PR DESCRIPTION
## Summary

- Remove direct dependencies on internal MAPL submodules in compiled GOCART files
- All MAPL symbols now accessed via the public `MAPL` or `MAPL_Constants` wrapper modules

## Affected Files

| File | Internal Module Removed |
|------|------------------------|
| `ESMF/Apps/aop_calculator.F90` | `MAPL_LatLonGridFactoryMod` |
| `ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90` | `MAPL_StringTemplate`, `MAPL_PackedTimeMod` |
| `ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90` | `MAPL_StringTemplate`, `MAPL_PackedTimeMod` |
| `ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90` | `MAPL_StringTemplate`, `MAPL_PackedTimeMod` |

## Dependencies

Requires GEOS-ESM/MAPL#4964 (merged) which re-exports `PackedDateCreate`, `PackedTimeCreate`, and `StrTemplate` via the MAPL umbrella module.

Closes #449