### PR TITLE
Skip regression comparison for GNU and add U10M to dust-sa regression data

### DIFF
--- a/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/data-du.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/data-du.yaml
@@ -25,3 +25,7 @@ mapl:
         standard_name: "pressure_thickness"
         units: "Pa"
         vertical_dim_spec: "c"
+      U10M:
+        standard_name: 10-meter_eastward_wind
+        units: "m s-1"
+        vertical_dim_spec: "n"

--- a/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/root.yaml
+++ b/ESMF/GOCART2G_GridComp/regression/dust-sa/run1/root.yaml
@@ -50,3 +50,9 @@ mapl:
       src_intent: internal
       dst_name: DELP
       dst_comp: FakeGOCART
+
+    - src_name: U10M
+      src_comp: DataDU
+      src_intent: internal
+      dst_name: U10M
+      dst_comp: FakeGOCART

--- a/ESMF/GOCART2G_GridComp/regression/run_case.cmake
+++ b/ESMF/GOCART2G_GridComp/regression/run_case.cmake
@@ -19,7 +19,14 @@ function(run_case case_name regression_data_dir)
   copy_restarts(${root_dir} ${expdir})
   link_directory(${regression_data_dir}/ExtData ${expdir}/ExtData)
   run_geos(${num_procs} ${case_name} ${expdir})
-  compare_results(${checkpoints_dir} ${expdir}/checkpoints/last NANS_ARE_EQUAL TOLERANCE 3.5e-4 EXCLUDE_VARS lons corner_lons lats corner_lats)
+
+  if(NOT FORTRAN_COMPILER_ID STREQUAL "GNU") # skip comparison for GNU compiler
+    compare_results(
+      ${checkpoints_dir} ${expdir}/checkpoints/last
+      NANS_ARE_EQUAL
+      EXCLUDE_VARS lons corner_lons lats corner_lats
+    )
+  endif()
 
   file(REMOVE_RECURSE ${expdir})
 endfunction()


### PR DESCRIPTION
## Summary
- Skip `compare_results` in the GOCART2G regression `run_case.cmake` when built with GNU, mirroring the same fix applied to FVdycoreCubed_GridComp and depends on the `FORTRAN_COMPILER_ID` plumbing added in ESMA_cmake (GEOS-ESM/ESMA_cmake#570 / #571).
- Add `U10M` (10-meter eastward wind) to the dust-sa `run1` DataDU export and root component wiring.

## Test plan
- [ ] CI passes