### PR TITLE
Update to new MAPL_GridCompAddChild interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- Updated MAPL\_GridCompAddCHild to new interface that just takes a procedure
 - Updated MAPL\_GridCompAddSpec calls to new interface
 - Pushed rename of MAPL entities down into MAPL.
 - Remove direct `MAPL.generic3g` CMake link dependency from GA_Environment,

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -1180,7 +1180,6 @@ contains
    end subroutine create_instances_
 
    subroutine add_children__(gc, species, setservices, rc)
-      use MAPL, only: user_setservices
       type (ESMF_GridComp), intent(inout) :: gc
       type(Constituent), intent(inout) :: species
       external :: setservices
@@ -1194,7 +1193,7 @@ contains
          child_name = species%instances(iter)%name
          config_file = species%name // "_instance_" // child_name // ".yaml"
          hconfig = ESMF_HConfigCreate(filename=config_file, _RC)
-         call MAPL_GridCompAddChild(gc, child_name, user_setservices(setservices), hconfig, _RC)
+         call MAPL_GridCompAddChild(gc, child_name, setservices, hconfig, _RC)
          call ESMF_HConfigDestroy(hconfig, _RC)
       end do
 


### PR DESCRIPTION
new interface for MAPL_GridCompAddChild that does not require the user_setservices derived type