### PR TITLE
Remove direct MAPL.generic3g link dependency (closes #451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove direct `MAPL.generic3g` CMake link dependency from GA_Environment,
+  SS2G_GridComp, and DU2G_GridComp (closes #451). The target has been renamed
+  to `MAPL.generic` in MAPL and all symbols remain accessible transitively
+  via `MAPL`. Zero-diff structural change.
 - Replace internal MAPL module references with `USE MAPL` in `aop_calculator.F90`
   (`MAPL_LatLonGridFactoryMod`), `CA2G_GridCompMod.F90`, `DU2G_GridCompMod.F90`,
   and `SU2G_GridCompMod.F90` (`MAPL_StringTemplate`, `MAPL_PackedTimeMod`). All

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove direct `MAPL.generic3g` CMake link dependency from GA_Environment,
   SS2G_GridComp, and DU2G_GridComp (closes #451). The target has been renamed
   to `MAPL.generic` in MAPL and all symbols remain accessible transitively
-  via `MAPL`. Zero-diff structural change.
+  via `MAPL`. Also removes spurious `MAPL.field` (invalid target),
+  `MAPL.utilities`, and `MAPL.field_bundle` sub-target dependencies from
+  SS2G_GridComp, DU2G_GridComp, and ESMF/Shared respectively. Zero-diff
+  structural change.
 - Replace internal MAPL module references with `USE MAPL` in `aop_calculator.F90`
   (`MAPL_LatLonGridFactoryMod`), `CA2G_GridCompMod.F90`, `DU2G_GridCompMod.F90`,
   and `SU2G_GridCompMod.F90` (`MAPL_StringTemplate`, `MAPL_PackedTimeMod`). All

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL MAPL.utilities Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
+  DEPENDENCIES GA_Environment MAPL Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 mapl_acg (

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES GA_Environment MAPL MAPL.generic3g MAPL.utilities Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
+  DEPENDENCIES GA_Environment MAPL MAPL.utilities Chem_Shared2G Process_Library ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 mapl_acg (

--- a/ESMF/GOCART2G_GridComp/GA_Environment/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPL MAPL.generic3g Chem_Shared2G Process_Library ESMF::ESMF
+  DEPENDENCIES MAPL Chem_Shared2G Process_Library ESMF::ESMF
   )
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPL MAPL.generic3g MAPL.field GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPL MAPL.field GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 mapl_acg (

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPL MAPL.field GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPLGA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 mapl_acg (

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS ${this}Mod.F90
-  DEPENDENCIES MAPLGA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPL GA_Environment Chem_Shared2G Process_Library esmf NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 mapl_acg (

--- a/ESMF/Shared/CMakeLists.txt
+++ b/ESMF/Shared/CMakeLists.txt
@@ -7,7 +7,7 @@ set (srcs
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL MAPL.field_bundle ESMF::ESMF
+  DEPENDENCIES MAPL ESMF::ESMF
 )
 
 if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/@GSW )


### PR DESCRIPTION
## Summary

- Remove `MAPL.generic3g` from `DEPENDENCIES` in GA_Environment, SS2G_GridComp, and DU2G_GridComp CMakeLists.txt files

All symbols are available transitively through `MAPL`. This target no longer exists as of GEOS-ESM/MAPL#4990.

## Dependency

**Draft — contingent on GEOS-ESM/MAPL#4990.**