### PR TITLE
DU2G, SS2G: added back the mapl section for CI to run successfully

### DIFF
--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.yaml
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.yaml
@@ -71,3 +71,17 @@ pressure_lid_in_hPa: 10.0
 
 # SettlingSolver options: gocart or ufs
 settling_scheme: gocart
+
+# TODO: remove this section once GOCART regression tests
+# start running via ctest on CI
+mapl:
+  misc:
+    activate_all_imports: true
+    activate_all_exports: true
+    restart:
+      import: true
+      internal: true
+    checkpoint:
+      export: true
+      import: true
+      internal: true

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.yaml
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.yaml
@@ -38,3 +38,17 @@ pressure_lid_in_hPa: 40.0
 
 # SettlingSolver options (gocart or ufs)
 settling_scheme: gocart
+
+# TODO: remove this section once GOCART regression tests
+# start running via ctest on CI
+mapl:
+  misc:
+    activate_all_imports: true
+    activate_all_exports: true
+    restart:
+      import: true
+      internal: true
+    checkpoint:
+      export: true
+      import: true
+      internal: true


### PR DESCRIPTION
Restore the `mapl` section in the DU2G and SS2G instance YAMLs that was removed in favor of tests being run via `ctest`, which was preventing CI from running successfully.