### PR TITLE
implement klid for SU and NI tracers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add local `ios` variable in `CO_Emission` to prevent host-association aliasing under optimization
 
 ### Added
-
+- setZeroKlid for non-radiatively active tracers in Run0
 ## [v2.6.6] - 2026-08-26
 
 ### Fixed

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -606,6 +606,11 @@ contains
     call setZeroKlid (self%km, self%klid, ptr3d_int)
     call MAPL_GetPointer (internal, name='NO3an3', ptr=ptr3d_int, __RC__)
     call setZeroKlid (self%km, self%klid, ptr3d_int)
+    call MAPL_GetPointer (internal, name='NH4a', ptr=ptr3d_int, __RC__)
+    call setZeroKlid (self%km, self%klid, ptr3d_int)
+    call MAPL_GetPointer (internal, name='NH3', ptr=ptr3d_int, __RC__)
+    call setZeroKlid (self%km, self%klid, ptr3d_int)
+    
 
     RETURN_(ESMF_SUCCESS)
 
@@ -837,6 +842,8 @@ contains
     call setZeroKlid (self%km, self%klid, NO3an1)
     call setZeroKlid (self%km, self%klid, NO3an2)
     call setZeroKlid (self%km, self%klid, NO3an3)
+    call setZeroKlid (self%km, self%klid, NH4a)
+    call setZeroKlid (self%km, self%klid, NH3)
 
     allocate(dqa, mold=lwi, __STAT__)
     allocate(drydepositionfrequency, mold=lwi, __STAT__)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -746,6 +746,13 @@ contains
     call findKlid (self%klid, self%plid, ple, __RC__)
     call MAPL_GetPointer (internal, NAME='SO4', ptr=ptr3d_int, __RC__)
     call setZeroKlid (self%km, self%klid, ptr3d_int)
+    call MAPL_GetPointer (internal, NAME='SO2', ptr=ptr3d_int, __RC__)
+    call setZeroKlid (self%km, self%klid, ptr3d_int)
+    call MAPL_GetPointer (internal, NAME='DMS', ptr=ptr3d_int, __RC__)
+    call setZeroKlid (self%km, self%klid, ptr3d_int)
+    call MAPL_GetPointer (internal, NAME='MSA', ptr=ptr3d_int, __RC__)
+    call setZeroKlid (self%km, self%klid, ptr3d_int)
+    
 
     RETURN_(ESMF_SUCCESS)
 
@@ -765,7 +772,7 @@ contains
     type (ESMF_Clock),    intent(inout) :: clock  ! The clock
     integer, optional,    intent(  out) :: rc     ! Error code:
 
-! !DESCRIPTION: Run method for the Sea Salt Grid Component. Determines whether to run
+! !DESCRIPTION: Run method for the Sulfate Component. Determines whether to run
 !               data or computational run method.
 
 !EOP
@@ -1219,6 +1226,9 @@ contains
 !   ---------------------------------------------------
     call findKlid (self%klid, self%plid, ple, __RC__)
     call setZeroKlid (self%km, self%klid, SO4)
+    call setZeroKlid (self%km, self%klid, SO2)
+    call setZeroKlid (self%km, self%klid, DMS)
+    call setZeroKlid (self%km, self%klid, MSA)
 
     thread = MAPL_get_current_thread()
     workspace => self%workspaces(thread)
@@ -1394,7 +1404,7 @@ contains
 
 !============================================================================
 !BOP
-! !IROUTINE: Run_data -- ExtData Sea Salt Grid Component
+! !IROUTINE: Run_data -- ExtData Sulfate Grid Component
 
 ! !INTERFACE:
 


### PR DESCRIPTION
This remedies the fact that radiatively active aerosol tracers are zeroed out above the klid but ammonium, ammonia, and sulfur dioxide are not. This is marked as zero diff as zeros will be introduced for these fields if klid is anything but 0.01 hPa in the instance files. It passes all regression testing.