### PR TITLE
GOCART2G: drop redundant 3g argument from mapl_acg() calls

### DIFF
--- a/ESMF/GOCART2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/CMakeLists.txt
@@ -32,7 +32,6 @@ esma_add_library (${this}
 mapl_acg (
   ${this} GOCART2G_StateSpecs.rc
   IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS GET_POINTERS DECLARE_POINTERS
-  3g
 )
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt
@@ -8,7 +8,6 @@ esma_add_library (${this}
 mapl_acg (
   ${this} DU2G_StateSpecs.rc
   IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS GET_POINTERS DECLARE_POINTERS
-  3g
 )
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt
@@ -8,7 +8,6 @@ esma_add_library (${this}
 mapl_acg (
   ${this} SS2G_StateSpecs.rc
   IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS GET_POINTERS DECLARE_POINTERS
-  3g
 )
 
 file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc *.yaml)


### PR DESCRIPTION
Remove the `3g` argument from `mapl_acg()` in three CMakeLists.txt files:
- `ESMF/GOCART2G_GridComp/CMakeLists.txt`
- `ESMF/GOCART2G_GridComp/DU2G_GridComp/CMakeLists.txt`
- `ESMF/GOCART2G_GridComp/SS2G_GridComp/CMakeLists.txt`