### PR TITLE
GOCART2G regression: compare only against IntelLLVM baselines

### DIFF
--- a/ESMF/GOCART2G_GridComp/regression/run_case.cmake
+++ b/ESMF/GOCART2G_GridComp/regression/run_case.cmake
@@ -20,12 +20,8 @@ function(run_case case_name regression_data_dir)
   link_directory(${regression_data_dir}/ExtData ${expdir}/ExtData)
   run_geos(${num_procs} ${case_name} ${expdir})
 
-  if(NOT FORTRAN_COMPILER_ID STREQUAL "GNU") # skip comparison for GNU compiler
-    compare_results(
-      ${checkpoints_dir} ${expdir}/checkpoints/last
-      NANS_ARE_EQUAL
-      EXCLUDE_VARS lons corner_lons lats corner_lats
-    )
+  if(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
+    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last NANS_ARE_EQUAL)
   endif()
 
   file(REMOVE_RECURSE ${expdir})


### PR DESCRIPTION
Only run the checkpoint comparison in the GOCART2G_GridComp regression test when the Fortran compiler is IntelLLVM, since baselines are generated with IntelLLVM.