### PR TITLE
Fix regression test setservices key and modernize expdir cleanup

### DIFF
--- a/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/fake-gocart.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/fake-gocart.yaml
@@ -24,6 +24,6 @@ mapl:
   children:
     DU:
       dso: libDU2G_GridComp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: DU_instance_DU.yaml
       run_phases: [Run1]

--- a/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/root.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/root.yaml
@@ -16,7 +16,7 @@ mapl:
   children:
     DataDU:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-du.yaml
 
     FakeGOCART:

--- a/ESMF/GOCART2G_GridComp/regression/dust-sa/run2/fake-gocart.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/dust-sa/run2/fake-gocart.yaml
@@ -24,6 +24,6 @@ mapl:
   children:
     DU:
       dso: libDU2G_GridComp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: DU_instance_DU.yaml
       run_phases: [Run2]

--- a/ESMF/GOCART2G_GridComp/regression/dust-sa/run2/root.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/dust-sa/run2/root.yaml
@@ -16,7 +16,7 @@ mapl:
   children:
     DataDU:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-du.yaml
     FakeGOCART:
       dso: libconfigurable_gridcomp.so

--- a/ESMF/GOCART2G_GridComp/regression/gocart+seasalt+dust/run1/root.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/gocart+seasalt+dust/run1/root.yaml
@@ -15,28 +15,28 @@ mapl:
   children:
     DataDU:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-du.yaml
       run_phases:
         - run
 
     DataSS:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-ss.yaml
       run_phases:
         - run
 
     DataGOCART2G:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-gocart2g.yaml
       run_phases:
         - run
 
     GOCART2G:
       dso: libGOCART2G_GridComp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: GOCART2G_GridComp.yaml
       run_phases:
         - Run1

--- a/ESMF/GOCART2G_GridComp/regression/gocart+seasalt+dust/run2/root.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/gocart+seasalt+dust/run2/root.yaml
@@ -15,28 +15,28 @@ mapl:
   children:
     DataDU:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-du.yaml
       run_phases:
         - run
 
     DataSS:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-ss.yaml
       run_phases:
         - run
 
     DataGOCART2G:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-gocart2g.yaml
       run_phases:
         - run
 
     GOCART2G:
       dso: libGOCART2G_GridComp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: GOCART2G_GridComp.yaml
       run_phases:
         - Run2

--- a/ESMF/GOCART2G_GridComp/regression/run_case.cmake
+++ b/ESMF/GOCART2G_GridComp/regression/run_case.cmake
@@ -1,15 +1,5 @@
 include("${ESMA_REGRESSION_HELPERS}")
 
-function(copy_restarts root_dir expdir)
-  file(GLOB checkpoint_subdirs LIST_DIRECTORIES true ${root_dir}/checkpoints/*)
-  foreach(ckpt_dir IN LISTS checkpoint_subdirs)
-    get_filename_component(ckpt_name ${ckpt_dir} NAME)
-    if(IS_DIRECTORY ${ckpt_dir} AND NOT ckpt_name STREQUAL "last")
-      copy_directory(${ckpt_dir} ${expdir}/checkpoints/${ckpt_name})
-    endif()
-  endforeach()
-endfunction()
-
 function(run_case case_name regression_data_dir)
   string(RANDOM LENGTH 24 expdir)
   execute_process(
@@ -29,16 +19,9 @@ function(run_case case_name regression_data_dir)
   copy_restarts(${root_dir} ${expdir})
   link_directory(${regression_data_dir}/ExtData ${expdir}/ExtData)
   run_geos(${num_procs} ${case_name} ${expdir})
-
-  if(NOT EXISTS ${checkpoints_dir})
-    message(WARNING "Baseline directory [${checkpoints_dir}] not found. Skipping comparison.")
-    return()
-  endif()
   compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
 
-  # execute_process(
-  #   COMMAND ${CMAKE_COMMAND} -E rm -rf ${expdir}
-  # )
+  file(REMOVE_RECURSE ${expdir})
 endfunction()
 
 run_case(${TEST_CASE} ${REGRESSION_DATA_DIR})

--- a/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run1/fake-gocart.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run1/fake-gocart.yaml
@@ -24,6 +24,6 @@ mapl:
   children:
     SS:
       dso: libSS2G_GridComp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: SS_instance_SS.yaml
       run_phases: [Run1]

--- a/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run1/root.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run1/root.yaml
@@ -16,7 +16,7 @@ mapl:
   children:
     DataSS:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-ss.yaml
 
     FakeGOCART:

--- a/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run2/fake-gocart.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run2/fake-gocart.yaml
@@ -24,6 +24,6 @@ mapl:
   children:
     SS:
       dso: libSS2G_GridComp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: SS_instance_SS.yaml
       run_phases: [Run2]

--- a/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run2/root.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/seasalt-sa/run2/root.yaml
@@ -16,7 +16,7 @@ mapl:
   children:
     DataSS:
       dso: libconfigurable_gridcomp.so
-      setservice: setservices_
+      setservices: setservices_
       config_file: data-ss.yaml
 
     FakeGOCART:


### PR DESCRIPTION
## Summary
- Fix regression test key: `setservice` -> `setservices` in the GOCART2G regression yamls (dust-sa, seasalt-sa, gocart+seasalt+dust), matching MAPL's `ComponentSpecParser` now that GEOS-ESM/MAPL#5307 fixed a string-length bug that previously truncated the key.
- Replace the `execute_process(COMMAND ${CMAKE_COMMAND} -E rm -rf ${expdir})` cleanup step in `run_case.cmake` with the native `file(REMOVE_RECURSE ${expdir})`.

## Test plan
- [x] Regression tests (dust-sa, seasalt-sa, gocart+seasalt+dust) pass with the corrected key
- [x] Regression harness still cleans up its experiment directory after each run