### PR TITLE
GOCART2G regression: exclude coordinate variables

### DIFF
--- a/ESMF/GOCART2G_GridComp/regression/run_case.cmake
+++ b/ESMF/GOCART2G_GridComp/regression/run_case.cmake
@@ -21,7 +21,10 @@ function(run_case case_name regression_data_dir)
   run_geos(${num_procs} ${case_name} ${expdir})
 
   if(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
-    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last NANS_ARE_EQUAL)
+    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last
+      NANS_ARE_EQUAL
+      EXCLUDE_VARS lons lats corner_lons corner_lats
+    )
   endif()
 
   file(REMOVE_RECURSE ${expdir})

--- a/ESMF/GOCART2G_GridComp/regression/run_case.cmake
+++ b/ESMF/GOCART2G_GridComp/regression/run_case.cmake
@@ -21,7 +21,8 @@ function(run_case case_name regression_data_dir)
   run_geos(${num_procs} ${case_name} ${expdir})
 
   if(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
-    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last
+    compare_results(
+      ${checkpoints_dir} ${expdir}/checkpoints/last
       NANS_ARE_EQUAL
       EXCLUDE_VARS lons lats corner_lons corner_lats
     )


### PR DESCRIPTION
Exclude longitude and latitude coordinate variables from GOCART2G checkpoint comparisons.

These coordinates should not determine the component regression result.