### PR TITLE
v2.6: Backport GOCART1 ifx fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [v2.6.6] - 2026-08-03
+
+### Fixed
+
+- Fixed ifx compilation errors in legacy GOCART GridComps (Ops emissions path):
+  - Changed `intent(in)` to `intent(inout)` on `w_c` (`Chem_Bundle`) arguments in `Aero`, `CFC`, `CH4`, `CO`, `CO2`, and `Rn` GridComps, as sub-components temporarily modify registry indices
+- Additional fixes in `CO_GridCompMod.F90`:
+  - Initialize `eCO_bioburn_` to `0.0` to prevent use of uninitialized data when `diurnal_bb` is false
+  - Guard `DEALLOCATE` of `ier` with an `ALLOCATED` check
+  - Add local `ios` variable in `CO_Emission` to prevent host-association aliasing under optimization
+
 ## [v2.6.5] - 2026-05-15
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if (GOCART_STANDALONE)
   project (
           GOCART
-          VERSION 2.6.5
+          VERSION 2.6.6
           LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
   if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/ESMF/GOCART_GridComp/Aero_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/Aero_GridCompMod.F90
@@ -507,7 +507,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   type(Chem_Bundle), intent(in)  :: w_c      ! Chemical tracer fields   
+   type(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: sub-components temporarily modify reg indices)
    integer, intent(in) :: nymd, nhms          ! time
    real, intent(in) :: cdt                    ! chemistry timestep (secs)
 
@@ -601,4 +601,3 @@ CONTAINS
  end subroutine Aero_GridCompFinalize
 
  end module Aero_GridCompMod
-

--- a/ESMF/GOCART_GridComp/CFC_GridComp/CFC_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CFC_GridComp/CFC_GridCompMod.F90
@@ -130,7 +130,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 

--- a/ESMF/GOCART_GridComp/CH4_GridComp/CH4_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CH4_GridComp/CH4_GridCompMod.F90
@@ -174,7 +174,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -310,7 +310,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -366,7 +366,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -459,7 +459,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 

--- a/ESMF/GOCART_GridComp/CO2_GridComp/CO2_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CO2_GridComp/CO2_GridCompMod.F90
@@ -265,7 +265,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   type(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   type(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    integer, intent(in) :: nymd, nhms           ! time
    real,    intent(in) :: cdt                  ! chemical timestep (secs)
 
@@ -989,7 +989,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   type(Chem_Bundle), intent(in)  :: w_c      ! Chemical tracer fields   
+   type(Chem_Bundle), intent(inout) :: w_c   ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)
    integer, intent(in) :: nymd, nhms          ! time
    real,    intent(in) :: cdt                 ! chemical timestep (secs)
 

--- a/ESMF/GOCART_GridComp/CO_GridComp/CO_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/CO_GridComp/CO_GridCompMod.F90
@@ -197,7 +197,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c          ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c       ! Chemical tracer fields (inout: CO_SingleInstance_ temporarily modifies reg indices)
    INTEGER, INTENT(IN) :: nymd, nhms             ! time
    REAL,    INTENT(IN) :: cdt                    ! chemical timestep (secs)
 
@@ -353,7 +353,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c          ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c       ! Chemical tracer fields (inout: CO_SingleInstance_ temporarily modifies reg indices)
    INTEGER, INTENT(IN) :: nymd, nhms             ! time
    REAL,    INTENT(IN) :: cdt                    ! chemical timestep (secs)
 
@@ -411,7 +411,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c          ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c       ! Chemical tracer fields (inout: CO_SingleInstance_ temporarily modifies reg indices)
    INTEGER, INTENT(IN) :: nymd, nhms             ! time
    REAL,    INTENT(IN) :: cdt                    ! chemical timestep (secs)
 
@@ -702,6 +702,7 @@ CONTAINS
               ier(nerr),STAT=ios )
    ier = 0
    IF ( ios /= 0 ) rc = 100
+   gcCO%eCO_bioburn_ = 0.0   ! initialize to prevent use of uninitialized data if diurnal_bb is false
    END SUBROUTINE init_
 
    SUBROUTINE final_(ierr)
@@ -711,7 +712,8 @@ CONTAINS
                 gcCO%eCO_bioburn_, &
                 gcCO%COsfcFlux, gcCO%eCO_iso, gcCO%eCO_mon, &
                 gcCO%eCO_mtn, gcCO%CH4, gcCO%OHnd, &
-                ier, STAT=ios )
+                STAT=ios )
+   IF ( ALLOCATED(ier) ) DEALLOCATE( ier, STAT=ios )
    CALL I90_release()
    rc = ierr
    END SUBROUTINE final_
@@ -1149,6 +1151,7 @@ CONTAINS
    CHARACTER(LEN=*), PARAMETER :: myname = 'CO_Emission'
 
    INTEGER :: i, j, k, kt, minkPBL
+   INTEGER :: ios                        ! local ios - prevent host association aliasing under optimization
    INTEGER, ALLOCATABLE :: index(:)
 
    REAL, PARAMETER :: mwtAir=28.97

--- a/ESMF/GOCART_GridComp/Rn_GridComp/Rn_GridCompMod.F90
+++ b/ESMF/GOCART_GridComp/Rn_GridComp/Rn_GridCompMod.F90
@@ -183,7 +183,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -316,7 +316,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -373,7 +373,7 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 
@@ -461,7 +461,7 @@ subroutine RN_GridCompSetServices1_(  gc, chemReg, iname, rc)
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), intent(in) :: w_c        ! Chemical tracer fields      
+   TYPE(Chem_Bundle), intent(inout) :: w_c     ! Chemical tracer fields (inout: SingleInstance_ temporarily modifies reg indices)      
    INTEGER, INTENT(IN) :: nymd, nhms	       ! time
    REAL,    INTENT(IN) :: cdt		       ! chemical timestep (secs)
 


### PR DESCRIPTION
This is a backport of #399 into GOCART v2.6. The fixes are already on v2.7 (aka `develop`) but v2.7 is still in testing. With this PR, ifx will be able to run GOCART v2.6 which current GEOSgcm v11.10+ uses.

When running GEOSgcm v12 with ifx 2025.3 and OPS emissions in Release mode, the CO_GridComp (and other legacy GOCART GridComps) would fail during initialization due to ifx's stricter enforcement of intent(in) on arguments that are temporarily modified internally.

See #399 for more details.

---

Tested and for ifort it is zero-diff for both AMIP and OPS. For ifx, it runs both, which is good. 