### PR TITLE
GOCART2G regression: allow NaN-equal, tolerance, and exclude lat/lon vars in checkpoint comparison

### DIFF
--- a/ESMF/GOCART2G_GridComp/regression/run_case.cmake
+++ b/ESMF/GOCART2G_GridComp/regression/run_case.cmake
@@ -19,7 +19,7 @@ function(run_case case_name regression_data_dir)
   copy_restarts(${root_dir} ${expdir})
   link_directory(${regression_data_dir}/ExtData ${expdir}/ExtData)
   run_geos(${num_procs} ${case_name} ${expdir})
-  compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
+  compare_results(${checkpoints_dir} ${expdir}/checkpoints/last NANS_ARE_EQUAL TOLERANCE 3.5e-4 EXCLUDE_VARS lons corner_lons lats corner_lats)
 
   file(REMOVE_RECURSE ${expdir})
 endfunction()


### PR DESCRIPTION
## Summary
- ifort/ifx floating-point differences require a small tolerance to get a passing checkpoint comparison for the GOCART2G regression test
- Pass `NANS_ARE_EQUAL` and `TOLERANCE 3.5e-4` to `compare_results()`, using the new arguments added in ESMA_cmake
- Exclude `lons`/`corner_lons`/`lats`/`corner_lats` outright, since they diverge between ifort and ifx beyond what tolerance can absorb (tracked in #472)

## Test plan
- [ ] Confirm GOCART2G regression test passes with ifort and ifx builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)