### PR TITLE
Simplify callback field creation and access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Introduce new function to add fields to callback state and reference field when retrieving by long name, attribute logic was unneccessary
+
 ### Fixed
 
 ### Added

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -578,8 +578,8 @@ contains
     call ESMF_AttributeSet(aero, name='mie_table_instance', value=instance, __RC__)
 
     ! Add variables to CA instance's aero state. This is used in aerosol optics calculations
-    call add_aero (aero, label='air_pressure_for_aerosol_optics',      label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='relative_humidity_for_aerosol_optics', label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='air_pressure_for_aerosol_optics',      label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='relative_humidity_for_aerosol_optics', label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
 !   call ESMF_StateGet (import, 'PLE', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
 !   call ESMF_StateGet (import, 'RH2', field, __RC__)
@@ -587,21 +587,21 @@ contains
 
 !+++PRC
     ! Add variables to CA instance aero state for chemistry
-    call add_aero (aero, label='effective_radius_in_microns', label2='REFF', grid=grid, typekind=MAPL_R4,__RC__)
-    call add_aero (aero, label='surface_area_density', label2='SAREA', grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='effective_radius_in_microns', label2='REFF', grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='surface_area_density', label2='SAREA', grid=grid, typekind=MAPL_R4,__RC__)
 !---PRC
 
-    call add_aero (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
     call ESMF_ConfigGetAttribute (universal_cfg, nmom_, label='n_phase_function_moments_photolysis:', default=0,  __RC__)
     if(nmom_ > 0) then
-       call add_aero (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
+       call add_aero_named_alias (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
                       grid=grid, typekind=MAPL_R8, ungrid=nmom_, __RC__)
     endif
-    call add_aero (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
+    call add_aero_named_alias (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
                    label2='monochromatic_EXT', grid=grid, typekind=MAPL_R4,__RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
 
     call ESMF_AttributeSet(aero, name='band_for_aerosol_optics', value=0, __RC__)
     call ESMF_AttributeSet(aero, name='wavelength_for_aerosol_optics', value=0.0, __RC__)
@@ -1024,7 +1024,7 @@ contains
     real, pointer, dimension(:,:,:)       :: int_ptr
     real, allocatable, dimension(:,:,:,:) :: int_arr
     character(len=2)  :: GCsuffix
-    character(len=ESMF_MAXSTR)      :: short_name, fld_name
+    character(len=ESMF_MAXSTR)      :: short_name
     real, pointer, dimension(:,:,:)  :: intPtr_phobic, intPtr_philic
     real, pointer, dimension(:,:)     :: flux_ptr
 
@@ -1212,20 +1212,14 @@ contains
 
     if(associated(SAREA)) then
      nullify(int_ptr)
-     call ESMF_AttributeGet(aero, name='surface_area_density', value=fld_name, __RC__)
-     if (fld_name /= '') then
-         call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
-         int_ptr = SAREA
-     endif
+     call MAPL_GetPointer(aero, int_ptr, 'surface_area_density', __RC__)
+     int_ptr = SAREA
     endif
 
     if(associated(REFF)) then ! Note unit conversion below to microns
      nullify(int_ptr)
-     call ESMF_AttributeGet(aero, name='effective_radius_in_microns', value=fld_name, __RC__)
-     if (fld_name /= '') then
-         call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
-         int_ptr = REFF*1.e6
-     endif
+     call MAPL_GetPointer(aero, int_ptr, 'effective_radius_in_microns', __RC__)
+     int_ptr = REFF*1.e6
     endif
 
     i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)
@@ -1344,7 +1338,6 @@ contains
     type(C_PTR)                                      :: address
     type(CA2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
     character (len=ESMF_MAXSTR),allocatable          :: aerosol_names(:)
 
@@ -1358,6 +1351,7 @@ contains
     integer                                          :: usePhotTable
     real                                             :: wavelength
     integer :: i, j, k
+    type(ESMF_StateItem_Flag) :: item_type
 
     __Iam__('CA2G::aerosol_optics')
 
@@ -1385,8 +1379,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
@@ -1396,8 +1389,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
@@ -1436,30 +1428,30 @@ contains
        call mie_ (self%rad_Mie, nbins, band, q_4d, rh, ext_s, ssa_s, asy_s, __RC__)
     endif
 
-    call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ext_s(:,:,:)
+    call ESMF_StateGet(state, 'extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = ext_s(:,:,:)
     end if
 
-    call ESMF_AttributeGet(state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ssa_s(:,:,:)
+    call ESMF_StateGet(state, 'single_scattering_albedo_of_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'single_scattering_albedo_of_ambient_aerosol', __RC__)
+       var = ssa_s(:,:,:)
     end if
 
     if (usePhotTable /= 0) then
-       call ESMF_AttributeGet (state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var4d, trim(fld_name), __RC__)
-           var4d = pmom_s(:,:,:,:)
-     end if
+       call ESMF_StateGet(state, 'legendre_coefficients_of_p11_for_photolysis', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var4d, 'legendre_coefficients_of_p11_for_photolysis', __RC__)
+          var4d = pmom_s(:,:,:,:)
+       end if
     else
-       call ESMF_AttributeGet (state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
-           var = asy_s(:,:,:)
-     end if
+       call ESMF_StateGet(state, 'asymmetry_parameter_of_ambient_aerosol', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var, 'asymmetry_parameter_of_ambient_aerosol', __RC__)
+          var = asy_s(:,:,:)
+       end if
     end if
 
     deallocate(ext_s, ssa_s, asy_s, __STAT__)
@@ -1570,10 +1562,8 @@ contains
     type(C_PTR)                                      :: address
     type(CA2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
     character (len=ESMF_MAXSTR),allocatable          :: aerosol_names(:)
-
     real, dimension(:,:,:), allocatable              :: tau_s, tau  ! (lon:,lat:,lev:)
     real                                             :: x
     integer                                          :: instance
@@ -1581,6 +1571,7 @@ contains
     integer                                          :: i1, j1, i2, j2, km
     real                                             :: wavelength
     integer                                          :: i, j, k
+    type(ESMF_StateItem_Flag) :: item_type
 
     __Iam__('CA2G::monochromatic_aerosol_optics')
 
@@ -1602,8 +1593,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
     i1 = lbound(ple, 1); i2 = ubound(ple, 1)
@@ -1612,8 +1602,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
     allocate(tau_s(i1:i2, j1:j2, km), &
@@ -1649,9 +1638,9 @@ contains
        tau_s = tau_s + tau
     end do
 
-    call ESMF_AttributeGet(state, name='monochromatic_extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-       call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
+    call ESMF_StateGet(state, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', __RC__)
        var = sum(tau_s, dim=3)
     end if
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -508,8 +508,9 @@ contains
     call ESMF_StateGet (export, trim(COMP_NAME)//'_AERO_DP' , Bundle_DP, __RC__)
 
     call ESMF_StateGet (internal, 'DU', field, __RC__)
-    fld = MAPL_FieldCreate (field, 'DU', __RC__)
-    call MAPL_StateAdd (aero, fld, __RC__)
+    call MAPL_StateAdd (aero, field, __RC__)
+    !fld = MAPL_FieldCreate (field, 'DU', __RC__)
+    !call MAPL_StateAdd (aero, fld, __RC__)
 
     call ESMF_AttributeSet(field, NAME='ScavengingFractionPerKm', value=self%fscav(1), __RC__)
 
@@ -588,20 +589,20 @@ contains
 
 !   Add variables to DU instance's aero state. This is used in aerosol optics calculations
 !   --------------------------------------------------------------------------------------
-    call add_aero (aero, label='air_pressure_for_aerosol_optics',      label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='relative_humidity_for_aerosol_optics', label2='RH',  grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='air_pressure_for_aerosol_optics',      label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='relative_humidity_for_aerosol_optics', label2='RH',  grid=grid, typekind=MAPL_R4, __RC__)
 
-    call add_aero (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8, __RC__)
-    call add_aero (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8, __RC__)
-    call add_aero (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8, __RC__)
+    call add_aero_named_alias (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8, __RC__)
+    call add_aero_named_alias (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8, __RC__)
+    call add_aero_named_alias (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8, __RC__)
     call ESMF_ConfigGetAttribute (universal_cfg, nmom_, label='n_phase_function_moments_photolysis:', default=0,  __RC__)
     if(nmom_ > 0) then
-       call add_aero (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
+       call add_aero_named_alias (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
                       grid=grid, typekind=MAPL_R8, ungrid=nmom_, __RC__)
     endif
-    call add_aero (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', label2='monochromatic_EXT', &
+    call add_aero_named_alias (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', label2='monochromatic_EXT', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
 
     call ESMF_AttributeSet (aero, name='band_for_aerosol_optics', value=0, __RC__)
     call ESMF_AttributeSet (aero, name='wavelength_for_aerosol_optics', value=0., __RC__)
@@ -1228,7 +1229,6 @@ contains
     type(C_PTR)                                      :: address
     type(DU2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
 
     real(kind=DP), dimension(:,:,:), allocatable     :: ext_s, ssa_s, asy_s  ! (lon:,lat:,lev:)
@@ -1242,6 +1242,7 @@ contains
     real                                             :: wavelength
 
     integer :: k
+    type(ESMF_StateItem_Flag) :: item_type
 
     __Iam__('DU2G::aerosol_optics')
 
@@ -1263,8 +1264,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet (state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer (state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer (state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
@@ -1274,8 +1274,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet (state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer (state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer (state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
@@ -1313,30 +1312,30 @@ contains
        call mie_ (self%rad_Mie, nbins, band, q_4d, rh, ext_s, ssa_s, asy_s, __RC__)
     endif
 
-    call ESMF_AttributeGet (state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
-        var = ext_s(:,:,:)
+    call ESMF_StateGet(state, 'extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer (state, var, 'extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = ext_s(:,:,:)
     end if
 
-    call ESMF_AttributeGet (state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
+    call ESMF_StateGet(state, 'single_scattering_albedo_of_ambient_aerosol' ,item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+    call MAPL_GetPointer (state, var, 'single_scattering_albedo_of_ambient_aerosol', __RC__)
         var = ssa_s(:,:,:)
     end if
 
     if (usePhotTable /= 0) then
-       call ESMF_AttributeGet (state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var4d, trim(fld_name), __RC__)
-           var4d = pmom_s(:,:,:,:)
-     end if
+       call ESMF_StateGet(state, 'legendre_coefficients_of_p11_for_photolysis' ,item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var4d, 'legendre_coefficients_of_p11_for_photolysis', __RC__)
+          var4d = pmom_s(:,:,:,:)
+       end if
     else
-       call ESMF_AttributeGet (state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
-           var = asy_s(:,:,:)
-     end if
+       call ESMF_StateGet(state, 'asymmetry_parameter_of_ambient_aerosol' ,item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var, 'asymmetry_parameter_of_ambient_aerosol', __RC__)
+          var = asy_s(:,:,:)
+       end if
     end if
 
     deallocate(ext_s, ssa_s, asy_s, __STAT__)
@@ -1445,7 +1444,6 @@ contains
     type(C_PTR)                                      :: address
     type(DU2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
 
     real, dimension(:,:,:), allocatable              :: tau_s, tau, x ! (lon:,lat:,lev:)
@@ -1453,6 +1451,7 @@ contains
     integer                                          :: n, nbins, k
     integer                                          :: i1, j1, i2, j2, km, i, j
     real                                             :: wavelength
+    type(ESMF_StateItem_Flag) :: item_type
 
     __Iam__('DU2G::monochromatic_aerosol_optics')
 
@@ -1469,8 +1468,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet (state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer (state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer (state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
@@ -1480,8 +1478,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet (state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer (state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer (state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
@@ -1518,9 +1515,9 @@ contains
        tau_s = tau_s + tau
     end do
 
-    call ESMF_AttributeGet (state, name='monochromatic_extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-       call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
+    call ESMF_StateGet(state, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer (state, var, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', __RC__)
        var = sum(tau_s, dim=3)
     end if
 

--- a/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/GOCART2G_GridCompMod.F90
@@ -361,38 +361,38 @@ contains
 !   Begin AERO_RAD
 !   --------------
 !   Add variables to AERO_RAD state. Used in aerosol optics calculations
-    call add_aero (aero, label='air_pressure_for_aerosol_optics', label2='PLE', &
+    call add_aero_named_alias (aero, label='air_pressure_for_aerosol_optics', label2='PLE', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='relative_humidity_for_aerosol_optics', label2='RH', &
+    call add_aero_named_alias (aero, label='relative_humidity_for_aerosol_optics', label2='RH', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='extinction_in_air_due_to_ambient_aerosol', label2='EXT', &
+    call add_aero_named_alias (aero, label='extinction_in_air_due_to_ambient_aerosol', label2='EXT', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', &
+    call add_aero_named_alias (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='asymmetry_parameter_of_ambient_aerosol', label2='ASY', &
+    call add_aero_named_alias (aero, label='asymmetry_parameter_of_ambient_aerosol', label2='ASY', &
                    grid=grid, typekind=MAPL_R4, __RC__)
     call ESMF_ConfigGetAttribute (universal_cfg, nmom_, label='n_phase_function_moments_photolysis:', default=0,  __RC__)
     if(nmom_ > 0) then
-       call add_aero (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
+       call add_aero_named_alias (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
                       grid=grid, typekind=MAPL_R4, ungrid=nmom_, __RC__)
     endif
-    call add_aero (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
+    call add_aero_named_alias (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
                    label2='monochromatic_EXT', grid=grid, typekind=MAPL_R4, __RC__)
 
 !   Used in get_mixRatioSum
-    call add_aero (aero, label='sum_of_internalState_aerosol_DU', label2='aerosolSumDU', &
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol_DU', label2='aerosolSumDU', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol_SS', label2='aerosolSumSS', &
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol_SS', label2='aerosolSumSS', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol_NI', label2='aerosolSumNI', &
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol_NI', label2='aerosolSumNI', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol_CA.oc', label2='aerosolSumCA.oc', &
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol_CA.oc', label2='aerosolSumCA.oc', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol_CA.bc', label2='aerosolSumCA.bc', &
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol_CA.bc', label2='aerosolSumCA.bc', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol_CA.br', label2='aerosolSumCA.br', &
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol_CA.br', label2='aerosolSumCA.br', &
                    grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol_SU', label2='aerosolSumSU', &
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol_SU', label2='aerosolSumSU', &
                    grid=grid, typekind=MAPL_R4, __RC__)
 
     call ESMF_AttributeSet(aero, name='band_for_aerosol_optics', value=0, __RC__)
@@ -443,16 +443,16 @@ contains
     call ESMF_AttributeSet(aero, name='ccn_tuning', value=CCNtuning, __RC__)
 
 !   Add variables to AERO state
-    call add_aero (aero, label='air_temperature', label2='T', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='fraction_of_land_type', label2='FRLAND', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='width_of_aerosol_mode', label2='SIGMA', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='aerosol_number_concentration', label2='NUM', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='aerosol_dry_size', label2='DGN', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='aerosol_density', label2='density', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='aerosol_hygroscopicity', label2='KAPPA', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='fraction_of_dust_aerosol', label2='FDUST', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='fraction_of_soot_aerosol', label2='FSOOT', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='fraction_of_organic_aerosol', label2='FORGANIC', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='air_temperature', label2='T', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='fraction_of_land_type', label2='FRLAND', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='width_of_aerosol_mode', label2='SIGMA', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='aerosol_number_concentration', label2='NUM', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='aerosol_dry_size', label2='DGN', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='aerosol_density', label2='density', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='aerosol_hygroscopicity', label2='KAPPA', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='fraction_of_dust_aerosol', label2='FDUST', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='fraction_of_soot_aerosol', label2='FSOOT', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='fraction_of_organic_aerosol', label2='FORGANIC', grid=grid, typekind=MAPL_R4, __RC__)
 
 !   Attach the aerosol optics method
     call ESMF_MethodAdd(aero, label='aerosol_activation_properties', userRoutine=aerosol_activation_properties, __RC__)
@@ -1575,6 +1575,7 @@ contains
     real, pointer,     dimension(:,:,:)              :: as_ptr_3d
 
     type (ESMF_StateItem_Flag), allocatable          :: itemTypes(:)
+    type (ESMF_StateItem_Flag)                       :: item_type
 
     __Iam__('GOCART2G::run_aerosol_optics')
 
@@ -1596,13 +1597,11 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, RH, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, RH, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, PLE, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, PLE, 'air_pressure_for_aerosol_optics', __RC__)
 
     i1 = lbound(ple, 1); i2 = ubound(ple, 1)
     j1 = lbound(ple, 2); j2 = ubound(ple, 2)
@@ -1647,18 +1646,24 @@ contains
         call ESMF_StateGet(state, trim(aeroList(i)), child_state, __RC__)
 
 !       ! set RH in child's aero state
-        call ESMF_AttributeGet(child_state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
+        !call ESMF_AttributeGet(child_state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
 
-        if (fld_name /= '') then
-            call MAPL_GetPointer(child_state, as_ptr_3d, trim(fld_name), __RC__)
+        call ESMF_StateGet(child_state, 'relative_humidity_for_aerosol_optics', item_type, _RC)
+        !if (fld_name /= '') then
+        if (item_type == ESMF_STATEITEM_FIELD) then
+            !call MAPL_GetPointer(child_state, as_ptr_3d, trim(fld_name), __RC__)
+            call MAPL_GetPointer(child_state, as_ptr_3d, 'relative_humidity_for_aerosol_optics', __RC__)
             as_ptr_3d = rh
         end if
 
 !       ! set PLE in child's aero state
-        call ESMF_AttributeGet(child_state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
+        !call ESMF_AttributeGet(child_state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
 
-        if (fld_name /= '') then
-            call MAPL_GetPointer(child_state, as_ptr_3d, trim(fld_name), __RC__)
+        call ESMF_StateGet(child_state, 'air_pressure_for_aerosol_optics', item_type, _RC)
+        !if (fld_name /= '') then
+        if (item_type == ESMF_STATEITEM_FIELD) then
+            !call MAPL_GetPointer(child_state, as_ptr_3d, trim(fld_name), __RC__)
+            call MAPL_GetPointer(child_state, as_ptr_3d, 'air_pressure_for_aerosol_optics', __RC__)
             as_ptr_3d = ple
         end if
 
@@ -1672,30 +1677,42 @@ contains
         call ESMF_MethodExecute(child_state, label="aerosol_optics", __RC__)
 
 !       ! Retrieve extinction from each child
-        call ESMF_AttributeGet(child_state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-        if (fld_name /= '') then
-            call MAPL_GetPointer(child_state, ext_, trim(fld_name), __RC__)
+        !call ESMF_AttributeGet(child_state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
+        call ESMF_StateGet(child_state, 'extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+        !if (fld_name /= '') then
+        if (item_type == ESMF_STATEITEM_FIELD) then
+            !call MAPL_GetPointer(child_state, ext_, trim(fld_name), __RC__)
+            call MAPL_GetPointer(child_state, ext_, 'extinction_in_air_due_to_ambient_aerosol', __RC__)
         end if
 
 !       ! Retrieve scattering from each child
-        call ESMF_AttributeGet(child_state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
-        if (fld_name /= '') then
-            call MAPL_GetPointer(child_state, ssa_, trim(fld_name), __RC__)
+        !call ESMF_AttributeGet(child_state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
+        call ESMF_StateGet(child_state, 'single_scattering_albedo_of_ambient_aerosol', item_type, _RC)
+        !if (fld_name /= '') then
+        if (item_type == ESMF_STATEITEM_FIELD) then
+            !call MAPL_GetPointer(child_state, ssa_, trim(fld_name), __RC__)
+            call MAPL_GetPointer(child_state, ssa_, 'single_scattering_albedo_of_ambient_aerosol', __RC__)
         end if
 
 !       ! If for radiation retrieve asymmetry parameter multiplied by scattering from each child
 !       ! If for photolysis retrieve the phase function moments multipled by the scattering from each child
 
         if(usePhotTable /= 0) then
-          call ESMF_AttributeGet(child_state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
-          if (fld_name /= '') then
-              call MAPL_GetPointer(child_state, pmom_, trim(fld_name), __RC__)
+          !call ESMF_AttributeGet(child_state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
+          call ESMF_StateGet(child_state, 'legendre_coefficients_of_p11_for_photolysis', item_type, _RC)
+          !if (fld_name /= '') then
+          if (item_type == ESMF_STATEITEM_FIELD) then
+              !call MAPL_GetPointer(child_state, pmom_, trim(fld_name), __RC__)
+              call MAPL_GetPointer(child_state, pmom_, 'legendre_coefficients_of_p11_for_photolysis', __RC__)
           end if
 
         else
-          call ESMF_AttributeGet(child_state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
-          if (fld_name /= '') then
-              call MAPL_GetPointer(child_state, asy_, trim(fld_name), __RC__)
+          !call ESMF_AttributeGet(child_state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
+          call ESMF_StateGet(child_state, 'asymmetry_parameter_of_ambient_aerosol', item_type, _RC)
+          !if (fld_name /= '') then
+          if (item_type == ESMF_STATEITEM_FIELD) then
+              !call MAPL_GetPointer(child_state, asy_, trim(fld_name), __RC__)
+              call MAPL_GetPointer(child_state, asy_, 'asymmetry_parameter_of_ambient_aerosol', __RC__)
           end if
        end if
 
@@ -1713,27 +1730,39 @@ contains
 
 !   ! Set ext, ssa, asy to equal the sum of ext, ssa, asy from the children.
     ! This is what is passed to radiation or photolysis.
-    call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
+    !call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
+    call ESMF_StateGet(state, 'extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+    !if (fld_name /= '') then
+        !call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
+        call MAPL_GetPointer(state, var, 'extinction_in_air_due_to_ambient_aerosol', __RC__)
         var = ext(:,:,:)
     end if
 
-    call ESMF_AttributeGet(state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
+    !call ESMF_AttributeGet(state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
+    call ESMF_StateGet(state, 'single_scattering_albedo_of_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+    !if (fld_name /= '') then
+        !call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
+        call MAPL_GetPointer(state, var, 'single_scattering_albedo_of_ambient_aerosol', __RC__)
         var = ssa(:,:,:)
     end if
     if(usePhotTable /= 0) then
-       call ESMF_AttributeGet(state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer(state, var4d, trim(fld_name), __RC__)
+       !call ESMF_AttributeGet(state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
+       call ESMF_StateGet(state, 'legendre_coefficients_of_p11_for_photolysis', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+       !if (fld_name /= '') then
+           !call MAPL_GetPointer(state, var4d, trim(fld_name), __RC__)
+           call MAPL_GetPointer(state, var4d, 'legendre_coefficients_of_p11_for_photolysis', __RC__)
            var4d = pmom(:,:,:,:)
        end if
     else
-       call ESMF_AttributeGet(state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
+       !call ESMF_AttributeGet(state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
+       call ESMF_StateGet(state, 'asymmetry_parameter_of_ambient_aerosol', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+       !if (fld_name /= '') then
+           !call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
+           call MAPL_GetPointer(state, var, 'asymmetry_parameter_of_ambient_aerosol', __RC__)
            var = asy(:,:,:)
        end if
     end if
@@ -1786,8 +1815,6 @@ contains
 
     real                            :: max_clean          ! max mixing ratio before considered polluted
     real                            :: ccn_tuning         ! tunes conversion factors for sulfate
-
-    character(len=ESMF_MAXSTR)      :: fld_name
 
     integer                         :: i2, j2, km
     integer                         :: b, i, j, n, aerosol_bin
@@ -1850,18 +1877,15 @@ contains
 
 !   Land fraction
 !   -------------
-    call ESMF_AttributeGet(state, name='fraction_of_land_type', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, f_land, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, f_land, 'fraction_of_land_type', __RC__)
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !   Temperature
 !   -----------
-    call ESMF_AttributeGet(state, name='air_temperature', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, temperature, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, temperature, 'air_temperature', __RC__)
 
     i2 = ubound(temperature, 1)
     j2 = ubound(temperature, 2)
@@ -1869,29 +1893,21 @@ contains
 
 !   Activation activation properties
 !   --------------------------------
-    call ESMF_AttributeGet(state, name='aerosol_number_concentration', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, num, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, num, 'aerosol_number_concentration', __RC__)
 
-    call ESMF_AttributeGet(state, name='aerosol_dry_size', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, diameter, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, diameter, 'aerosol_dry_size', __RC__)
 
-    call ESMF_AttributeGet(state, name='width_of_aerosol_mode', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, sigma, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, sigma, 'width_of_aerosol_mode', __RC__)
 
-    call ESMF_AttributeGet(state, name='aerosol_density', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, density, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, density, 'aerosol_density', __RC__)
 
-    call ESMF_AttributeGet(state, name='aerosol_hygroscopicity', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, hygroscopicity, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, hygroscopicity, 'aerosol_hygroscopicity', __RC__)
 
-    call ESMF_AttributeGet(state, name='fraction_of_dust_aerosol', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, f_dust, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, f_dust, 'fraction_of_dust_aerosol', __RC__)
 
-    call ESMF_AttributeGet(state, name='fraction_of_soot_aerosol', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, f_soot, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, f_soot, 'fraction_of_soot_aerosol', __RC__)
 
-    call ESMF_AttributeGet(state, name='fraction_of_organic_aerosol', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, f_organic, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, f_organic, 'fraction_of_organic_aerosol', __RC__)
 
 !   Sea salt scaling fctor
 !   ----------------------
@@ -2298,13 +2314,11 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, RH, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, RH, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, PLE, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, PLE, 'air_pressure_for_aerosol_optics', __RC__)
 
     i1 = lbound(ple, 1); i2 = ubound(ple, 1)
     j1 = lbound(ple, 2); j2 = ubound(ple, 2)

--- a/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/NI2G_GridComp/NI2G_GridCompMod.F90
@@ -502,24 +502,24 @@ contains
     call ESMF_AttributeSet(aero, name='mie_table_instance', value=instance, __RC__)
 
     ! Add variables to NI instance's aero state. This is used in aerosol optics calculations
-    call add_aero (aero, label='air_pressure_for_aerosol_optics',             label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='relative_humidity_for_aerosol_optics',        label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='air_pressure_for_aerosol_optics',             label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='relative_humidity_for_aerosol_optics',        label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
 !   call ESMF_StateGet (import, 'PLE', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
 !   call ESMF_StateGet (import, 'RH2', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
 
-    call add_aero (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
     call ESMF_ConfigGetAttribute (universal_cfg, nmom_, label='n_phase_function_moments_photolysis:', default=0,  __RC__)
     if(nmom_ > 0) then
-       call add_aero (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
+       call add_aero_named_alias (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
                       grid=grid, typekind=MAPL_R8, ungrid=nmom_, __RC__)
     endif
-    call add_aero (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
+    call add_aero_named_alias (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
                    label2='monochromatic_EXT', grid=grid, typekind=MAPL_R4,__RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
 
     call ESMF_AttributeSet (aero, name='band_for_aerosol_optics', value=0, __RC__)
     call ESMF_AttributeSet (aero, name='wavelength_for_aerosol_optics', value=0., __RC__)
@@ -1194,7 +1194,6 @@ contains
     type(C_PTR)                                      :: address
     type(NI2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
     character (len=ESMF_MAXSTR),allocatable          :: aerosol_names(:)
 
@@ -1208,6 +1207,7 @@ contains
     integer                                          :: usePhotTable
     real                                             :: wavelength
     integer :: i, j, k
+    type(ESMF_StateItem_Flag) :: item_type
 
     __Iam__('NI2G::aerosol_optics')
 
@@ -1235,8 +1235,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
@@ -1246,8 +1245,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
@@ -1286,30 +1284,30 @@ contains
        call mie_ (self%rad_Mie, nbins, band, q_4d, rh, ext_s, ssa_s, asy_s, __RC__)
     endif
 
-    call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ext_s(:,:,:)
+    call ESMF_StateGet(state, 'extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = ext_s(:,:,:)
     end if
 
-    call ESMF_AttributeGet(state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ssa_s(:,:,:)
+    call ESMF_StateGet(state, 'single_scattering_albedo_of_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'single_scattering_albedo_of_ambient_aerosol', __RC__)
+       var = ssa_s(:,:,:)
     end if
 
     if (usePhotTable /= 0) then
-       call ESMF_AttributeGet (state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var4d, trim(fld_name), __RC__)
-           var4d = pmom_s(:,:,:,:)
-     end if
+       call ESMF_StateGet(state, 'legendre_coefficients_of_p11_for_photolysis', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var4d, 'legendre_coefficients_of_p11_for_photolysis', __RC__)
+          var4d = pmom_s(:,:,:,:)
+       end if
     else
-       call ESMF_AttributeGet (state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
-           var = asy_s(:,:,:)
-     end if
+       call ESMF_StateGet(state, 'asymmetry_parameter_of_ambient_aerosol', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var, 'asymmetry_parameter_of_ambient_aerosol', __RC__)
+          var = asy_s(:,:,:)
+       end if
     end if
 
     deallocate(ext_s, ssa_s, asy_s, __STAT__)
@@ -1421,7 +1419,6 @@ contains
     type(C_PTR)                                      :: address
     type(NI2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
     character (len=ESMF_MAXSTR),allocatable          :: aerosol_names(:)
 
@@ -1432,6 +1429,7 @@ contains
     integer                                          :: i1, j1, i2, j2, km
     real                                             :: wavelength
     integer :: i, j, k
+    type(ESMF_StateItem_Flag) :: item_type
 
     __Iam__('NI2G:: monochromatic_aerosol_optics')
 
@@ -1454,8 +1452,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
     i1 = lbound(ple, 1); i2 = ubound(ple, 1)
@@ -1464,8 +1461,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
     allocate(tau_s(i1:i2, j1:j2, km), &
@@ -1501,10 +1497,10 @@ contains
        tau_s = tau_s + tau
     end do
 
-    call ESMF_AttributeGet(state, name='monochromatic_extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = sum(tau_s, dim=3)
+    call ESMF_StateGet(state, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = sum(tau_s, dim=3)
     end if
 
     deallocate(q_4d, __STAT__)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -513,23 +513,23 @@ contains
     call ESMF_AttributeSet(aero, name='mie_table_instance', value=instance, __RC__)
 
     ! Add variables to SS instance's aero state. This is used in aerosol optics calculations
-    call add_aero (aero, label='air_pressure_for_aerosol_optics',             label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='relative_humidity_for_aerosol_optics',        label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='air_pressure_for_aerosol_optics',             label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='relative_humidity_for_aerosol_optics',        label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
 !   call ESMF_StateGet (import, 'PLE', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
 !   call ESMF_StateGet (import, 'RH2', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
-    call add_aero (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
     call ESMF_ConfigGetAttribute (universal_cfg, nmom_, label='n_phase_function_moments_photolysis:', default=0,  __RC__)
     if(nmom_ > 0) then
-       call add_aero (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
+       call add_aero_named_alias (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
                       grid=grid, typekind=MAPL_R8, ungrid=nmom_, __RC__)
     endif
-    call add_aero (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
+    call add_aero_named_alias (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
                    label2='monochromatic_EXT', grid=grid, typekind=MAPL_R4,__RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
     call ESMF_AttributeSet (aero, name='band_for_aerosol_optics', value=0, __RC__)
     call ESMF_AttributeSet (aero, name='wavelength_for_aerosol_optics', value=0., __RC__)
     mieTable_pointer = transfer(c_loc(self), [1])
@@ -1069,6 +1069,7 @@ contains
     integer                                          :: usePhotTable
     real                                             :: wavelength
     integer ::  k
+    type(ESMF_StateItem_Flag) :: item_type
 
     __Iam__('SS2G::aerosol_optics')
 
@@ -1090,8 +1091,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
@@ -1101,8 +1101,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
@@ -1141,30 +1140,30 @@ contains
        call mie_ (self%rad_Mie, nbins, band, q_4d, rh, ext_s, ssa_s, asy_s, __RC__)
     endif
 
-    call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ext_s(:,:,:)
+    call ESMF_StateGet(state, 'extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = ext_s(:,:,:)
     end if
 
-    call ESMF_AttributeGet(state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ssa_s(:,:,:)
+    call ESMF_StateGet(state, 'single_scattering_albedo_of_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'single_scattering_albedo_of_ambient_aerosol', __RC__)
+       var = ssa_s(:,:,:)
     end if
 
     if (usePhotTable /= 0) then
-       call ESMF_AttributeGet (state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var4d, trim(fld_name), __RC__)
-           var4d = pmom_s(:,:,:,:)
-     end if
+       call ESMF_StateGet(state, 'legendre_coefficients_of_p11_for_photolysis', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var4d, 'legendre_coefficients_of_p11_for_photolysis', __RC__)
+          var4d = pmom_s(:,:,:,:)
+       end if
     else
-       call ESMF_AttributeGet (state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
-           var = asy_s(:,:,:)
-     end if
+       call ESMF_StateGet(state, 'asymmetry_parameter_of_ambient_aerosol', item_type, _RC)
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var, 'asymmetry_parameter_of_ambient_aerosol', __RC__)
+          var = asy_s(:,:,:)
+       end if
     end if
 
     deallocate(ext_s, ssa_s, asy_s, __STAT__)
@@ -1178,7 +1177,7 @@ contains
     subroutine mie_(mie, nbins, band, q, rh, bext_s, bssa_s, basym_s, rc)
 
     implicit none
-
+ 
     type(GOCART2G_Mie),            intent(inout) :: mie              ! mie table
     integer,                       intent(in   ) :: nbins            ! number of bins
     integer,                       intent(in )   :: band             ! channel
@@ -1282,6 +1281,7 @@ contains
     integer                                          :: n, nbins, k
     integer                                          :: i1, j1, i2, j2, km, i, j
     real                                             :: wavelength
+    type(ESMF_StateItem_Flag)                        :: item_type
 
     __Iam__('SS2G::monochromatic_aerosol_optics')
 
@@ -1298,8 +1298,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet (state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer (state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer (state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
@@ -1309,8 +1308,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet (state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer (state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer (state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
@@ -1347,10 +1345,10 @@ contains
        tau_s = tau_s + tau
     end do
 
-    call ESMF_AttributeGet (state, name='monochromatic_extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
-        var = sum(tau_s, dim=3)
+    call ESMF_StateGet(state, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer (state, var, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = sum(tau_s, dim=3)
     end if
 
     deallocate(q_4d, __STAT__)

--- a/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SU2G_GridComp/SU2G_GridCompMod.F90
@@ -647,28 +647,28 @@ contains
     call ESMF_AttributeSet(aero, name='mie_table_instance', value=instance, __RC__)
 
     ! Add variables to SU instance's aero state. This is used in aerosol optics calculations
-    call add_aero (aero, label='air_pressure_for_aerosol_optics',             label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='relative_humidity_for_aerosol_optics',        label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='air_pressure_for_aerosol_optics',             label2='PLE', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='relative_humidity_for_aerosol_optics',        label2='RH',  grid=grid, typekind=MAPL_R4,__RC__)
 !   call ESMF_StateGet (import, 'PLE', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
 !   call ESMF_StateGet (import, 'RH2', field, __RC__)
 !   call MAPL_StateAdd (aero, field, __RC__)
 
     ! Add variables to SU instance aero state for chemistry
-    call add_aero (aero, label='surface_area_density', label2='SAREA', grid=grid, typekind=MAPL_R4,__RC__)
-    call add_aero (aero, label='effective_radius_in_microns', label2='REFF', grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='surface_area_density', label2='SAREA', grid=grid, typekind=MAPL_R4,__RC__)
+    call add_aero_named_alias (aero, label='effective_radius_in_microns', label2='REFF', grid=grid, typekind=MAPL_R4,__RC__)
 
-    call add_aero (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
-    call add_aero (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='extinction_in_air_due_to_ambient_aerosol',    label2='EXT', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='single_scattering_albedo_of_ambient_aerosol', label2='SSA', grid=grid, typekind=MAPL_R8,__RC__)
+    call add_aero_named_alias (aero, label='asymmetry_parameter_of_ambient_aerosol',      label2='ASY', grid=grid, typekind=MAPL_R8,__RC__)
     call ESMF_ConfigGetAttribute (universal_cfg, nmom_, label='n_phase_function_moments_photolysis:', default=0,  __RC__)
     if(nmom_ > 0) then
-       call add_aero (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
+       call add_aero_named_alias (aero, label='legendre_coefficients_of_p11_for_photolysis', label2='MOM', &
                       grid=grid, typekind=MAPL_R8, ungrid=nmom_, __RC__)
     endif
-    call add_aero (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
+    call add_aero_named_alias (aero, label='monochromatic_extinction_in_air_due_to_ambient_aerosol', &
                    label2='monochromatic_EXT', grid=grid, typekind=MAPL_R4, __RC__)
-    call add_aero (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
+    call add_aero_named_alias (aero, label='sum_of_internalState_aerosol', label2='aerosolSum', grid=grid, typekind=MAPL_R4, __RC__)
 
     call ESMF_AttributeSet (aero, name='band_for_aerosol_optics', value=0, __RC__)
     call ESMF_AttributeSet (aero, name='wavelength_for_aerosol_optics', value=0., __RC__)
@@ -1155,7 +1155,7 @@ contains
     logical                           :: KIN
     real, pointer, dimension(:,:)     :: lats
     real, pointer, dimension(:,:)     :: lons
-    character(len=ESMF_MAXSTR)        :: short_name, fld_name
+    character(len=ESMF_MAXSTR)        :: short_name
     real, pointer, dimension(:,:,:)   :: int_ptr
 
     real, dimension(:,:,:), allocatable :: xoh, xno3, xh2o2
@@ -1172,6 +1172,7 @@ contains
     real, target, allocatable, dimension(:,:,:)   :: RH20,RH80
     real, pointer, dimension(:,:)     :: flux_ptr
     integer :: settling_opt
+    type(ESMF_StateItem_Flag) :: item_type
 #include "SU2G_DeclarePointer___.h"
 
     __Iam__('Run2')
@@ -1342,20 +1343,20 @@ contains
 
     if(associated(SO4SAREA)) then
       nullify(int_ptr)
-      call ESMF_AttributeGet(aero, name='surface_area_density', value=fld_name, __RC__)
-      if (fld_name /= '') then
-          call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
-          int_ptr = SO4SAREA
-      endif
+      call ESMF_StateGet(aero, 'surface_area_density', item_type, _RC)
+      if (item_type == ESMF_STATEITEM_FIELD) then
+         call MAPL_GetPointer(aero, int_ptr, 'surface_area_density', __RC__)
+         int_ptr = SO4SAREA
+      end if
     endif
 
     if(associated(SO4REFF)) then ! Note unit conversion below to microns
       nullify(int_ptr)
-      call ESMF_AttributeGet(aero, name='effective_radius_in_microns', value=fld_name, __RC__)
-      if (fld_name /= '') then
-          call MAPL_GetPointer(aero, int_ptr, trim(fld_name), __RC__)
-          int_ptr = SO4REFF*1.e6
-      endif
+      call ESMF_StateGet(aero, 'effective_radius_in_microns', item_type, _RC)
+      if (item_type == ESMF_STATEITEM_FIELD) then
+         call MAPL_GetPointer(aero, int_ptr, 'effective_radius_in_microns', __RC__)
+         int_ptr = SO4REFF*1.e6
+      end if
     endif
 
     i1 = lbound(RH2, 1); i2 = ubound(RH2, 1)
@@ -1466,7 +1467,6 @@ contains
     type(C_PTR)                                      :: address
     type(SU2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
     character (len=ESMF_MAXSTR),allocatable          :: aerosol_names(:)
 
@@ -1481,6 +1481,7 @@ contains
     real                                             :: wavelength
 
     integer :: i, j, k
+    type(ESMF_StateItem_Flag)                        :: item_type
 
     __Iam__('SU2G::aerosol_optics')
 
@@ -1508,8 +1509,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
@@ -1519,8 +1519,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
@@ -1559,30 +1558,27 @@ contains
        call mie_ (self%rad_Mie, nbins, band, q_4d, rh, ext_s, ssa_s, asy_s, __RC__)
     endif
 
-    call ESMF_AttributeGet(state, name='extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ext_s(:,:,:)
+    call ESMF_StateGet(state, 'extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = ext_s(:,:,:)
     end if
 
-    call ESMF_AttributeGet(state, name='single_scattering_albedo_of_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = ssa_s(:,:,:)
+    if (item_type == ESMF_STATEITEM_FIELD) then
+       call MAPL_GetPointer(state, var, 'single_scattering_albedo_of_ambient_aerosol', __RC__)
+       var = ssa_s(:,:,:)
     end if
 
     if (usePhotTable /= 0) then
-       call ESMF_AttributeGet (state, name='legendre_coefficients_of_p11_for_photolysis', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var4d, trim(fld_name), __RC__)
-           var4d = pmom_s(:,:,:,:)
-     end if
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var4d, 'legendre_coefficients_of_p11_for_photolysis', __RC__)
+          var4d = pmom_s(:,:,:,:)
+       end if
     else
-       call ESMF_AttributeGet (state, name='asymmetry_parameter_of_ambient_aerosol', value=fld_name, __RC__)
-       if (fld_name /= '') then
-           call MAPL_GetPointer (state, var, trim(fld_name), __RC__)
-           var = asy_s(:,:,:)
-     end if
+       if (item_type == ESMF_STATEITEM_FIELD) then
+          call MAPL_GetPointer (state, var, 'asymmetry_parameter_of_ambient_aerosol', __RC__)
+          var = asy_s(:,:,:)
+       end if
     end if
 
     deallocate(ext_s, ssa_s, asy_s, __STAT__)
@@ -1693,7 +1689,6 @@ contains
     type(C_PTR)                                      :: address
     type(SU2G_GridComp), pointer                     :: self
 
-    character (len=ESMF_MAXSTR)                      :: fld_name
     type(ESMF_Field)                                 :: fld
     character (len=ESMF_MAXSTR),allocatable          :: aerosol_names(:)
 
@@ -1704,6 +1699,7 @@ contains
     integer                                          :: i1, j1, i2, j2, km
     real                                             :: wavelength
     integer :: i, j, k
+    type(ESMF_StateItem_Flag)                        :: item_type
 
     __Iam__('SU2G::monochromatic_aerosol_optics')
 
@@ -1726,8 +1722,7 @@ contains
 
 !   Pressure at layer edges
 !   ------------------------
-    call ESMF_AttributeGet(state, name='air_pressure_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, ple, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, ple, 'air_pressure_for_aerosol_optics', __RC__)
 !    call MAPL_GetPointer (state, ple, 'PLE', __RC__)
 
     i1 = lbound(ple, 1); i2 = ubound(ple, 1)
@@ -1736,8 +1731,7 @@ contains
 
 !   Relative humidity
 !   -----------------
-    call ESMF_AttributeGet(state, name='relative_humidity_for_aerosol_optics', value=fld_name, __RC__)
-    call MAPL_GetPointer(state, rh, trim(fld_name), __RC__)
+    call MAPL_GetPointer(state, rh, 'relative_humidity_for_aerosol_optics', __RC__)
 !    call MAPL_GetPointer (state, rh, 'RH2', __RC__)
 
     allocate(tau_s(i1:i2, j1:j2, km), &
@@ -1773,10 +1767,10 @@ contains
        tau_s = tau_s + tau
     end do
 
-    call ESMF_AttributeGet(state, name='monochromatic_extinction_in_air_due_to_ambient_aerosol', value=fld_name, __RC__)
-    if (fld_name /= '') then
-        call MAPL_GetPointer(state, var, trim(fld_name), __RC__)
-        var = sum(tau_s, dim=3)
+    call ESMF_StateGet(state, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', item_type, _RC)
+    if (item_type == ESMF_STATEITEM_FIELD) then 
+       call MAPL_GetPointer(state, var, 'monochromatic_extinction_in_air_due_to_ambient_aerosol', __RC__)
+       var = sum(tau_s, dim=3)
     end if
 
     deallocate(q_4d, __STAT__)

--- a/ESMF/Shared/Chem_AeroGeneric.F90
+++ b/ESMF/Shared/Chem_AeroGeneric.F90
@@ -25,6 +25,7 @@ module  Chem_AeroGeneric
 !
 ! !PUBLIC MEMBER FUNCTIONS:
    public add_aero
+   public add_aero_named_alias
    public append_to_bundle
    public determine_data_driven
    public setZeroKlid
@@ -98,6 +99,59 @@ contains
     RETURN_(ESMF_SUCCESS)
 
   end subroutine add_aero
+
+!=====================================================================================
+
+!====================================================================================
+  subroutine add_aero_named_alias (state, label, label2, grid, typekind, ptr, ungrid, rc)
+
+!   Description: Adds fields to aero state for aerosol optics calcualtions.
+
+    implicit none
+
+    type (ESMF_State),                          intent(inout)     :: state
+    character (len=*),                          intent(in   )     :: label
+    character (len=*),                          intent(in   )     :: label2
+    type (ESMF_Grid),                           intent(inout)     :: grid
+    integer,                                    intent(in   )     :: typekind
+    real, pointer, dimension(:,:,:), optional,  intent(in   )     :: ptr
+    integer, optional,                          intent(in   )     :: ungrid
+    integer,                                    intent(  out)     :: rc
+    
+    ! locals
+    type (ESMF_Field)                                             :: field
+    character (len=ESMF_MAXSTR)                                   :: field_name
+    type (ESMF_Field)                                             :: field_alias
+
+    __Iam__('add_aero_named_alias')
+
+!----------------------------------------------------------------------------------
+!   Begin...
+
+    call ESMF_AttributeSet (state, name=trim(label), value=trim(label2),  __RC__)
+
+    field_name = label
+    if (label /= '') then
+       field = MAPL_FieldCreateEmpty(trim(field_name), grid, __RC__)
+       if (trim(label2) == 'PLE') then
+          call MAPL_FieldAllocCommit (field, dims=MAPL_DimsHorzVert, location=MAPL_VLocationEdge, typekind=typekind, hw=0, __RC__)
+       else if ((trim(label2) == 'FRLAND') .or. (trim(label2) == 'monochromatic_EXT')) then
+          call MAPL_FieldAllocCommit(field, dims=MAPL_DimsHorzOnly, location=MAPL_VLocationCenter, typekind=MAPL_R4, hw=0, __RC__)
+       else
+          if(present(ungrid)) then
+             call MAPL_FieldAllocCommit (field, dims=MAPL_DimsHorzVert, location=MAPL_VLocationCenter, typekind=typekind, ungrid=[ungrid], hw=0, __RC__)
+          else        
+             call MAPL_FieldAllocCommit (field, dims=MAPL_DimsHorzVert, location=MAPL_VLocationCenter, typekind=typekind, hw=0, __RC__)
+          end if
+       end if
+       field_alias = ESMF_NamedAlias(field, name=label2, __RC__)
+       call MAPL_StateAdd (state, field, __RC__)
+       call MAPL_StateAdd (state, field_alias, __RC__)
+    end if
+
+    RETURN_(ESMF_SUCCESS)
+
+  end subroutine add_aero_named_alias
 
 !=====================================================================================
 


### PR DESCRIPTION
In anticipation of MAPL3 we were review how the callback fields were created. After careful analysis it seems the this whole pattern of adding a field via the short name, then accessing via a long name that had to be retrieved from the attribute was completely unnecessary.  We could see no reason for this pattern. The fields added to the callback state were created in `add_aero`. They could simply be given the long name in the first place as the field name and retrieved from state with the long name rather than this indirection.

Now so that this doesn't break the other places outside of go-cart using this, we added a named alias using the short name, and still add the attribute, so that places outside of go-cart can still work as they did. Once this PR is in, we can start cleaning up the places in moist and radiation just like go-cart and retrieve by the long name rather than the short name.